### PR TITLE
Fix issue #586: Add missing update_pointer_files() call

### DIFF
--- a/app/core/v2/pipeline.py
+++ b/app/core/v2/pipeline.py
@@ -1332,6 +1332,9 @@ def create_full_analysis_pipeline(
                 # Re-write metadata.json with logs reference
                 with open(run_metadata_path, 'w', encoding='utf-8') as f:
                     json.dump(combined_metadata, f, indent=2, ensure_ascii=False)
+        
+        # Update pointer files (latest.json, index.json)
+        update_pointer_files(run_id, combined_metadata)
         logger.info(f"[Phase 6] Updated pointer files (latest.json, index.json)")
         
         metadata_metrics.finish(memory_mb=get_memory_usage_mb())


### PR DESCRIPTION
## Summary

Fixes the bug where pointer files (latest.json, index.json) were not being updated in `create_full_analysis_pipeline()`.

## Problem

The log message indicated that pointer files were updated, but the actual function call to `update_pointer_files()` was missing. This was likely introduced during pipeline refactoring in Issues #574 and #581.

## Changes

- Added missing call to `update_pointer_files(run_id, combined_metadata)` before the log message
- Pointer files will now be properly updated after metadata.json is created

## Impact

- ✅ `latest.json` will now correctly point to the most recent run
- ✅ `index.json` will now correctly include run metadata
- ✅ Dashboard and API endpoints that depend on these files will work correctly

## Testing

The fix is straightforward - adding a function call that was already defined in the same file. The function `update_pointer_files()` exists and is correctly used in `create_stubbed_pipeline()` - we're just adding it to the full pipeline where it was accidentally omitted.

Fixes #586

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensures pointer files are refreshed during Phase 6 of the full pipeline.
> 
> - Calls `update_pointer_files(run_id, combined_metadata)` after writing run-level `metadata.json`, enabling updates to `latest.json` and `index.json`
> - Keeps existing logging and performance tracking unchanged
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1ee08c7f3e6d04ed572f6d4bb7c9dac8480b89eb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->