### PR TITLE
Replace legacy `los` column with `los_class` across flagging, artifacts and APIs

### DIFF
--- a/app/core/artifacts/frontend.py
+++ b/app/core/artifacts/frontend.py
@@ -249,8 +249,6 @@ def generate_segment_metrics_json(reports_dir: Path) -> Dict[str, Dict[str, Any]
             # Issue #603: Extract LOS from worst bin (not recalculated)
             if 'los_class' in worst_bin_row:
                 worst_los = str(worst_bin_row['los_class'])
-            elif 'los' in worst_bin_row:
-                worst_los = str(worst_bin_row['los'])
             else:
                 # Fallback: classify from density if los_class not available
                 try:
@@ -1015,7 +1013,7 @@ def generate_density_schema_json(dataset_version: str = "unknown") -> Dict[str, 
         "units": {
             "density": "persons_per_m2",
             "rate": "persons_per_second", 
-            "los": "A-F",
+            "los_class": "A-F",
             "severity": "NONE|WATCH|ALERT|CRITICAL",
             "time": "ISO8601"
         },
@@ -1051,7 +1049,7 @@ def generate_density_schema_json(dataset_version: str = "unknown") -> Dict[str, 
                 "description": "Persons per second (p/s)."
             },
             {
-                "name": "los",
+                "name": "los_class",
                 "type": "string",
                 "required": True,
                 "description": "Level of Service classification (A–F)."
@@ -1180,4 +1178,3 @@ def generate_health_json(artifacts_dir: Path, run_id: str, environment: str = "l
 
 if __name__ == "__main__":
     main()
-

--- a/app/core/bin/summary.py
+++ b/app/core/bin/summary.py
@@ -218,7 +218,7 @@ def generate_bin_summary(
                 "end_time": format_time_for_display(str(bin_row["t_end"])),
                 "density": round(float(bin_row["density"]), 3),  # Use density column (NOT density_peak)
                 "rate": round(float(bin_row["rate"]), 3),
-                "los": str(bin_row["los_class"]),  # Use los_class column
+                "los_class": str(bin_row["los_class"]),  # Use los_class column
                 "flag": bin_row["flag_reason"] if pd.notna(bin_row["flag_reason"]) else "flagged"
             }
             bins_list.append(bin_data)

--- a/app/new_flagging.py
+++ b/app/new_flagging.py
@@ -242,7 +242,7 @@ def _evaluate_row_with_rulebook(row: pd.Series) -> pd.Series:
         util_percentile=row.get('util_percentile')
     )
     return pd.Series({
-        'los': result.los_class,
+        'los_class': result.los_class,
         'rate_per_m_per_min': result.rate_per_m_per_min,
         'util_percent': result.util_percent,
         'util_percentile': result.util_percentile,
@@ -254,7 +254,7 @@ def _evaluate_row_with_rulebook(row: pd.Series) -> pd.Series:
 def _apply_rulebook_evaluation(result_df: pd.DataFrame) -> pd.DataFrame:
     """Apply rulebook evaluation to all rows and update DataFrame."""
     eval_results = result_df.apply(_evaluate_row_with_rulebook, axis=1)
-    result_df['los'] = eval_results['los']
+    result_df['los_class'] = eval_results['los_class']
     result_df['rate_per_m_per_min'] = eval_results['rate_per_m_per_min']
     result_df['util_percent'] = eval_results['util_percent']
     result_df['util_percentile'] = eval_results['util_percentile']
@@ -382,7 +382,7 @@ def summarize_segment_flags_new(df: pd.DataFrame) -> pd.DataFrame:
             worst_bin_t_start = worst_bin.get('t_start', None)
             worst_bin_rate = worst_bin.get('rate', 0)
             worst_bin_density = worst_bin['density']
-            worst_bin_los = worst_bin['los']
+            worst_bin_los = worst_bin['los_class']
         else:
             worst_severity = 'none'
             worst_reason = 'none'
@@ -412,7 +412,7 @@ def summarize_segment_flags_new(df: pd.DataFrame) -> pd.DataFrame:
             'worst_bin_los': worst_bin_los,
             'peak_density': group['density'].max(),
             'peak_rate_per_m_per_min': group['rate_per_m_per_min'].max(),
-            'peak_los': group['los'].max()  # Highest LOS letter
+            'peak_los': group['los_class'].max()  # Highest LOS letter
         })
     
     return pd.DataFrame(summaries).sort_values('worst_severity', key=lambda x: x.map(get_severity_rank_new), ascending=False)
@@ -430,7 +430,7 @@ def get_flagging_statistics_new(df: pd.DataFrame) -> Dict[str, any]:
     # Get worst severity and LOS
     if flagged_count > 0:
         worst_severity = flagged.sort_values('flag_severity', key=lambda x: x.map(get_severity_rank_new), ascending=False).iloc[0]['flag_severity']
-        worst_los = df['los'].max()
+        worst_los = df['los_class'].max()
     else:
         worst_severity = 'none'
         worst_los = 'A'

--- a/app/routes/api_bins.py
+++ b/app/routes/api_bins.py
@@ -80,7 +80,7 @@ def load_bins_data(run_id: Optional[str] = None, day: Optional[str] = None) -> L
                     "t_end": bin_data.get("end_time", ""),
                     "density": float(bin_data.get("density", 0.0)),
                     "rate": float(bin_data.get("rate", 0.0)),
-                    "los_class": str(bin_data.get("los", "Unknown")),
+                    "los_class": str(bin_data.get("los_class", "Unknown")),
                     "flag": bin_data.get("flag", "flagged")
                 }
                 bins_data.append(bin_record)

--- a/app/save_bins.py
+++ b/app/save_bins.py
@@ -311,7 +311,7 @@ def _update_features_with_severity(features: t.List[Feature], rows: t.List[JsonD
         severity_lookup = {row['bin_id']: {
             'flag_severity': row.get('flag_severity', 'none'),
             'flag_reason': row.get('flag_reason', 'none'),
-            'los': row.get('los', row.get('los_class', 'A')),
+            'los_class': row.get('los_class', 'A'),
             'rate_per_m_per_min': row.get('rate_per_m_per_min', 0.0)
         } for row in rows}
         

--- a/config/reporting.yml
+++ b/config/reporting.yml
@@ -202,7 +202,7 @@ schemas:
       - t_start
       - t_end
       - density
-      - los
+      - los_class
   
   flow_csv:
     type: csv
@@ -220,4 +220,3 @@ validation_options:
   strict_mode: false                 # If true, required = critical (no partial pass)
   validate_api_consistency: true     # Check APIs serve from correct run_id
   validate_latest_json: true         # Verify latest.json matches index.json
-


### PR DESCRIPTION
### Motivation

- Remove legacy `los` column usage and standardize on the canonical `los_class` field in bin outputs and downstream consumers. 
- Ensure the SSOT rulebook flagging outputs and all artifact producers/consumers read and emit a single LOS column name to avoid fallback chains. 
- Keep schema validation and UI artifact metadata aligned with the canonical column name. 

### Description

- Update flagging to emit `los_class` instead of `los` from `apply_new_flagging` / rulebook evaluation in `app/new_flagging.py` and propagate that column through evaluation and summaries. 
- Change bin artifact generation and feature updates to use `los_class` (map rows → features and severity lookup) in `app/save_bins.py` and `app/core/bin/summary.py`. 
- Align API and frontend consumers to expect `los_class` (updated `app/routes/api_bins.py`, `app/core/artifacts/frontend.py`) and remove legacy `los` fallbacks. 
- Update reporting schema validation to require `los_class` in `config/reporting.yml` and adjust UI schema metadata to expose `los_class` in `generate_density_schema_json`.

### Testing

- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960359925bc832291c9b48c2f38bc36)