### PR TITLE
Disable legacy frontend workflows

### DIFF
--- a/.github/workflows/dashboard.yml
+++ b/.github/workflows/dashboard.yml
@@ -1,8 +1,9 @@
 name: Build Dashboard
 
+# DISABLED: Legacy workflow referencing archived frontend code
+# Will be refactored in future milestone
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   dashboard:

--- a/.github/workflows/map.yml
+++ b/.github/workflows/map.yml
@@ -1,8 +1,9 @@
 name: Generate Runflow Map
 
+# DISABLED: Legacy workflow referencing archived frontend code
+# Will be refactored in future milestone
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   map:

--- a/.github/workflows/reports.yml
+++ b/.github/workflows/reports.yml
@@ -1,8 +1,9 @@
 name: Build Density Report
 
+# DISABLED: Legacy workflow referencing archived frontend code
+# Will be refactored in future milestone
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   reports:

--- a/.github/workflows/ui-artifacts-qc.yml
+++ b/.github/workflows/ui-artifacts-qc.yml
@@ -1,11 +1,9 @@
 name: UI Artifacts QC
 
+# DISABLED: Legacy workflow referencing archived frontend code
+# Will be refactored in future milestone
 on:
   workflow_dispatch:
-  push:
-    branches: [ feature/rf-fe-002, main ]
-  pull_request:
-    branches: [ main ]
 
 jobs:
   qc:

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,8 +1,9 @@
 name: Validate Data Contracts
 
+# DISABLED: Legacy workflow referencing archived frontend code
+# Will be refactored in future milestone
 on:
-  push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   validate:


### PR DESCRIPTION
## 🧹 Cleanup

Disables 5 legacy GitHub Actions workflows that were causing PR check failures.

## 📋 Workflows Disabled
- `reports.yml` - Build Density Report
- `dashboard.yml` - Build Dashboard  
- `map.yml` - Generate Runflow Map
- `validate.yml` - Validate Data Contracts
- `ui-artifacts-qc.yml` - UI Artifacts QC

## 🐛 Problem
These workflows reference archived frontend code in `frontend/validation/`, `frontend/reports/`, etc. that no longer exists in the repository, causing them to fail on every push/PR with:
```
python: can't open file 'frontend/validation/scripts/validate_data.py': [Errno 2] No such file or directory
```

## ✅ Solution
Changed trigger from `push + pull_request` to `workflow_dispatch` only.

**Benefits:**
- ✅ Stops automatic failures on every PR
- ✅ Workflows can still be manually triggered if needed
- ✅ Clean PR checks for future work
- ✅ No impact on main CI Pipeline

## 📝 Notes
- These workflows will be refactored in a future milestone
- Main CI Pipeline (`ci-pipeline.yml`) is unaffected and working correctly
- Frontend architecture will be redesigned per RF-FE-002