### PR TITLE
Fix: Add null check for geometry in generate_segments_geojson (#323)

### DIFF
--- a/analytics/export_frontend_artifacts.py
+++ b/analytics/export_frontend_artifacts.py
@@ -524,8 +524,8 @@ def generate_segments_geojson(reports_dir: Path) -> Dict[str, Any]:
             }
         
         # Add bin centroid to segment's coordinate list
-        geom = feature.get("geometry", {})
-        if geom.get("type") == "Polygon":
+        geom = feature.get("geometry")
+        if geom and geom.get("type") == "Polygon":
             # Compute centroid (simple average of coordinates)
             coords = geom.get("coordinates", [[]])[0]
             if coords:


### PR DESCRIPTION
## 🐛 Issue
Fixes #323

## 📋 Summary
CI pipeline was failing during "Generate UI Artifacts (Local)" step with:
```
AttributeError: 'NoneType' object has no attribute 'get'
```

## 🔧 Changes
**File**: `analytics/export_frontend_artifacts.py`
- Line 527: Changed `geom = feature.get('geometry', {})` to `feature.get('geometry')`
- Line 528: Added null check: `if geom and geom.get('type') == 'Polygon'`

## 🧪 Testing
✅ **Local test passed**: 
```bash
python analytics/export_frontend_artifacts.py 2025-10-23
```
All artifacts generated successfully including segments.geojson with 22 features.

## 📊 Impact
- ✅ Fixes CI Stage 2 (E2E Density/Flow) artifact generation
- ✅ Unblocks automated release (Stage 4)
- ✅ No impact on Cloud Run runtime (already working)
- ✅ Handles edge case where bin geometry is None

## 🎯 Merge Criteria
- [ ] CI pipeline passes (all 4 stages)
- [ ] E2E tests pass
- [ ] UI artifacts generated successfully