### PR TITLE
Add unified density pipeline orchestration

### DIFF
--- a/analytics/pipeline.py
+++ b/analytics/pipeline.py
@@ -1,0 +1,247 @@
+"""Unified analytics pipeline orchestration.
+
+This module provides a single entry point for running the density analysis
+pipeline end-to-end.  The :func:`run_density_pipeline` function stitches
+together the existing analytics components to produce the full suite of
+reports, UI artifacts, heatmaps, and optional cloud uploads.
+
+The goal is to centralize the workflow without modifying the individual
+modules.  Each step prints user-friendly progress logs so operators can
+follow the pipeline execution in local and Cloud Run environments.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from app.constants import DEFAULT_START_TIMES
+from app.density_report import generate_density_report
+from app.flow_report import generate_temporal_flow_report
+from app.storage_service import (
+    StorageConfig,
+    StorageService,
+    get_storage_service,
+    initialize_storage_service,
+)
+
+from analytics.export_frontend_artifacts import (
+    calculate_flow_segment_counts,
+    export_ui_artifacts,
+)
+from analytics.export_heatmaps import export_heatmaps_and_captions
+
+
+def _prepare_storage(use_cloud: bool) -> StorageService:
+    """Initialize and return a configured :class:`StorageService`."""
+
+    config = StorageConfig(use_cloud_storage=use_cloud)
+    storage = initialize_storage_service(config)
+
+    environment = "cloud" if storage.config.use_cloud_storage else "local"
+    print(f"🔐 Storage configured for {environment} mode")
+
+    # Ensure the local reports directory exists for downstream consumers
+    Path(storage.config.local_reports_dir).mkdir(parents=True, exist_ok=True)
+
+    return storage
+
+
+def _extract_run_id_from_path(path: Path, default: str) -> str:
+    """Return the run identifier inferred from a report path."""
+
+    name = path.stem
+    for suffix in ("-Density", "-Flow"):
+        if name.endswith(suffix):
+            return name[: -len(suffix)]
+    return default
+
+
+def _copy_reports_to_run_folder(source: Path, destination: Path) -> None:
+    """Copy generated report assets into a run-specific directory."""
+
+    if source.resolve() == destination.resolve():
+        return
+
+    print(f"🗂️  Preparing run directory at {destination}")
+    destination.mkdir(parents=True, exist_ok=True)
+
+    for item in source.iterdir():
+        target = destination / item.name
+        if item.is_dir():
+            if target.exists():
+                shutil.rmtree(target)
+            shutil.copytree(item, target)
+        else:
+            shutil.copy2(item, target)
+
+
+def _locate_latest_report(candidates: List[Path]) -> Optional[Path]:
+    """Return the newest report path from a list of candidates."""
+
+    existing = [p for p in candidates if p and p.exists()]
+    if not existing:
+        return None
+    return max(existing, key=lambda p: p.stat().st_mtime)
+
+
+def run_density_pipeline(run_id: str, use_cloud: bool = False) -> Dict[str, Any]:
+    """Execute the full density analytics pipeline.
+
+    Args:
+        run_id: Identifier for the analytics run (e.g., ``2025-10-30-1025``).
+        use_cloud: When ``True`` the pipeline saves outputs via GCS.
+
+    Returns:
+        Dictionary summarizing the pipeline execution for downstream tooling.
+    """
+
+    print("🚀 Starting density analytics pipeline…")
+    print(f"🆔 Run ID: {run_id}")
+    print(f"☁️  Cloud uploads enabled: {use_cloud}")
+
+    storage = _prepare_storage(use_cloud)
+    environment = "cloud" if storage.config.use_cloud_storage else "local"
+    reports_base = Path(storage.config.local_reports_dir)
+
+    summary: Dict[str, Any] = {
+        "run_id": run_id,
+        "environment": environment,
+        "density": {},
+        "flow": {},
+    }
+
+    density_result: Dict[str, Any] = {}
+    flow_result: Dict[str, Any] = {}
+
+    print("📈 Running density analysis…")
+    try:
+        density_result = generate_density_report(
+            pace_csv="data/runners.csv",
+            density_csv="data/segments.csv",
+            start_times=DEFAULT_START_TIMES,
+            output_dir=str(reports_base),
+        )
+        summary["density"] = {
+            "ok": density_result.get("ok", False),
+            "report_path": density_result.get("report_path"),
+        }
+        print("✅ Density analysis complete")
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        print(f"⚠️ Density analysis failed: {exc}")
+        summary["density"] = {"ok": False, "error": str(exc)}
+
+    print("🌊 Running temporal flow analysis…")
+    try:
+        flow_result = generate_temporal_flow_report(
+            pace_csv="data/runners.csv",
+            segments_csv="data/segments.csv",
+            start_times=DEFAULT_START_TIMES,
+            output_dir=str(reports_base),
+            density_results=density_result.get("analysis_results"),
+            environment=environment,
+        )
+        summary["flow"] = {
+            "ok": flow_result.get("ok", False),
+            "report_path": flow_result.get("report_path"),
+        }
+        print("✅ Temporal flow analysis complete")
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        print(f"⚠️ Temporal flow analysis failed: {exc}")
+        summary["flow"] = {"ok": False, "error": str(exc)}
+
+    candidate_paths: List[Path] = []
+    for key in ("report_path",):
+        report_path = density_result.get(key)
+        if report_path:
+            candidate_paths.append(Path(report_path))
+        report_path = flow_result.get(key)
+        if report_path:
+            candidate_paths.append(Path(report_path))
+
+    latest_report = _locate_latest_report(candidate_paths)
+    if latest_report:
+        inferred_run_id = _extract_run_id_from_path(latest_report, run_id)
+        print(f"🕒 Latest report detected: {latest_report.name} → run_id={inferred_run_id}")
+    else:
+        inferred_run_id = run_id
+        print("⚠️ Could not infer run ID from reports; using provided identifier")
+
+    run_reports_dir = reports_base / inferred_run_id
+    if latest_report:
+        _copy_reports_to_run_folder(latest_report.parent, run_reports_dir)
+    else:
+        run_reports_dir.mkdir(parents=True, exist_ok=True)
+
+    summary["final_run_id"] = inferred_run_id
+    summary["reports_dir"] = str(run_reports_dir)
+
+    try:
+        print("📊 Calculating flow segment counts…")
+        overtaking_segments, co_presence_segments = calculate_flow_segment_counts(
+            reports_base, inferred_run_id
+        )
+    except Exception as exc:
+        print(f"⚠️ Flow segment count calculation failed: {exc}")
+        overtaking_segments, co_presence_segments = 0, 0
+
+    summary["flow_segment_counts"] = {
+        "overtaking": overtaking_segments,
+        "co_presence": co_presence_segments,
+    }
+
+    artifacts_dir: Optional[Path] = None
+    if run_reports_dir.exists():
+        print("🧩 Generating UI artifacts…")
+        try:
+            artifacts_dir = export_ui_artifacts(
+                run_reports_dir,
+                inferred_run_id,
+                overtaking_segments,
+                co_presence_segments,
+                environment=environment,
+            )
+            print(f"✅ UI artifacts ready at {artifacts_dir}")
+        except Exception as exc:
+            print(f"⚠️ UI artifact export failed: {exc}")
+    else:
+        print(f"⚠️ Reports directory missing: {run_reports_dir}")
+
+    heatmap_counts: Tuple[int, int] = (0, 0)
+    if run_reports_dir.exists():
+        print("🌡️  Generating heatmaps and captions…")
+        try:
+            storage_service = get_storage_service()
+            heatmap_counts = export_heatmaps_and_captions(
+                inferred_run_id, run_reports_dir, storage_service
+            )
+            print(
+                "✅ Heatmap generation complete: "
+                f"{heatmap_counts[0]} heatmaps, {heatmap_counts[1]} captions"
+            )
+        except Exception as exc:
+            print(f"⚠️ Heatmap generation skipped: {exc}")
+
+    summary["artifacts_dir"] = str(artifacts_dir) if artifacts_dir else None
+    summary["heatmaps"] = {
+        "generated": heatmap_counts[0],
+        "captions": heatmap_counts[1],
+    }
+
+    summary_path = f"artifacts/{inferred_run_id}/ui/pipeline_summary.json"
+    try:
+        action = "Uploading" if storage.config.use_cloud_storage else "Saving"
+        print(f"📦 {action} pipeline summary to {summary_path}…")
+        storage.save_artifact_json(summary_path, summary)
+        print("✅ Pipeline summary persisted")
+    except Exception as exc:  # pragma: no cover - defensive logging path
+        print(f"⚠️ Failed to persist pipeline summary: {exc}")
+
+    print("🎉 Density analytics pipeline complete")
+    return summary
+
+
+__all__ = ["run_density_pipeline"]
+

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,0 +1,184 @@
+"""Tests for the analytics pipeline orchestration."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from types import ModuleType, SimpleNamespace
+
+
+class DummyStorage:
+    """Lightweight storage service stub for tests."""
+
+    def __init__(self, base_dir: Path):
+        self.base_dir = base_dir
+        self.config = SimpleNamespace(
+            local_reports_dir=str(base_dir / "reports"),
+            use_cloud_storage=False,
+            bucket_name="test-bucket",
+        )
+
+    def save_artifact_json(self, file_path: str, data):
+        full_path = self.base_dir / file_path
+        full_path.parent.mkdir(parents=True, exist_ok=True)
+        full_path.write_text(json.dumps(data))
+        return str(full_path)
+
+
+def test_run_density_pipeline(monkeypatch, tmp_path):
+    pandas_stub = ModuleType("pandas")
+    pandas_stub.DataFrame = dict
+    pandas_stub.read_csv = lambda *args, **kwargs: None
+    pandas_stub.read_parquet = lambda *args, **kwargs: None
+    pandas_stub.isna = lambda value: False
+    pandas_stub.Series = dict
+    pandas_stub.concat = lambda *args, **kwargs: None
+    sys.modules.setdefault("pandas", pandas_stub)
+
+    pyarrow_stub = ModuleType("pyarrow")
+    pyarrow_stub.Table = SimpleNamespace(from_pylist=lambda *args, **kwargs: SimpleNamespace())
+    sys.modules.setdefault("pyarrow", pyarrow_stub)
+
+    parquet_stub = ModuleType("pyarrow.parquet")
+    parquet_stub.write_table = lambda *args, **kwargs: None
+    sys.modules.setdefault("pyarrow.parquet", parquet_stub)
+
+    numpy_stub = ModuleType("numpy")
+    numpy_stub.array = lambda *args, **kwargs: None
+    numpy_stub.isnan = lambda value: False
+    numpy_stub.isfinite = lambda value: True
+    numpy_stub.nan = float("nan")
+    numpy_stub.ndarray = list
+
+    def _numpy_default(name):
+        def _stub(*args, **kwargs):
+            return None
+
+        return _stub
+
+    numpy_stub.__getattr__ = _numpy_default
+    sys.modules.setdefault("numpy", numpy_stub)
+
+    yaml_stub = ModuleType("yaml")
+    yaml_stub.safe_load = lambda *args, **kwargs: {}
+    sys.modules.setdefault("yaml", yaml_stub)
+
+    google_stub = ModuleType("google")
+    cloud_stub = ModuleType("google.cloud")
+    storage_stub = ModuleType("google.cloud.storage")
+    storage_stub.Client = lambda *args, **kwargs: None
+    exceptions_stub = ModuleType("google.cloud.exceptions")
+    sys.modules.setdefault("google", google_stub)
+    sys.modules.setdefault("google.cloud", cloud_stub)
+    sys.modules.setdefault("google.cloud.storage", storage_stub)
+    sys.modules.setdefault("google.cloud.exceptions", exceptions_stub)
+
+    fastapi_stub = ModuleType("fastapi")
+
+    class _DummyRouter:
+        def __init__(self, *args, **kwargs):
+            pass
+
+        def get(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+        def post(self, *args, **kwargs):
+            def decorator(func):
+                return func
+
+            return decorator
+
+    class _HTTPException(Exception):
+        def __init__(self, status_code=500, detail=""):
+            super().__init__(detail)
+            self.status_code = status_code
+            self.detail = detail
+
+    fastapi_stub.APIRouter = _DummyRouter
+    fastapi_stub.HTTPException = _HTTPException
+    fastapi_stub.Query = lambda *args, **kwargs: None
+    sys.modules.setdefault("fastapi", fastapi_stub)
+
+    responses_stub = ModuleType("fastapi.responses")
+    responses_stub.JSONResponse = SimpleNamespace
+    sys.modules.setdefault("fastapi.responses", responses_stub)
+
+    matplotlib_stub = ModuleType("matplotlib")
+    pyplot_stub = ModuleType("matplotlib.pyplot")
+    colors_stub = ModuleType("matplotlib.colors")
+
+    class _DummyColormap:
+        def set_bad(self, *args, **kwargs):
+            return None
+
+    colors_stub.LinearSegmentedColormap = SimpleNamespace(from_list=lambda *args, **kwargs: _DummyColormap())
+
+    class _DummyPowerNorm:
+        def __init__(self, *args, **kwargs):
+            pass
+
+    colors_stub.PowerNorm = _DummyPowerNorm
+
+    matplotlib_stub.pyplot = pyplot_stub
+    pyplot_stub.subplots = lambda *args, **kwargs: (SimpleNamespace(), SimpleNamespace())
+    pyplot_stub.close = lambda *args, **kwargs: None
+    pyplot_stub.Axes = SimpleNamespace
+    matplotlib_stub.use = lambda *args, **kwargs: None
+    sys.modules.setdefault("matplotlib", matplotlib_stub)
+    sys.modules.setdefault("matplotlib.pyplot", pyplot_stub)
+    sys.modules.setdefault("matplotlib.colors", colors_stub)
+
+    import analytics.pipeline as pipeline
+
+    storage = DummyStorage(tmp_path)
+
+    monkeypatch.setattr(pipeline, "initialize_storage_service", lambda config: storage)
+    monkeypatch.setattr(pipeline, "get_storage_service", lambda: storage)
+
+    def fake_generate_density_report(*_, **kwargs):
+        output_dir = Path(kwargs.get("output_dir", storage.config.local_reports_dir))
+        source_dir = Path(output_dir) / "2025-01-01"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        density_path = source_dir / "test-run-Density.md"
+        density_path.write_text("density report")
+        return {
+            "ok": True,
+            "report_path": str(density_path),
+            "analysis_results": {"segments": []},
+        }
+
+    def fake_generate_flow_report(*_, **kwargs):
+        output_dir = Path(kwargs.get("output_dir", storage.config.local_reports_dir))
+        source_dir = Path(output_dir) / "2025-01-01"
+        source_dir.mkdir(parents=True, exist_ok=True)
+        flow_md = source_dir / "test-run-Flow.md"
+        flow_md.write_text("flow report")
+        flow_csv = source_dir / "test-run-Flow.csv"
+        flow_csv.write_text("seg_id,overtaking_a,overtaking_b,copresence_a,copresence_b\n")
+        return {"ok": True, "report_path": str(flow_md), "segments": []}
+
+    monkeypatch.setattr(pipeline, "generate_density_report", fake_generate_density_report)
+    monkeypatch.setattr(pipeline, "generate_temporal_flow_report", fake_generate_flow_report)
+    monkeypatch.setattr(pipeline, "calculate_flow_segment_counts", lambda *_: (1, 2))
+
+    def fake_export_ui_artifacts(reports_dir, run_id, *_args, **_kwargs):
+        artifacts_dir = storage.base_dir / "artifacts" / run_id / "ui"
+        artifacts_dir.mkdir(parents=True, exist_ok=True)
+        (artifacts_dir / "meta.json").write_text("{}")
+        return artifacts_dir
+
+    monkeypatch.setattr(pipeline, "export_ui_artifacts", fake_export_ui_artifacts)
+    monkeypatch.setattr(pipeline, "export_heatmaps_and_captions", lambda *_: (2, 1))
+
+    summary = pipeline.run_density_pipeline("test-run", use_cloud=False)
+
+    assert summary["final_run_id"] == "test-run"
+    assert summary["heatmaps"] == {"generated": 2, "captions": 1}
+
+    summary_path = storage.base_dir / "artifacts/test-run/ui/pipeline_summary.json"
+    assert summary_path.exists()
+


### PR DESCRIPTION
## Summary
- add a new analytics pipeline entry point that runs density, flow, artifact, and heatmap generation while handling local or cloud storage
- introduce a focused unit test with dependency stubs to ensure the pipeline function executes successfully in local mode

## Testing
- PYENV_VERSION=3.11.12 python -m pytest tests/test_pipeline.py

------
https://chatgpt.com/codex/tasks/task_e_6903dcd9eb708322a4c12b8a3b1dfd73