### PR TITLE
Issue #361: Suppress hardcoded fallback to outdated artifacts

### DIFF
--- a/templates/pages/density.html
+++ b/templates/pages/density.html
@@ -234,7 +234,9 @@
         tbody.innerHTML = '';
         
         if (!segments || segments.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="10" class="placeholder">No density data available</td></tr>';
+            // Issue #361: Show informative message with run_id when artifacts are missing
+            const runId = '{{ run_id if run_id else "latest run" }}';
+            tbody.innerHTML = `<tr><td colspan="10" class="placeholder">⚠️ No density data available for latest run ID: ${runId}. Check logs.</td></tr>`;
             return;
         }
         
@@ -269,8 +271,10 @@
     }
     
     function showDensityError() {
+        // Issue #361: Show informative message with run_id when artifacts are missing
         const tbody = document.querySelector('#density-table tbody');
-        tbody.innerHTML = '<tr><td colspan="10" class="placeholder">Error loading density data</td></tr>';
+        const runId = '{{ run_id if run_id else "latest run" }}';
+        tbody.innerHTML = `<tr><td colspan="10" class="placeholder">⚠️ Error loading density data for run ID: ${runId}. Check logs.</td></tr>`;
     }
     
     function showSegmentDetail(seg_id) {


### PR DESCRIPTION
## Issue #361
Fixes silent fallback to outdated artifacts when current run artifacts are missing.

## Changes Made
- **Backend**: Modified `app/storage.py` to return `None` instead of falling back to hardcoded '2025-10-25' date
- **Backend**: Added proper logging with WARNING when artifacts are missing
- **Backend**: Updated `app/routes/ui.py` to pass `run_id` to density template for error messages
- **Frontend**: Modified `templates/pages/density.html` to show informative error message with run_id when data is unavailable

## Impact
- Users will see clear warning when artifacts are missing instead of silently showing outdated data
- Logs will show WARNING messages when artifacts unavailable
- Prevents data integrity issues where users might see incorrect dates

## Files Changed
- app/storage.py - Removed hardcoded fallback logic
- app/routes/ui.py - Added run_id to template context
- templates/pages/density.html - Enhanced error messages

## Testing Notes
- After merge, will need to test in Cloud Run to verify error messages display correctly
- Should verify logs show WARNING when artifacts missing for current run_id