### PR TITLE
Issue #334: Finish Auto-Captions and UI Wiring

### DIFF
--- a/app/common/config.py
+++ b/app/common/config.py
@@ -89,3 +89,29 @@ def load_reporting() -> Dict[str, Any]:
     with path.open("r", encoding="utf-8") as f:
         return yaml.safe_load(f)
 
+
+def load_captioning() -> Dict[str, Any]:
+    """
+    Load captioning.yml (caption thresholds and qualitative rules).
+    
+    Returns:
+        dict: Parsed captioning config containing keys like:
+            - wave_gap_minutes
+            - clearance_threshold_p_m2
+            - clearance_sustain_minutes
+            - similarity_pct
+            - spread_pct
+    
+    Raises:
+        FileNotFoundError: If captioning.yml not found
+        yaml.YAMLError: If YAML parsing fails
+    """
+    path = CONFIG_DIR / "captioning.yml"
+    if not path.exists():
+        raise FileNotFoundError(
+            f"captioning.yml not found at {path}. "
+            f"Ensure config/ directory contains caption thresholds as documented."
+        )
+    with path.open("r", encoding="utf-8") as f:
+        return yaml.safe_load(f)
+

--- a/config/density_rulebook.yml
+++ b/config/density_rulebook.yml
@@ -26,6 +26,14 @@ globals:
     E: { min: 1.08, max: 1.63, label: "Very dense" }
     F: { min: 1.63, max: 999.0, label: "Extremely dense" }
   
+  # Captioning thresholds (Issue #334; used for heatmap auto-captions)
+  captioning:
+    wave_gap_minutes: 5
+    clearance_threshold_p_m2: 0.10
+    clearance_sustain_minutes: 6
+    similarity_pct: 0.10
+    spread_pct: 0.20
+  
   # Operational policy (tuned to ~10% flagging rate, matching operational baseline)
   policy:
     density_watch_at: "C"           # Start flagging at LOS C (0.54 p/m²)

--- a/templates/pages/density.html
+++ b/templates/pages/density.html
@@ -66,6 +66,11 @@
             <img id="heatmap-image" src="" alt="Density heatmap" style="max-width: 100%; border-radius: 4px;" />
             <div id="heatmap-placeholder" class="placeholder">No heatmap data available for this segment.</div>
         </div>
+
+        <!-- Caption beneath heatmap (Issue #334) -->
+        <div id="caption-container" style="margin: 0.5rem 0 1.5rem 0; display: none;">
+            <div id="segment-caption" style="padding: 0.75rem; background: #f8f9fa; border-left: 4px solid #2c3e50; border-radius: 4px; color: #2c3e50; line-height: 1.4;"></div>
+        </div>
         
         <!-- Bin-Level Table -->
         <div id="bin-details-container" style="margin: 1.5rem 0;">
@@ -507,6 +512,17 @@
         } else {
             heatmapImg.style.display = 'none';
             noBinData.style.display = 'block';
+        }
+        
+        // Render caption (Issue #334)
+        const captionContainer = document.getElementById('caption-container');
+        const captionEl = document.getElementById('segment-caption');
+        if (detail.caption) {
+            captionEl.textContent = detail.caption;
+            captionContainer.style.display = 'block';
+        } else {
+            captionEl.textContent = '';
+            captionContainer.style.display = 'none';
         }
         
         // Show detail panel


### PR DESCRIPTION
# Captions on Density Heatmaps (Finalize Auto‑Captions Pipeline)

Status: OPEN  
Related: #280 (closed, authoritative spec), #318, #279  
Owner: Cursor Dev (under Senior Architect guidance)

---

## Objective
Complete the auto‑caption feature for density heatmaps by finishing the captions generation logic and reconnecting it to the API and UI. This implements the authoritative rules from Issue #280 while respecting repo guardrails and SSOT configs.

---

## Scope of Work

### 1) Preparation
- Verify branch is up to date and that `captions.json` exists but has empty `waves`, `clearance_time`, and `label` fields; UI caption rendering was previously removed.
- Add caption thresholds to config (no hardcoding):
  - `config/density_rulebook.yml` or a small dedicated section in a new `config/captioning.yml` if preferred:
    - `wave_gap_minutes: 5`
    - `clearance_threshold_p_m2: 0.10`
    - `clearance_sustain_minutes: 6`
    - `similarity_pct: 0.10`
    - `spread_pct: 0.20`
  - `config/reporting.yml`: qualitative label mapping (bands/text) if needed for UI phrasing.

### 2) Backend Logic (analytics)
Implement/finish `export_segment_captions(run_id, artifacts_root)` in `analytics/export_frontend_artifacts.py` using `artifacts/<run_id>/bin_summary.json` as input (not arrivals from `segments.csv`).

- Column normalization and parsing:
  - Use canonical aliases from #280: `segment_id`, `t_start`, `t_end`, `start_km`, `end_km`, `density`.
  - Parse times to event‑local; display as `HH:MM`.
- Wave detection (authoritative rule from #280):
  - Sort bins by `t_start`.
  - New wave when `(next.t_start - prev.t_end) > wave_gap_minutes` (end→start gap). Overlaps (gap ≤ 0) stay in the same wave.
- Peak and location:
  - Global max density across bins; LOS band from `config/density_rulebook.yml`.
  - Format location as `"a–b km"` using one decimal.
- Clearance detection (sustained window):
  - Build a 1‑minute series per segment.
  - For each minute, compute max density across all distance bins.
  - Clearance time is earliest `T` where every minute in `[T, T+clearance_sustain_minutes)` has `max_density ≤ clearance_threshold_p_m2`.
  - Minutes with no coverage are unknown; skip such windows. If none found, `null`.
- Qualitative descriptors (optional when confident):
  - Heavier/lighter/similar by ±`similarity_pct` of prior wave peak.
  - Dispersed/concentrated/similar by ±`spread_pct` of spread score (unique minutes × unique distance bins).
  - Omit adjectives if marginal data.
- Summary text:
  - Deterministic, concise narrative per #280 examples (single‑wave and multi‑wave templates).
- Output schema per #280:
  - Required: `seg_id`, `label`, `summary`, `peak{density_p_m2,time,km_range,los}`, `waves[]`, `clearance_time`, `notes`.
  - Always emit JSON object; never crash. Minimal caption with notes when data sparse.

### 3) Storage and API
- Ensure a small helper exists to load captions via the unified storage abstraction (`app/storage.py`).
- Extend `/api/density/segment/<seg_id>` in `app/routes/api_density.py` to include:
  - `caption` (summary string), and optionally `waves`, `peak`, `clearance` (for future richer UI).
- Do not fetch raw `captions.json` from the UI; keep templates thin and API‑driven.

### 4) UI
- In `templates/pages/density.html`, render `segment.caption` beneath the heatmap (restore previously removed behavior).
- Optional: a simple “Show captions” toggle that hides/shows the caption div (no new data fetch).

### 5) Tests & Validation
- Unit tests (`tests/test_export_segment_captions.py`):
  - Wave split rule, sustained clearance window, qualitative thresholds, and schema.
- API tests (`tests/test_api_density_segment.py`):
  - Caption present and non‑empty when available; null when absent.
- UI tests (`tests/test_ui_pages_density.py`):
  - Caption renders; toggle hides/shows.
- QC test (`tests/test_ui_artifacts_qc.py`):
  - `captions.json` schema validation.
- E2E per guardrails:
  - `python e2e.py --local` and Cloud validation; verify `/density` shows captions beneath heatmaps and that artifacts are produced.

---

## Acceptance Criteria
- `export_segment_captions` populates `waves`, `clearance_time`, and `summary/label` deterministically from `bin_summary.json`.
- `/api/density/segment/<seg_id>` includes `caption` (and remains backward‑compatible).
- `/density` page displays caption beneath the heatmap; toggle (if added) functions.
- No hardcoded thresholds; all values sourced from config.
- Unit, API, UI, and E2E validations pass.

---

## Non‑Goals
- New visualization libraries or client‑side heatmap logic.
- Direct UI access to artifact files.
- Reintroducing bin‑level details table (tracked in #318).

---

## Risks & Mitigations
- Sparse data can reduce confidence → emit minimal caption with `notes` and avoid adjectives.
- Clearance may not be provable in window → set `clearance_time=null` with explanatory note.
- UI clutter → keep caption beneath heatmap; avoid map overlays in this issue.

---

## Implementation Notes
- Small, testable edits only; dev branch; PR with E2E proof.
- Reuse SSOT configs: `config/density_rulebook.yml`, `config/reporting.yml`.
- Follow Issue #280’s algorithms exactly; this issue completes the remaining wiring.
