### PR TITLE
🚀 Issue #229 Phase 1: ChatGPT's Bins → Segments Migration

### DIFF
--- a/app/density_report.py
+++ b/app/density_report.py
@@ -862,6 +862,18 @@ def generate_density_report(
                              total_ms=int(elapsed * 1000),
                              metadata=bin_metadata)
                 
+                # ChatGPT's Bins → Segments Migration (Issue #229)
+                SEGMENTS_FROM_BINS = os.getenv("SEGMENTS_FROM_BINS", "true").lower() == "true"
+                if SEGMENTS_FROM_BINS:
+                    try:
+                        from .segments_from_bins import create_canonical_segments_from_bins
+                        log.info("SEG_ROLLUP_START out_dir=%s parquet=%s geojson=%s",
+                                 os.path.abspath(daily_folder_path), os.path.abspath(parquet_path), os.path.abspath(geojson_path))
+                        seg_from_bins_path = create_canonical_segments_from_bins(daily_folder_path, parquet_path, geojson_path)
+                        log.info("SEG_ROLLUP_DONE path=%s", seg_from_bins_path)
+                    except Exception as e:
+                        log.exception("SEG_ROLLUP_FAILED: %s", e)
+                
                 print(f"📦 Bin dataset saved: {geojson_path} | {parquet_path}")
                 print(f"📦 Generated {final_features} bin features in {elapsed:.1f}s (bin_size={bin_size_to_use}km, dt={dt_seconds}s)")
                 if bins_status != "ok":

--- a/app/segments_from_bins.py
+++ b/app/segments_from_bins.py
@@ -1,0 +1,67 @@
+# app/segments_from_bins.py
+from __future__ import annotations
+import os, json, gzip, logging
+from typing import Tuple
+import pandas as pd
+
+log = logging.getLogger(__name__)
+
+def load_bins_parquet_or_geojson(bins_path_parquet: str, bins_path_geojson_gz: str) -> pd.DataFrame:
+    try:
+        df = pd.read_parquet(bins_path_parquet)
+        log.info("SEG_BINS_LOAD: parquet=%s rows=%d", os.path.abspath(bins_path_parquet), len(df))
+        return df
+    except Exception as e:
+        log.warning("SEG_BINS_LOAD: parquet failed (%s), attempting geojson.gz", e)
+
+    with gzip.open(bins_path_geojson_gz, "rt") as f:
+        gj = json.load(f)
+    rows = []
+    for ft in gj.get("features", []):
+        p = ft.get("properties", {})
+        rows.append({
+            "segment_id": p.get("segment_id"),
+            "start_km": p.get("start_km"),
+            "end_km": p.get("end_km"),
+            "t_start": p.get("t_start"),
+            "t_end": p.get("t_end"),
+            "density": p.get("density"),
+        })
+    df = pd.DataFrame(rows)
+    log.info("SEG_BINS_LOAD: geojson=%s rows=%d", os.path.abspath(bins_path_geojson_gz), len(df))
+    return df
+
+def bins_to_segment_windows(df_bins: pd.DataFrame) -> pd.DataFrame:
+    # Types & derived fields
+    df = df_bins.dropna(subset=["segment_id","start_km","end_km","t_start","t_end","density"]).copy()
+    df["t_start"] = pd.to_datetime(df["t_start"], utc=True)
+    df["t_end"]   = pd.to_datetime(df["t_end"],   utc=True)
+    df["bin_len_m"] = (df["end_km"].astype(float) - df["start_km"].astype(float)) * 1000.0
+
+    # length-weighted mean density per (segment, window) + peak
+    def _agg(g: pd.DataFrame) -> pd.Series:
+        wsum = (g["density"] * g["bin_len_m"]).sum()
+        lsum = max(1e-9, g["bin_len_m"].sum())
+        return pd.Series({
+            "density_mean": wsum / lsum,
+            "density_peak": g["density"].max(),
+            "n_bins": len(g)
+        })
+
+    out = (df.groupby(["segment_id","t_start","t_end"], as_index=False)
+             .apply(_agg)
+             .reset_index(drop=True))
+    return out
+
+def write_segment_windows(out_dir: str, seg_df: pd.DataFrame) -> Tuple[str, int]:
+    os.makedirs(out_dir, exist_ok=True)
+    out_path = os.path.join(out_dir, "segment_windows_from_bins.parquet")
+    seg_df.to_parquet(out_path, index=False)
+    log.info("POST_SAVE segment_windows_from_bins=%s rows=%d", os.path.abspath(out_path), len(seg_df))
+    return out_path, len(seg_df)
+
+def create_canonical_segments_from_bins(out_dir: str, bins_parquet: str, bins_geojson_gz: str) -> str:
+    df_bins = load_bins_parquet_or_geojson(bins_parquet, bins_geojson_gz)
+    seg_df  = bins_to_segment_windows(df_bins)
+    out, n  = write_segment_windows(out_dir, seg_df)
+    return out


### PR DESCRIPTION
## 🎯 **ChatGPT's Bins → Segments Migration - Phase 1**

### **✅ IMPLEMENTATION COMPLETE**

**Following ChatGPT's exact implementation from Bin Reconciliation migration runbook.**

#### **🔧 New Module: app/segments_from_bins.py**
- **Canonical Roll-Up Functions**: `bins_to_segment_windows()` using length-weighted mean
- **Dual Format Support**: Parquet preferred, GeoJSON.gz fallback
- **Core Formula**: `segment_density = Σ(bin_density × bin_len_m) / Σ(bin_len_m)`

#### **🔗 Integration: app/density_report.py**
- **Environment Flag**: `SEGMENTS_FROM_BINS=true` for reversible rollout
- **Trigger Point**: After bins are saved (POST_SAVE bins)
- **Error Handling**: Graceful failure with `SEG_ROLLUP_FAILED` logging

### **📊 Expected Outcomes**

#### **Files Generated**:
- `bins.parquet` ✅ (existing)
- `bins.geojson.gz` ✅ (existing)
- `segment_windows_from_bins.parquet` 🆕 (canonical segments)

#### **Logs to Confirm**:
- `SEG_ROLLUP_START` with file paths
- `POST_SAVE segment_windows_from_bins` with row count
- No `SEG_ROLLUP_FAILED` errors

### **🎯 Testing Strategy**
Deploy to Cloud Run to test with visible logs and validate:
1. Canonical segments file generation
2. Length-weighted mean calculations
3. Integration with existing bin generation

**Ready for Cloud Run testing to validate ChatGPT's migration implementation.** 🚀