### PR TITLE
Fix: Add missing pyproj dependency and static directory to Docker (#326)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ COPY app ./app
 COPY data ./data
 COPY config ./config
 COPY frontend ./frontend
+COPY static ./static
 COPY templates ./templates
 COPY tests ./tests
 COPY e2e.py ./

--- a/requirements.txt
+++ b/requirements.txt
@@ -31,6 +31,7 @@ httpx>=0.24.0
 # Bin Dataset Support (Issue #198)
 pyarrow>=10.0.0
 shapely>=2.0.0
+pyproj>=3.6.0
 
 # NOTE: Heavy dependencies removed from web runtime:
 # - folium (static map generation → Leaflet client-side)


### PR DESCRIPTION
## 🐛 Issue
Fixes #326

## 🔍 Root Cause Analysis

**Why segments map worked locally but not on Cloud Run:**

### Local Environment ✅
- `bins.geojson.gz`: **400 coordinates** per segment (Polygon geometries generated)
- `/static` directory: **accessible** from workspace
- `pyproj`: **installed** in test_env from previous sessions

### Cloud Run Environment ❌
- `bins.geojson.gz`: **0 coordinates** per segment (all geometries null)
- `/static` directory: **missing** from Docker image (404s)
- `pyproj`: **not installed** (missing from requirements.txt)

## 📊 Evidence

**Cloud Run Logs:**
```
⚠️ Geometry generation failed, bins will have null geometry: No module named 'pyproj'
Warning: Could not mount static directory: Directory 'static' does not exist
```

**GCS Artifact Verification:**
```bash
# Cloud Run bins.geojson.gz
$ gsutil cat gs://run-density-reports/artifacts/2025-10-23/ui/segments.geojson | jq '.features[0].geometry.coordinates | length'
0  # ❌ Empty

# Local bins.geojson.gz  
$ cat artifacts/2025-10-23/ui/segments.geojson | jq '.features[0].geometry.coordinates | length'
400  # ✅ Populated
```

## ✅ Fixes Applied

### 1. Add pyproj to requirements.txt
```diff
# Bin Dataset Support (Issue #198)
pyarrow>=10.0.0
shapely>=2.0.0
+pyproj>=3.6.0
```

This dependency was accidentally dropped during requirements consolidation (commit 14bcd36).
It's required by `app/bin_geometries.py` for coordinate transformations.

### 2. Add static directory to Dockerfile
```diff
COPY app ./app
COPY data ./data
COPY config ./config
COPY frontend ./frontend
+COPY static ./static
COPY templates ./templates
```

The `static/` directory contains JavaScript modules for the segments map:
- `static/js/map/base_map.js` - Leaflet initialization
- `static/js/map/segments.js` - Segment rendering and filtering

## 🧪 Testing

**Expected Results After Merge:**
- ✅ `bins.geojson.gz` should have Polygon geometries with coordinates
- ✅ `segments.geojson` should have populated coordinate arrays
- ✅ Segments map should render on Cloud Run
- ✅ JavaScript files should load (no 404s)
- ✅ Table-to-map filtering should work

## 📝 Notes
- This explains why Issue #317 worked perfectly in local testing but failed on Cloud Run
- The pyproj dependency was in requirements-core.txt but lost during consolidation
- Both fixes are required for the segments map to work end-to-end