### PR TITLE
Fix: CI pipeline architectural issue - use Cloud Run E2E APIs

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -163,31 +163,51 @@ jobs:
         echo "Testing Cloud Run deployment with e2e.py"
         python e2e.py --cloud
     
-    - name: Generate UI Artifacts
+    - name: Trigger Cloud Run E2E and Upload
       run: |
-        echo "=== Generating UI Artifacts for APIs ==="
-        REPORT_DATE=$(date +%Y-%m-%d)
+        echo "=== Triggering Cloud Run E2E Generation ==="
+        CLOUD_URL="https://run-density-ln4r3sfkha-uc.a.run.app"
         
-        # Generate UI artifacts using the latest run_id
-        python analytics/export_frontend_artifacts.py $REPORT_DATE
+        # Step 1: Trigger E2E generation in Cloud Run container
+        echo "Calling POST /api/e2e/run to generate reports in Cloud Run..."
+        E2E_RESPONSE=$(curl -X POST "$CLOUD_URL/api/e2e/run" \
+          --max-time 600 \
+          --fail-with-body \
+          -H "Content-Type: application/json" \
+          -w "\nHTTP_CODE:%{http_code}")
         
-        # Upload UI artifacts to Cloud Storage for API access
-        if [ -d "artifacts/$REPORT_DATE/ui" ]; then
-          echo "Uploading UI artifacts to Cloud Storage..."
-          gsutil -m cp -r artifacts/$REPORT_DATE/ui/* gs://run-density-reports/artifacts/$REPORT_DATE/ui/
-          echo "✅ UI artifacts uploaded to Cloud Storage"
-        else
-          echo "❌ UI artifacts directory not found: artifacts/$REPORT_DATE/ui"
+        HTTP_CODE=$(echo "$E2E_RESPONSE" | grep -o "HTTP_CODE:[0-9]*" | cut -d: -f2)
+        if [ "$HTTP_CODE" != "200" ]; then
+          echo "❌ E2E generation failed with HTTP $HTTP_CODE"
+          echo "$E2E_RESPONSE"
           exit 1
         fi
+        echo "✅ E2E generation completed in Cloud Run"
         
-        # Upload latest.json pointer file (Issue #293)
-        if [ -f "artifacts/latest.json" ]; then
-          echo "Uploading latest.json pointer to Cloud Storage..."
-          gsutil cp artifacts/latest.json gs://run-density-reports/artifacts/latest.json
-          echo "✅ latest.json uploaded to Cloud Storage"
+        # Step 2: Trigger GCS upload from Cloud Run container
+        echo "Calling POST /api/e2e/upload to upload artifacts to GCS..."
+        UPLOAD_RESPONSE=$(curl -X POST "$CLOUD_URL/api/e2e/upload" \
+          --max-time 300 \
+          --fail-with-body \
+          -H "Content-Type: application/json")
+        
+        echo "$UPLOAD_RESPONSE" | jq .
+        
+        # Verify upload was successful
+        UPLOAD_STATUS=$(echo "$UPLOAD_RESPONSE" | jq -r '.status')
+        if [ "$UPLOAD_STATUS" != "success" ]; then
+          echo "⚠️ Warning: Upload status was '$UPLOAD_STATUS', not 'success'"
         else
-          echo "⚠️ Warning: artifacts/latest.json not found"
+          echo "✅ Artifacts uploaded to GCS successfully"
+        fi
+        
+        # Step 3: Verify latest.json in GCS
+        echo "Verifying latest.json in GCS..."
+        if gsutil cat gs://run-density-reports/artifacts/latest.json; then
+          echo "✅ latest.json verified in GCS"
+        else
+          echo "❌ latest.json not found in GCS"
+          exit 1
         fi
     
     - name: Validate Dashboard Data (Main Only)


### PR DESCRIPTION
## Summary

Follow-up to PR #295 - Fixes architectural mismatch in CI pipeline where it tried to export artifacts locally that only exist in Cloud Run's ephemeral storage.

## Problem

After PR #295 merged, CI pipeline still failed with:
```
Error: Reports directory not found: reports/2025-10-21
```

**Root Cause**: CI was trying to run `export_frontend_artifacts.py` locally after calling `python e2e.py --cloud`. But:
- `e2e.py --cloud` tests **remote** Cloud Run APIs
- Reports are generated in **Cloud Run's ephemeral storage**  
- CI runner has **no local reports** to export

## Architectural Solution

Changed CI to use Cloud Run's E2E APIs instead of local export:

### Before (Broken):
```bash
python e2e.py --cloud  # Tests remote
python analytics/export_frontend_artifacts.py  # ❌ Expects local files
gsutil cp artifacts/...  # ❌ No files to upload
```

### After (Correct):
```bash
python e2e.py --cloud  # Tests remote
curl POST /api/e2e/run  # ✅ Cloud Run generates locally in container
curl POST /api/e2e/upload  # ✅ Cloud Run uploads to GCS
gsutil cat latest.json  # ✅ Verify upload succeeded
```

## Changes

**.github/workflows/ci-pipeline.yml**:
- Renamed step: "Generate UI Artifacts" → "Trigger Cloud Run E2E and Upload"
- Call `POST /api/e2e/run` to generate reports in Cloud Run container
- Call `POST /api/e2e/upload` to upload artifacts to GCS from Cloud Run
- Verify `latest.json` in GCS after upload

## Architecture (Per ChatGPT Review)

**Cloud Run Owns Artifacts** ✅
- Cloud Run generates reports
- Cloud Run exports UI artifacts
- Cloud Run uploads to GCS

**CI Owns Verification** ✅  
- CI validates APIs work remotely
- CI verifies GCS has expected files
- CI doesn't try to export/upload itself

## Testing

This change hasn't been tested yet (it was pushed after PR #295 merged).

**Next**: Merge this PR → CI will test the new flow → Verify `gs://run-density-reports/artifacts/latest.json` appears

## Related

- Builds on: PR #295
- Implements: ChatGPT architectural guidance (Cloud-owned artifacts)
- Related to: #293, #294