### PR TITLE
Issue #348: Implement Naming Normalization

### DIFF
--- a/app/normalize.py
+++ b/app/normalize.py
@@ -1,0 +1,146 @@
+"""
+Naming Normalization Module
+
+Normalizes variable names from various formats to canonical internal names.
+Used primarily at API boundaries to accept legacy aliases while maintaining
+internal naming consistency.
+
+See ADR-001 for naming conventions and migration strategy.
+"""
+
+from typing import Optional
+
+
+def normalize_segment_id(request: dict, default: Optional[str] = None) -> Optional[str]:
+    """
+    Normalize segment identifier from request dict.
+    
+    Accepts various alias formats and returns canonical 'segment_id'.
+    
+    Supported aliases:
+        - segment_id (canonical)
+        - segmentId (camelCase)
+        - seg_id (internal data layer)
+        - segId (mixed case)
+    
+    Args:
+        request: Dictionary containing segment identifier (e.g., request params, JSON body)
+        default: Optional default value if no segment identifier found
+        
+    Returns:
+        Normalized segment_id string, or default if not found
+        
+    Example:
+        >>> request = {'segmentId': 'A1'}
+        >>> normalize_segment_id(request)
+        'A1'
+        
+        >>> request = {'seg_id': 'B2'}
+        >>> normalize_segment_id(request)
+        'B2'
+    """
+    # Try canonical name first
+    if 'segment_id' in request:
+        return request['segment_id']
+    
+    # Try camelCase variant
+    if 'segmentId' in request:
+        return request['segmentId']
+    
+    # Try internal data layer name
+    if 'seg_id' in request:
+        return request['seg_id']
+    
+    # Try mixed case variant
+    if 'segId' in request:
+        return request['segId']
+    
+    return default
+
+
+def normalize_checkpoint_id(request: dict, default: Optional[str] = None) -> Optional[str]:
+    """
+    Normalize checkpoint identifier from request dict.
+    
+    Accepts various alias formats and returns canonical 'checkpoint_id'.
+    
+    Supported aliases:
+        - checkpoint_id (canonical)
+        - checkpointId (camelCase)
+        - chk_id (internal data layer)
+        - chkptId (mixed case)
+    
+    Args:
+        request: Dictionary containing checkpoint identifier
+        default: Optional default value if no checkpoint identifier found
+        
+    Returns:
+        Normalized checkpoint_id string, or default if not found
+        
+    Example:
+        >>> request = {'checkpointId': 'CP1'}
+        >>> normalize_checkpoint_id(request)
+        'CP1'
+        
+        >>> request = {'chk_id': 'CP2'}
+        >>> normalize_checkpoint_id(request)
+        'CP2'
+    """
+    # Try canonical name first
+    if 'checkpoint_id' in request:
+        return request['checkpoint_id']
+    
+    # Try camelCase variant
+    if 'checkpointId' in request:
+        return request['checkpointId']
+    
+    # Try internal data layer name
+    if 'chk_id' in request:
+        return request['chk_id']
+    
+    # Try mixed case variant
+    if 'chkptId' in request:
+        return request['chkptId']
+    
+    return default
+
+
+def normalize_cursor_index(request: dict, default: Optional[int] = None) -> Optional[int]:
+    """
+    Normalize cursor/index identifier from request dict.
+    
+    Accepts various alias formats and returns canonical 'cursor_index'.
+    
+    Supported aliases:
+        - cursor_index (canonical)
+        - cursorIndex (camelCase)
+        - event_cursor (legacy)
+        - cursor_pos (legacy)
+    
+    Args:
+        request: Dictionary containing cursor identifier
+        default: Optional default value if no cursor found
+        
+    Returns:
+        Normalized cursor_index integer, or default if not found
+    """
+    # Try canonical name first
+    if 'cursor_index' in request:
+        val = request['cursor_index']
+        return int(val) if val is not None else default
+    
+    # Try camelCase variant
+    if 'cursorIndex' in request:
+        val = request['cursorIndex']
+        return int(val) if val is not None else default
+    
+    # Try legacy names
+    if 'event_cursor' in request:
+        val = request['event_cursor']
+        return int(val) if val is not None else default
+    
+    if 'cursor_pos' in request:
+        val = request['cursor_pos']
+        return int(val) if val is not None else default
+    
+    return default

--- a/docs/adr/ADR-001-Naming-Normalization.md
+++ b/docs/adr/ADR-001-Naming-Normalization.md
@@ -1,0 +1,133 @@
+# ADR-001: Naming Normalization and Migration Strategy
+
+**Status:** Accepted  
+**Date:** 2025-10-26  
+**ADR Type:** Standards / Compatibility  
+**Linked Issues:** #340, #341, #348
+
+---
+
+## 1. Context
+
+The `run-density` codebase currently contains **inconsistent naming conventions** across frontend, backend, and artifacts. Variants include:
+
+| Concept        | Variants Found                             |
+|----------------|--------------------------------------------|
+| Segment ID     | `segment_id`, `seg_id`, `segmentId`, `segId` |
+| Checkpoint ID  | `checkpoint_id`, `chk_id`, `chkptId`       |
+| Cursor         | `cursor`, `event_cursor`, `cursor_pos`     |
+
+These inconsistencies exist in:
+- API query parameters (camelCase: `segmentId`)
+- Python internal variables (snake_case: `segment_id`)
+- Templates and JS handlers (mixed)
+- Legacy schema/alias layers (`seg_id`, `seg_label`)
+- Output reports and CSV headers
+
+This drift increases the risk of:
+- Bugs from ambiguous variable meanings
+- Broken API contracts
+- Duplicate logic for alias handling
+- Inconsistent test coverage
+
+---
+
+## 2. Decision Summary
+
+We adopt a **canonical, snake_case naming standard** for all internal code. API input/output may retain legacy names **only via adapter layers** or alias maps.
+
+### ✅ Canonical Names and Layer Mapping
+
+**Critical Clarification**: The existing `seg_id` → `segment_id` mapping convention is preserved:
+
+| Layer | Field Name | Example |
+|-------|------------|---------|
+| **Internal Data Layer** | `seg_id` | CSV files, pandas DataFrames, internal lookups |
+| **API Layer** | `segment_id` | API request/response, JSON bodies, external interfaces |
+
+This dual naming is **intentional** and reflects the boundary between:
+- Data ingestion/persistence (uses `seg_id`)
+- External API contracts (uses `segment_id`)
+
+### ✅ Canonical Internal Names
+
+| Canonical Term     | Applies To | Notes |
+|--------------------|------------|-------|
+| `segment_id`       | All API boundaries (request/response) | External-facing |
+| `seg_id`           | Internal data layer (CSV, DB, DataFrames) | Internal data |
+| `checkpoint_id`    | All internal code  
+| `cursor_index`     | Cursor in segment sequence  
+| `bin_id`, `bin_flag`, `density_value` | Analysis objects
+
+- **snake_case is mandatory** for Python code
+- **camelCase remains permitted** in frontend inputs and API query parameters (mapped internally via adapters)
+- **Internal data sources** continue using `seg_id` (e.g., `segments.csv`)
+
+---
+
+## 3. Migration Strategy (Non-Breaking)
+
+Refactor proceeds in **three phases** to maintain compatibility:
+
+### Phase 0–1 (now)
+
+- No breaking changes or renames
+- **Adapter functions** (e.g., `normalize_segment_id()`) used to map aliases in request handlers
+- **Scope**: Normalize API input only (not responses)
+- **Location**: `app/normalize.py` (to be relocated to `core/` in Phase 3)
+- **Legacy aliases preserved** in `.to_dict()` and UI templates
+- Document legacy mappings in `docs/VARIABLE_NAMING_REFERENCE.md`
+
+### Phase 2 (future)
+
+- Internal renames: migrate `seg_id` → `segment_id` in internal code only
+- Refactor existing modules with compatibility layers (functions and data adapters)
+- Deprecate legacy terms in internal models; warn in CI if used
+
+### Phase 3 (final)
+
+- Remove aliases where possible
+- Update all consumers (internal & external) to canonical naming
+- Remove adapter logic
+
+---
+
+## 4. Rationale
+
+- Naming clarity reduces onboarding time and bug surface
+- SSOT (Single Source of Truth) supported through strict naming enforcement
+- Adapter-based compatibility allows gradual rollout and testing
+- Matches community Python conventions (PEP8, REST best practices)
+- Preserves existing working patterns (`seg_id` in data, `segment_id` in API)
+
+---
+
+## 5. Tradeoffs
+
+- Short-term increase in complexity due to adapter layers
+- Risk of inconsistencies in early phases unless CI enforces usage
+- Requires discipline to avoid bypassing adapters during refactors
+- Dual naming convention (`seg_id` vs `segment_id`) requires clear documentation
+
+---
+
+## 6. Implementation Plan
+
+**Phase 1 Tasks:**
+- [x] Create `app/normalize.py` with `normalize_segment_id()` and `normalize_checkpoint_id()`
+- [ ] Audit API boundary functions for alias handling
+- [ ] Add lint rule (or code comment tag) to detect legacy terms
+- [ ] Unit tests for adapters: accept all known aliases, map to canonical
+- [ ] Update `docs/VARIABLE_NAMING_REFERENCE.md`
+- [ ] Schedule full rename for Phase 2 milestone
+
+**Implementation Location**: `app/normalize.py` (Phase 1), move to `core/normalize.py` (Phase 3)
+
+---
+
+## 7. Related
+
+- 🔗 [#340] Refactor Parent Task  
+- 🔗 [#341] Phase 0 Code Review  
+- 🔗 [#348] This ADR  
+- 📄 `docs/VARIABLE_NAMING_REFERENCE.md` (in scope for update)

--- a/tests/test_normalize.py
+++ b/tests/test_normalize.py
@@ -1,0 +1,202 @@
+"""
+Unit tests for normalization module (app.normalize)
+
+Tests all supported alias formats and edge cases.
+"""
+
+import pytest
+from app.normalize import (
+    normalize_segment_id,
+    normalize_checkpoint_id,
+    normalize_cursor_index
+)
+
+
+class TestNormalizeSegmentId:
+    """Tests for normalize_segment_id function."""
+    
+    def test_canonical_segment_id(self):
+        """Test canonical 'segment_id' format."""
+        request = {'segment_id': 'A1'}
+        assert normalize_segment_id(request) == 'A1'
+    
+    def test_camelcase_segmentId(self):
+        """Test camelCase 'segmentId' format."""
+        request = {'segmentId': 'B2'}
+        assert normalize_segment_id(request) == 'B2'
+    
+    def test_internal_seg_id(self):
+        """Test internal data layer 'seg_id' format."""
+        request = {'seg_id': 'C3'}
+        assert normalize_segment_id(request) == 'C3'
+    
+    def test_mixed_segId(self):
+        """Test mixed case 'segId' format."""
+        request = {'segId': 'D4'}
+        assert normalize_segment_id(request) == 'D4'
+    
+    def test_priority_canonical_first(self):
+        """Test that canonical name takes priority when multiple exist."""
+        request = {
+            'segment_id': 'canonical',
+            'segmentId': 'camelCase',
+            'seg_id': 'internal'
+        }
+        assert normalize_segment_id(request) == 'canonical'
+    
+    def test_not_found_returns_none(self):
+        """Test that missing segment_id returns None."""
+        request = {'other_key': 'value'}
+        assert normalize_segment_id(request) is None
+    
+    def test_not_found_with_default(self):
+        """Test that missing segment_id returns provided default."""
+        request = {'other_key': 'value'}
+        assert normalize_segment_id(request, default='default') == 'default'
+    
+    def test_empty_dict(self):
+        """Test with empty dictionary."""
+        request = {}
+        assert normalize_segment_id(request) is None
+
+
+class TestNormalizeCheckpointId:
+    """Tests for normalize_checkpoint_id function."""
+    
+    def test_canonical_checkpoint_id(self):
+        """Test canonical 'checkpoint_id' format."""
+        request = {'checkpoint_id': 'CP1'}
+        assert normalize_checkpoint_id(request) == 'CP1'
+    
+    def test_camelcase_checkpointId(self):
+        """Test camelCase 'checkpointId' format."""
+        request = {'checkpointId': 'CP2'}
+        assert normalize_checkpoint_id(request) == 'CP2'
+    
+    def test_internal_chk_id(self):
+        """Test internal data layer 'chk_id' format."""
+        request = {'chk_id': 'CP3'}
+        assert normalize_checkpoint_id(request) == 'CP3'
+    
+    def test_mixed_chkptId(self):
+        """Test mixed case 'chkptId' format."""
+        request = {'chkptId': 'CP4'}
+        assert normalize_checkpoint_id(request) == 'CP4'
+    
+    def test_priority_canonical_first(self):
+        """Test that canonical name takes priority when multiple exist."""
+        request = {
+            'checkpoint_id': 'canonical',
+            'checkpointId': 'camelCase',
+            'chk_id': 'internal'
+        }
+        assert normalize_checkpoint_id(request) == 'canonical'
+    
+    def test_not_found_returns_none(self):
+        """Test that missing checkpoint_id returns None."""
+        request = {'other_key': 'value'}
+        assert normalize_checkpoint_id(request) is None
+    
+    def test_not_found_with_default(self):
+        """Test that missing checkpoint_id returns provided default."""
+        request = {'other_key': 'value'}
+        assert normalize_checkpoint_id(request, default='DEFAULT') == 'DEFAULT'
+
+
+class TestNormalizeCursorIndex:
+    """Tests for normalize_cursor_index function."""
+    
+    def test_canonical_cursor_index(self):
+        """Test canonical 'cursor_index' format."""
+        request = {'cursor_index': 5}
+        assert normalize_cursor_index(request) == 5
+    
+    def test_camelcase_cursorIndex(self):
+        """Test camelCase 'cursorIndex' format."""
+        request = {'cursorIndex': 10}
+        assert normalize_cursor_index(request) == 10
+    
+    def test_legacy_event_cursor(self):
+        """Test legacy 'event_cursor' format."""
+        request = {'event_cursor': 15}
+        assert normalize_cursor_index(request) == 15
+    
+    def test_legacy_cursor_pos(self):
+        """Test legacy 'cursor_pos' format."""
+        request = {'cursor_pos': 20}
+        assert normalize_cursor_index(request) == 20
+    
+    def test_string_conversion(self):
+        """Test that string values are converted to int."""
+        request = {'cursor_index': '25'}
+        assert normalize_cursor_index(request) == 25
+        assert isinstance(normalize_cursor_index(request), int)
+    
+    def test_priority_canonical_first(self):
+        """Test that canonical name takes priority when multiple exist."""
+        request = {
+            'cursor_index': 1,
+            'cursorIndex': 2,
+            'event_cursor': 3
+        }
+        assert normalize_cursor_index(request) == 1
+    
+    def test_not_found_returns_none(self):
+        """Test that missing cursor_index returns None."""
+        request = {'other_key': 'value'}
+        assert normalize_cursor_index(request) is None
+    
+    def test_not_found_with_default(self):
+        """Test that missing cursor_index returns provided default."""
+        request = {'other_key': 'value'}
+        assert normalize_cursor_index(request, default=99) == 99
+    
+    def test_none_value(self):
+        """Test that None value returns default."""
+        request = {'cursor_index': None}
+        assert normalize_cursor_index(request) is None
+        assert normalize_cursor_index(request, default=0) == 0
+
+
+class TestNormalizeIntegration:
+    """Integration tests combining multiple normalization functions."""
+    
+    def test_mixed_request_normalization(self):
+        """Test normalizing multiple fields from same request."""
+        request = {
+            'segmentId': 'A1',
+            'chk_id': 'CP1',
+            'cursor_pos': '5'
+        }
+        
+        segment = normalize_segment_id(request)
+        checkpoint = normalize_checkpoint_id(request)
+        cursor = normalize_cursor_index(request)
+        
+        assert segment == 'A1'
+        assert checkpoint == 'CP1'
+        assert cursor == 5
+    
+    def test_all_canonical_names(self):
+        """Test all canonical names together."""
+        request = {
+            'segment_id': 'S1',
+            'checkpoint_id': 'C1',
+            'cursor_index': 10
+        }
+        
+        assert normalize_segment_id(request) == 'S1'
+        assert normalize_checkpoint_id(request) == 'C1'
+        assert normalize_cursor_index(request) == 10
+    
+    def test_missing_fields_return_defaults(self):
+        """Test that missing fields use provided defaults."""
+        request = {}
+        
+        segment = normalize_segment_id(request, default='UNKNOWN')
+        checkpoint = normalize_checkpoint_id(request, default='NONE')
+        cursor = normalize_cursor_index(request, default=-1)
+        
+        assert segment == 'UNKNOWN'
+        assert checkpoint == 'NONE'
+        assert cursor == -1


### PR DESCRIPTION
## Summary
Implements naming normalization infrastructure as specified in Issue #348 and ADR-001.

## Changes
- **Created ADR-001**: Complete naming conventions documentation in `docs/adr/`
- **Created `app/normalize.py`**: Three normalization functions for API input:
  - `normalize_segment_id()` - supports segment_id, segmentId, seg_id, segId
  - `normalize_checkpoint_id()` - supports checkpoint_id, checkpointId, chk_id, chkptId
  - `normalize_cursor_index()` - supports cursor_index, cursorIndex, event_cursor, cursor_pos
- **Comprehensive unit tests**: 27 tests covering all aliases and edge cases (all passing)

## Key Clarifications from ADR
- `seg_id` remains in internal data layer (CSV, DataFrames)
- `segment_id` used in API boundaries (request/response)
- Adapter functions normalize API input only (Phase 1 scope)
- All functions return canonical names for internal consistency

## Testing
- All 27 unit tests passing
- Ready for Phase 1 integration into API endpoints

## Related
Closes #348