### PR TITLE
Fix: Correct path for latest.json in GCS mode

### DIFF
--- a/app/storage.py
+++ b/app/storage.py
@@ -269,7 +269,7 @@ class Storage:
         run_id = os.getenv("RUN_ID")
         if not run_id:
             try:
-                latest_data = self.read_json("artifacts/latest.json")
+                latest_data = self.read_json("latest.json")
                 run_id = latest_data.get("run_id")
             except Exception as e:
                 logging.warning(f"Could not load latest.json for run_id: {e}")


### PR DESCRIPTION
## Bug Fix
Fixes path duplication issue in Cloud Run for reading artifacts/latest.json

## Problem
Cloud Run logs showed: `No such object: run-density-reports/artifacts/artifacts/latest.json`

The path was being doubled because:
- Storage class is initialized with `prefix='artifacts'`
- Calling `self.read_json('artifacts/latest.json')` added the prefix again

## Solution
Changed `self.read_json('artifacts/latest.json')` to `self.read_json('latest.json')` on line 272.

The prefix is already added by the Storage class initialization, so we only need to provide the relative path after the prefix.

## Impact
- Fixes heatmap signed URL generation in Cloud Run
- Heatmaps will now display correctly on the density page