### PR TITLE
Fix issues #519/#542: Remove duplicate bins.parquet files

### DIFF
--- a/app/density_report.py
+++ b/app/density_report.py
@@ -3403,7 +3403,8 @@ def generate_new_density_report_issue246(
     output_path: Optional[str] = None,
     app_version: str = "1.6.42",
     events: Optional[Dict[str, Dict[str, Any]]] = None,
-    event_groups_res: Optional[Dict[str, Dict[str, Any]]] = None  # Issue #573: RES data for Executive Summary
+    event_groups_res: Optional[Dict[str, Dict[str, Any]]] = None,  # Issue #573: RES data for Executive Summary
+    bins_dir: Optional[str] = None  # Issue #519/542: Optional bins directory to avoid duplicate files
 ) -> Dict[str, Any]:
     """
     Generate the new density report per Issue #246 specification.
@@ -3412,11 +3413,14 @@ def generate_new_density_report_issue246(
     to replace the legacy report structure.
     
     Args:
-        reports_dir: Directory containing Parquet files
+        reports_dir: Directory containing segments.parquet
         output_path: Path to save the report (optional)
         app_version: Application version
         events: Optional dict of event info (name -> {start_time, start_time_formatted, runner_count})
         event_groups_res: Optional event groups RES data (Issue #573)
+        bins_dir: Optional directory containing bins.parquet and segment_windows_from_bins.parquet.
+                  If None, reads from reports_dir (for backward compatibility).
+                  Issue #519/542: Prefer reading from bins_dir to avoid duplicate files.
         
     Returns:
         Dictionary with report content and metadata
@@ -3430,8 +3434,9 @@ def generate_new_density_report_issue246(
     # Convert string paths to Path objects
     reports_path = Path(reports_dir)
     output_path_obj = Path(output_path) if output_path else None
+    bins_path = Path(bins_dir) if bins_dir else None
     
-    logger.info(f"generate_new_density_report_issue246: Calling generate_new_density_report with reports_dir={reports_path}, output_path={output_path_obj}")
+    logger.info(f"generate_new_density_report_issue246: Calling generate_new_density_report with reports_dir={reports_path}, bins_dir={bins_path}, output_path={output_path_obj}")
     
     # Generate the new report
     results = generate_new_density_report(
@@ -3439,7 +3444,8 @@ def generate_new_density_report_issue246(
         output_path_obj, 
         app_version, 
         events=events,
-        event_groups_res=event_groups_res  # Issue #573: Pass RES data
+        event_groups_res=event_groups_res,  # Issue #573: Pass RES data
+        bins_dir=bins_path  # Issue #519/542: Pass bins_dir to avoid duplicate files
     )
     
     logger.info(f"generate_new_density_report_issue246: generate_new_density_report returned, success={results.get('success', False)}")


### PR DESCRIPTION
## Summary

Removes duplicate `bins.parquet` files that were being copied from `{day}/bins/` to `{day}/reports/` directory.

## Changes

- **Updated `load_parquet_sources()`**: Added optional `bins_dir` parameter to read bins directly from bins directory
- **Removed copy operations**: Eliminated `shutil.copy2()` calls that duplicated `bins.parquet` and `segment_windows_from_bins.parquet`
- **Removed save operations**: No longer saves filtered bins back to reports directory
- **Updated function signatures**: Added `bins_dir` parameter throughout call chain:
  - `generate_new_density_report()`
  - `generate_new_density_report_issue246()`
  - `generate_density_report_v2()`
- **Cleaned up**: Removed unused imports and variables

## Testing

- ✅ E2E test run completed successfully
- ✅ Reports generated correctly (Density.md created for both days)
- ✅ Verified: `bins.parquet` only exists in `{day}/bins/` directory
- ✅ Verified: `bins.parquet` does NOT exist in `{day}/reports/` directory
- ✅ Logs confirm bins loaded from correct location

## Impact

- **File reduction**: Eliminates duplicate `bins.parquet` files (saves ~25-26KB per day)
- **Performance**: Removes unnecessary file I/O operations
- **Backward compatible**: Falls back to reading from reports_dir if bins_dir not provided

## Related Issues

- Fixes #519
- Fixes #542

Closes #519
Closes #542

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates duplicate bin artifacts by sourcing bins directly from the day `bins` directory and wiring this path through the report pipeline.
> 
> - Stop copying `bins.parquet`/`segment_windows_from_bins.parquet` into `reports`; verify day-scoping only and continue saving day-filtered `segments.parquet`
> - Add `bins_dir` parameter to `generate_density_report_v2`, `generate_new_density_report_issue246`, `new_density_report.generate_new_density_report`, and `load_parquet_sources` to load bins from `bins_dir` with fallback to `reports_dir`
> - Update logging/docstrings to reflect new source of bins; remove unused imports and obsolete copy/filter/save code
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 473ba2f0641e7ac472e9df915eb7ee540df2eb31. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->