### PR TITLE
Issue #399 Phase 3.1: Add C901 Complexity Checks (Non-Blocking)

### DIFF
--- a/.github/workflows/ci-pipeline.yml
+++ b/.github/workflows/ci-pipeline.yml
@@ -38,14 +38,17 @@ jobs:
           python -m pip install --upgrade pip
           pip install flake8 flake8-bugbear
 
-      - name: Run Bare Exception Check
+      - name: Run Complexity Checks (B001 + C901)
         run: |
           echo "=== Running Complexity Standards Check ==="
-          echo "Checking for bare exception handlers (B001)..."
+          echo "Checking for bare exception handlers (B001)...";
+          echo "Checking for complexity violations (C901, threshold=15)...";
           echo ""
           echo "This check is non-blocking - pipeline will continue regardless of results"
           echo ""
-          flake8 app/ core/ --select=B001 --exclude=tests/*
+          # Check B001 (bare exceptions) and C901 (complexity > 15)
+          # Note: C901 threshold is enforced via .flake8 config or radon
+          flake8 app/ core/ --max-complexity=15 --select=B001,C901 --exclude=tests/*
           echo ""
           echo "✅ Complexity check completed"
 


### PR DESCRIPTION
## Overview

Implements **Phase 3.1** of Issue #396: Phase 4 Complexity Checks.

## Changes

Adds cyclomatic complexity (C901) checks to Step 0 alongside existing B001 checks:

### Configuration
- **Check**: `flake8 --max-complexity=15 --select=B001,C901 --exclude=tests/*`
- **Threshold**: 15 (higher than standard 10, to avoid blocking initial assessment)
- **Non-Blocking**: `continue-on-error: true` - allows pipeline to continue
- **Combined**: Runs alongside B001 checks in same Step 0 job

### Expected Results

This will identify complexity violations:
- Functions with cyclomatic complexity > 15
- Provides visibility into complexity issues
- Does NOT block deployments (non-blocking)

### Known Issues

Based on previous analysis, we expect:
- `app/density_report.py:637` - `generate_density_report()` complexity = 68
- This will be flagged and addressed in Phase 3.2

## Related Issues

- **Issue**: #399 - Phase 3: Incremental Complexity Checks
- **Parent**: #396 - Phase 4 Complexity Checks
- **Prerequisites**: 
  - ✅ #397 - Phase 1: Step 0 (merged)
  - ✅ #398 - Phase 2: Fix Violations (merged)

## Testing

- CI will automatically validate the workflow
- Step 0 will show both B001 and C901 violations
- Should complete in ~30-60 seconds
- Non-blocking, so pipeline continues regardless