### PR TITLE
Hotfix: Update Dockerfile for v1.7 directory structure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,8 +13,6 @@ COPY requirements.txt ./
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY app ./app
-COPY api ./api
-COPY core ./core
 COPY data ./data
 COPY config ./config
 COPY frontend ./frontend


### PR DESCRIPTION
## Docker Build Failure Fix

Fixes Docker build failure in CI pipeline after v1.7 merge.

---

## Problem

**Docker Build Error:**
```
ERROR: /api: not found
ERROR: /core: not found
```

Dockerfile still references old directory structure:
- `COPY api ./api`
- `COPY core ./core`

But these directories were moved to:
- `/app/api`
- `/app/core`

---

## Solution

Remove obsolete COPY commands from Dockerfile:
- ❌ `COPY api ./api` (removed - now in app/api)
- ❌ `COPY core ./core` (removed - now in app/core)

These directories are already included when `COPY app ./app` runs.

---

## Testing

Local Docker build should now succeed.

---

**This hotfix is required for v1.7 deployment to Cloud Run.**