### PR TITLE
Fix CI Version Consistency: Update hardcoded version to v1.6.20

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -90,7 +90,7 @@ class FlowAuditRequest(BaseModel):
     conflictLengthM: float = DEFAULT_CONFLICT_LENGTH_METERS
     outputDir: str = "reports"
 
-app = FastAPI(title="run-density", version="v1.6.18")
+app = FastAPI(title="run-density", version="v1.6.20")
 APP_VERSION = os.getenv("APP_VERSION", app.version)
 GIT_SHA = os.getenv("GIT_SHA", "local")
 BUILD_AT = os.getenv("BUILD_AT", datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z")


### PR DESCRIPTION
## Problem

The CI workflow was consistently failing on the Version Consistency Check step due to a version mismatch:
- **Code version**: v1.6.18 (hardcoded in app/main.py)
- **Latest git tag**: v1.6.20

## Solution

Updated the hardcoded version in `app/main.py` from `v1.6.18` to `v1.6.20` to match the latest git tag.

## Changes

- **File**: `app/main.py`
- **Change**: `app = FastAPI(title="run-density", version="v1.6.20")`
- **Verification**: Version consistency check now passes locally

## Testing

- ✅ Version consistency check passes: `v1.6.20 matches git tag`
- ✅ E2E tests run successfully
- ✅ All API endpoints working correctly

## Impact

- Fixes CI pipeline failures
- Enables automated releases to proceed
- Improves developer experience with green CI status

## Related

- Resolves Issue #139: Fix CI Workflow Version Consistency Failures
- Part of ongoing CI/CD reliability improvements

## Next Steps

- Merge this PR to fix CI failures
- Consider implementing automated version bumping in CI workflow
- Monitor CI pipeline for continued success