### PR TITLE
Fix Issue #397: Add flake8-bugbear and sequential job execution

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -33,10 +33,10 @@ jobs:
         with:
           python-version: '3.11'
 
-      - name: Install flake8
+      - name: Install flake8 and flake8-bugbear
         run: |
           python -m pip install --upgrade pip
-          pip install flake8
+          pip install flake8 flake8-bugbear
 
       - name: Run Bare Exception Check
         run: |
@@ -54,6 +54,8 @@ jobs:
   build-deploy:
     name: "1️⃣ Build & Deploy (Docker → Artifacts)"
     runs-on: ubuntu-latest
+    # Run after Step 0 completes (but don\'t wait if it fails due to continue-on-error)
+    needs: [complexity-check]
     # Skip deployment for PR events to prevent race conditions with merge
     if: github.event_name != 'pull_request'
     permissions:


### PR DESCRIPTION
## Fixes for Issue #397

This PR fixes two issues discovered in the Phase 1 Step 0 implementation:

### Issue 1: Jobs Running in Parallel ❌ → ✅ Fixed
**Problem**: Step 0 and build-deploy were starting simultaneously (1 second apart).

**Solution**: Added `needs: [complexity-check]` to build-deploy job so Step 0 completes first.

### Issue 2: B001 Violations Not Detected ❌ → ✅ Fixed  
**Problem**: flake8 ran but found 0 violations (should find 2).

**Root Cause**: B001 (bare except) checks require `flake8-bugbear` plugin, which wasn't installed.

**Solution**: Updated installation to include flake8-bugbear:
```yaml
pip install flake8 flake8-bugbear
```

### Expected Results After Fix

1. ✅ **Sequential Execution**: Step 0 completes before build-deploy starts
2. ✅ **Violations Detected**: Will correctly find 2 B001 violations:
   - `app/heatmap_generator.py:229`
   - `app/routes/api_density.py:80`
3. ✅ **Non-Blocking**: Pipeline continues regardless (continue-on-error: true)

### Testing
- CI will validate the workflow on this PR
- Step 0 should show the 2 expected violations
- build-deploy should start after Step 0 completes

### Related
- **Issue**: #397 - Phase 1: Step 0 Bare Exception Check
- **Parent**: #396 - Phase 4 Complexity Checks