### PR TITLE
Fix Issue #365: Correct heatmap generation function name

### DIFF
--- a/app/density_report.py
+++ b/app/density_report.py
@@ -1043,7 +1043,7 @@ def generate_density_report(
             
             # Generate heatmaps automatically after density report (Issue #365 completion)
             try:
-                from .heatmap_generator import generate_heatmaps_and_captions
+                from .heatmap_generator import generate_heatmaps_for_run
                 from .storage_service import get_storage_service
                 
                 # Extract run_id from daily_folder_path (e.g., "reports/2025-10-27" -> "2025-10-27")
@@ -1052,7 +1052,7 @@ def generate_density_report(
                     print(f"🔥 Generating heatmaps for run_id: {run_id}")
                     
                     # Generate heatmaps locally
-                    heatmaps_generated, segments = generate_heatmaps_and_captions(run_id, force_regenerate=False)
+                    heatmaps_generated, segments = generate_heatmaps_for_run(run_id)
                     print(f"🔥 Generated {heatmaps_generated} heatmaps for {run_id}")
                     
                     # Upload to GCS if enabled


### PR DESCRIPTION
## Fix for Issue #365

### Problem Discovered
Cloud Run logs revealed the error:
```
WARNING:app.density_report:Could not generate heatmaps: cannot import name 'generate_heatmaps_and_captions' from 'app.heatmap_generator'
```

The function was called with the wrong name.

### Root Cause
In PR #369, I incorrectly called `generate_heatmaps_and_captions()` but the actual function in `app/heatmap_generator.py` is named `generate_heatmaps_for_run()`.

### Fix
- Changed function call from `generate_heatmaps_and_captions(run_id, force_regenerate=False)`
- To: `generate_heatmaps_for_run(run_id)`
- Also updated the import statement

### Expected Result
After this fix is deployed, the automatic heatmap generation should work correctly when density reports are created, completing Issue #365 as originally intended.

### Verification
After merge, the CI pipeline should:
1. Deploy this fix to Cloud Run
2. Run E2E tests which will trigger density report generation
3. Cloud Run logs should show heatmap generation succeeding
4. Heatmaps should appear in GCS for the current run date