### PR TITLE
Issue #355: Fix Heatmap Whitespace - Remove Flagged-Only Filtering

### DIFF
--- a/analytics/export_heatmaps.py
+++ b/analytics/export_heatmaps.py
@@ -58,13 +58,13 @@ def create_los_colormap(los_colors: Dict[str, str]) -> mcolors.LinearSegmentedCo
 
 def load_bin_data(reports_dir: Path) -> pd.DataFrame:
     """
-    Load bin data from bin.parquet (canonical SSOT) and apply filtering.
+    Load bin data from bin.parquet (canonical SSOT) without filtering.
     
     Args:
         reports_dir: Path to reports/<run_id>/ directory
         
     Returns:
-        DataFrame with filtered bin-level data (flagged bins only)
+        DataFrame with all bin-level data (no filtering applied)
     """
     bins_path = reports_dir / "bins.parquet"
     
@@ -75,15 +75,11 @@ def load_bin_data(reports_dir: Path) -> pd.DataFrame:
     df = pd.read_parquet(bins_path)
     print(f"   📊 Loaded {len(df)} bins from parquet")
     
-    # Apply same filtering logic as bin_summary.py (Issue #280 alignment)
-    if 'flag_severity' in df.columns:
-        # Filter to flagged bins only (same as bin_summary.py)
-        filtered_bins = df[df['flag_severity'] != 'none'].copy()
-        print(f"   📊 Filtered to {len(filtered_bins)} flagged bins (removed {len(df) - len(filtered_bins)} unflagged)")
-        return filtered_bins
-    else:
-        print(f"   ⚠️  flag_severity column not found, using all bins (no filtering)")
-        return df
+    # Issue #355: Show ALL bins in heatmaps (not just flagged bins)
+    # This restores the original behavior where all 19,440 bins are displayed
+    # This reduces whitespace and shows the full data distribution
+    print(f"   📊 Using all {len(df)} bins for heatmap generation (no filtering)")
+    return df
 
 
 def generate_segment_heatmap(


### PR DESCRIPTION
## Summary
Fixes Issue #355: Restore full bin data in heatmaps to reduce whitespace

## Problem
Commit `afc752e` (Oct 24, Issue #280) introduced filtering that only shows flagged bins in heatmaps. This reduced the data displayed from 19,440 bins to 1,875 flagged bins, resulting in excessive whitespace that doesn't match the expected look and feel.

## Solution
- Modified `analytics/export_heatmaps.py` to show ALL bins instead of only flagged bins
- Restores the original behavior where all bins are displayed
- Reduces visual clutter and whitespace
- Heatmaps now match the expected appearance from before the refactor

## Changes
- Removed flagged-only filtering in `load_bin_data()` function
- Updated docstring to reflect "all bins" behavior
- All 19,440 bins are now displayed in heatmaps

## Testing
- Regenerated heatmaps locally for 2025-10-26 run
- Verified that all bins are now included (no filtering applied)
- Ready for E2E testing in Cloud Run environment

## Related Issue
#355