### PR TITLE
Upload captions.json via StorageService (Cloud parity)

### DIFF
--- a/analytics/export_heatmaps.py
+++ b/analytics/export_heatmaps.py
@@ -585,15 +585,14 @@ def export_heatmaps_and_captions(
             print(f"   ⚠️  {seg_id}: Error generating caption: {e}")
             continue
     
-    # Save captions.json in artifacts directory
+    # Save captions.json using StorageService to support Cloud (GCS) and Local
     if captions:
-        captions_path = Path("artifacts") / run_id / "ui" / "captions.json"
         try:
-            with open(captions_path, 'w') as f:
-                json.dump(captions, f, indent=2)
+            artifacts_path = f"artifacts/{run_id}/ui/captions.json"
+            storage.save_artifact_json(artifacts_path, captions)
             print(f"   ✅ captions.json: {len(captions)} segments captioned")
         except Exception as e:
-            print(f"   ⚠️  Could not save captions.json: {e}")
+            print(f"   ⚠️  Could not save captions.json via StorageService: {e}")
     
     print(f"\n{'='*60}")
     print(f"✅ Heatmaps & Captions Complete")

--- a/app/storage_service.py
+++ b/app/storage_service.py
@@ -132,6 +132,26 @@ class StorageService:
         """
         content = json.dumps(data, indent=2, default=str)
         return self.save_file(filename, content, date)
+
+    def save_artifact_json(self, file_path: str, data: Dict[str, Any]) -> str:
+        """
+        Save JSON to an explicit artifacts path (e.g., "artifacts/<run_id>/ui/captions.json").
+        This avoids automatic date-prefixing used by save_file/save_json.
+        """
+        content = json.dumps(data, indent=2, default=str)
+        if self.config.use_cloud_storage:
+            return self._save_to_gcs(file_path, content)
+        else:
+            # Write relative to repository root for local mode
+            try:
+                full_path = Path(file_path)
+                full_path.parent.mkdir(parents=True, exist_ok=True)
+                full_path.write_text(content)
+                logger.info(f"Saved artifact locally: {full_path}")
+                return str(full_path)
+            except Exception as e:
+                logger.error(f"Failed to save artifact locally {file_path}: {e}")
+                raise
     
     def load_file(self, filename: str, date: Optional[str] = None) -> Optional[str]:
         """


### PR DESCRIPTION
Implements Option A: captions.json is now saved via StorageService to artifacts/<run_id>/ui, ensuring availability on GCS for Cloud UI. No changes to UI/API contracts. Verified locally; will confirm on Cloud after merge.