### PR TITLE
🔬 Issue #222: Add ChatGPT Diagnostic DEBUG Block

### DIFF
--- a/app/bins_accumulator.py
+++ b/app/bins_accumulator.py
@@ -170,7 +170,23 @@ def build_bin_features(
             # Avoid divide-by-zero, though validated above
             inv_area = 1.0 / area_m2
 
+            # DEBUG: ChatGPT diagnostic block for Issue #222
+            if logger and seg_id == "A1" and w_idx == 0:  # Debug first segment, first window
+                logger.info(f"🔬 DEBUG Issue #222 - Bin Density Calculation:")
+                logger.info(f"  bin_size_km: {bin_size_km}")
+                logger.info(f"  bin_len_m: {bin_len_m} (bin_size_km * 1000)")
+                logger.info(f"  seg.width_m: {seg.width_m}")
+                logger.info(f"  area_m2: {area_m2} (bin_len_m * width_m)")
+                logger.info(f"  inv_area: {inv_area} (1.0 / area_m2)")
+                logger.info(f"  counts[0:3]: {counts[:3]}")
+                logger.info(f"  density[0:3] before calc: [counts * inv_area]")
+
             density = counts.astype(np.float64) * inv_area  # p/m^2
+            
+            # DEBUG: Show calculated densities
+            if logger and seg_id == "A1" and w_idx == 0:
+                logger.info(f"  density[0:3] after calc: {density[:3]} p/m²")
+                logger.info(f"  max density in bin: {np.max(density):.6f} p/m²")
             mean_speed = np.divide(
                 sum_speed,
                 np.maximum(counts, 1),  # prevent div by zero


### PR DESCRIPTION
## 🔬 **ChatGPT Surgical Diagnostic Approach - Phase 1**

### **🎯 DEBUG Block Added**
Added ChatGPT's diagnostic DEBUG block to `app/bins_accumulator.py` lines 173-189.

### **📊 What Will Be Logged**
For segment A1, window 0:
```
🔬 DEBUG Issue #222 - Bin Density Calculation:
  bin_size_km: 0.1
  bin_len_m: 100.0 (bin_size_km * 1000)
  seg.width_m: [actual width]
  area_m2: [bin_len_m * width_m]
  inv_area: [1.0 / area_m2]
  counts[0:3]: [runner counts per bin]
  density[0:3] after calc: [calculated densities] p/m²
  max density in bin: [peak density] p/m²
```

### **🔍 Diagnostic Purpose**
This will reveal the exact formula and units being used in bin density calculation to identify the scale mismatch with segment densities (61-99% relative error).

### **⚙️ Testing Plan**
1. Merge to main to deploy DEBUG block
2. Run CI pipeline - Stage 3 will trigger bin generation
3. Check Cloud Run logs for DEBUG output
4. Analyze exact calculations vs segment density calculations
5. Apply surgical fix based on findings

**Following ChatGPT's precise diagnostic methodology for Issue #222.** 🎯