### PR TITLE
Fix density report GCS upload scoping error

### DIFF
--- a/app/density_report.py
+++ b/app/density_report.py
@@ -1041,7 +1041,6 @@ def generate_density_report(
             # Generate heatmaps automatically after density report (Issue #365 completion)
             try:
                 from .heatmap_generator import generate_heatmaps_for_run
-                from .storage_service import get_storage_service
                 
                 # Extract run_id from daily_folder_path (e.g., "reports/2025-10-27" -> "2025-10-27")
                 if 'daily_folder_path' in locals():


### PR DESCRIPTION
## Problem

Density reports were failing to upload to GCS in Cloud Run with error:
```
⚠️ Failed to upload density.md to GCS: cannot access local variable 'get_storage_service' where it is not associated with a value
```

## Root Cause

The issue was caused by a Python scoping error in `app/density_report.py`:

1. `get_storage_service` was imported at module level (lines 73-76)
2. There was a redundant import within the function scope (line 1044)
3. This created a local variable that shadowed the module-level import
4. Code at line 981 tried to use `get_storage_service()` before the local import executed

## Solution

- Removed the redundant `from .storage_service import get_storage_service` import within the function
- The module-level import already provides the function, so no additional import is needed

## Testing

- ✅ Import test passes locally
- ✅ No linting errors
- ✅ Fixes the UnboundLocalError

## Impact

- Resolves density report GCS upload failure in Cloud Run
- Density reports will now be properly uploaded to GCS
- Fixes regression introduced during storage migration (Issue #383)

Closes the density report upload issue.