### PR TITLE
Fix Issue #379: Density report GCS upload failures

### DIFF
--- a/app/density_report.py
+++ b/app/density_report.py
@@ -979,14 +979,11 @@ def generate_density_report(
                 if gcs_upload_enabled:
                     try:
                         storage_service = get_storage_service()
-                        # Read the generated report content
-                        with open(timestamped_path, 'r', encoding='utf-8') as f:
-                            report_content = f.read()
-                        
-                        # Upload to GCS using reports/ path
+                        # Upload to GCS using report_content_final (already available)
+                        # Issue #379: Fix - use content already in memory instead of reading from disk
                         gcs_path = storage_service.save_file(
                             filename=os.path.basename(timestamped_path),
-                            content=report_content,
+                            content=report_content_final,
                             date=None  # Use current date
                         )
                         print(f"☁️ Density report uploaded to GCS: {gcs_path}")


### PR DESCRIPTION
## Summary
Fixes Issue #379 where Density reports were not uploading to GCS after 14:01 UTC.

## Root Cause
Density reports were reading content from disk to upload, which could fail silently due to I/O issues. Flow reports work because they upload content directly from memory.

## Solution
Changed Density report upload to use `report_content_final` (already in memory) instead of re-reading from disk, matching the Flow report pattern.

## Changes
- `app/density_report.py` lines 977-991: Use `report_content_final` for GCS upload
- Eliminates potential file I/O failures
- Improves reliability by using content already available

## Testing
- ✅ No linting errors
- ⏳ Local E2E test pending
- ⏳ Cloud Run verification pending after deployment

## Related
Issue #379