### PR TITLE
Fix rulebook import causing 'unknown' version in Cloud Run

### DIFF
--- a/api/map.py
+++ b/api/map.py
@@ -132,8 +132,8 @@ async def get_map_manifest():
         
         # Issue #254: Add rulebook version for consistency tracking
         try:
-            from . import rulebook
-            rb_version = rulebook.version()
+            from app.rulebook import version
+            rb_version = version()
         except Exception:
             rb_version = "unknown"
         


### PR DESCRIPTION
## Summary

Fixes the root cause of rulebook_version showing 'unknown' in Cloud Run by correcting the broken import statement in api/map.py.

## Root Cause

During Phase 4 (Issue #345), rulebook.py was NOT moved to the api/ package, but api/map.py was importing it as if it was:



This caused a silent failure that defaulted to 'unknown'.

## The Fix

Changed the import to correctly reference the app module:



## Issue Reference

Fixes #354

## Testing

- ✅ Changed import statement to correct path
- ✅ Should now load rulebook version correctly in Cloud Run
- ✅ Debug logging remains in place for investigation