### PR TITLE
Issue #640.7 — Final SSOT & E2E verification for LOS pipeline

### DIFF
--- a/app/core/artifacts/heatmaps.py
+++ b/app/core/artifacts/heatmaps.py
@@ -332,24 +332,12 @@ def _compute_caption_peak(segment_bins):
 def _get_los_grade(peak_density):
     """Determine LOS grade for a density value."""
     try:
-        from app.common.config import load_rulebook
-        los_thresholds = load_rulebook().get("globals", {}).get("los_thresholds", {})
+        from app import rulebook
     except Exception:
-        los_thresholds = {}
-    
-    los_grade = "F"
-    if isinstance(los_thresholds, dict) and los_thresholds:
-        for grade, rng in los_thresholds.items():
-            try:
-                min_v = float(rng.get("min", 0.0))
-                max_v = float(rng.get("max", float("inf")))
-                if min_v <= peak_density < max_v:
-                    los_grade = grade
-                    break
-            except Exception:
-                continue
-    
-    return los_grade
+        return "F"
+
+    bands = rulebook.get_thresholds("on_course_open").los
+    return rulebook.classify_los(peak_density, bands)
 
 
 

--- a/app/core/v2/ui_artifacts.py
+++ b/app/core/v2/ui_artifacts.py
@@ -405,11 +405,10 @@ def _export_ui_artifacts_v2(
             # Issue #528: Use bins with 'rate' column (not 'rate_p_s') for flagging
             if aggregated_bins_for_flags is not None and not aggregated_bins_for_flags.empty and temp_reports:
                 # Ensure bins have required columns for flagging
-                required_cols = {'segment_id', 't_start', 't_end', 'density', 'rate', 'los', 'flag_severity', 'flag_reason'}
+                required_cols = {'segment_id', 't_start', 't_end', 'density', 'rate', 'los_class', 'flag_severity', 'flag_reason'}
                 missing_cols = required_cols - set(aggregated_bins_for_flags.columns)
                 if missing_cols:
-                    logger.warning(f"   ⚠️  Bins DataFrame missing required columns for flagging: {missing_cols}")
-                    flags = []
+                    raise ValueError(f"Bins DataFrame missing required columns for flagging: {missing_cols}")
                 else:
                     # Save bins with 'rate' column to temp_reports for generate_flags_json
                     # This overwrites the bins.parquet saved earlier (which had 'rate_p_s')
@@ -426,10 +425,10 @@ def _export_ui_artifacts_v2(
             else:
                 flags = []
         except Exception as e:
-            logger.warning(f"   ⚠️  Could not generate flags: {e}")
+            logger.error(f"   ❌ Could not generate flags: {e}")
             import traceback
             logger.debug(f"   Traceback: {traceback.format_exc()}")
-            flags = []
+            raise
         
         segments_with_flags = len(flags)
         flagged_bins = sum(flag.get("flagged_bins", 0) for flag in flags)
@@ -1269,4 +1268,3 @@ def _build_zone_caption_summary(
         summary_parts.append("This zone shows limited interaction between events.")
     
     return " ".join(summary_parts)
-

--- a/app/flagging.py
+++ b/app/flagging.py
@@ -5,7 +5,7 @@ This module provides the canonical API for flag computation and summarization.
 Both the Density report and UI artifacts consume from this SSOT to ensure parity.
 
 Architecture:
-- Reads authoritative flags from bins.parquet (with flag_severity, flag_reason, los)
+- Reads authoritative flags from bins.parquet (with flag_severity, flag_reason, los_class)
 - Does NOT recompute flags (trusts the upstream binning/flagging pipeline)
 - Provides two public functions: compute_bin_flags() and summarize_flags()
 - Tied to rulebook version/hash for reproducibility
@@ -43,7 +43,7 @@ class BinFlag:
     t_end: str    # ISO 8601 with timezone
     density: float  # persons per m² (p/m²)
     rate: float  # persons per second (p/s) - CANONICAL
-    los: str  # Level of Service (A-F)
+    los_class: str  # Level of Service (A-F)
     severity: str  # WATCH, ALERT, CRITICAL, or none
     reason: str  # Short code: utilization, density, rate, etc.
     
@@ -68,7 +68,7 @@ class BinFlag:
             "t_end": self.t_end,
             "density": float(self.density),
             "rate": float(self.rate),  # p/s - canonical
-            "los": self.los,
+            "los_class": self.los_class,
             "severity": self.severity,
             "reason": self.reason,
         }
@@ -97,7 +97,7 @@ def compute_bin_flags(bins: pd.DataFrame, rulebook: Optional[Dict[str, Any]] = N
     
     Args:
         bins: DataFrame with columns: segment_id, t_start, t_end, density, rate,
-              los, flag_severity, flag_reason (+ optional: bin_id, start_km, end_km)
+              los_class, flag_severity, flag_reason (+ optional: bin_id, start_km, end_km)
         rulebook: Optional rulebook config (for validation/metadata only)
     
     Returns:
@@ -107,7 +107,7 @@ def compute_bin_flags(bins: pd.DataFrame, rulebook: Optional[Dict[str, Any]] = N
         ValueError: If required columns are missing
     """
     # Validate required columns
-    required_cols = {'segment_id', 't_start', 't_end', 'density', 'rate', 'los', 'flag_severity', 'flag_reason'}
+    required_cols = {'segment_id', 't_start', 't_end', 'density', 'rate', 'los_class', 'flag_severity', 'flag_reason'}
     missing = required_cols - set(bins.columns)
     if missing:
         raise ValueError(f"Missing required columns in bins DataFrame: {missing}")
@@ -123,7 +123,7 @@ def compute_bin_flags(bins: pd.DataFrame, rulebook: Optional[Dict[str, Any]] = N
             t_end=str(row['t_end']),
             density=float(row['density']),
             rate=float(row['rate']),  # Already in p/s (canonical)
-            los=str(row['los']),
+            los_class=str(row['los_class']),
             severity=str(row['flag_severity']),
             reason=str(row['flag_reason']),
             bin_id=str(row.get('bin_id', '')),
@@ -187,8 +187,8 @@ def summarize_flags(bin_flags: List[BinFlag]) -> Dict[str, Any]:
             d["worst_severity"] = flag.severity
         
         # Update worst LOS (F > E > D > C > B > A)
-        if flag.los > d["worst_los"]:
-            d["worst_los"] = flag.los
+        if flag.los_class > d["worst_los"]:
+            d["worst_los"] = flag.los_class
         
         # Update peak values
         if flag.density > d["peak_density"]:
@@ -244,7 +244,9 @@ def get_flagging_summary_for_report(bins: pd.DataFrame, rulebook: Optional[Dict[
     }
     if len(bin_flags) > 0:
         worst_severity = max(bin_flags, key=lambda f: severity_order.get(f.severity, 0)).severity
-        worst_los = bins['los'].max() if 'los' in bins.columns else 'A'
+        if 'los_class' not in bins.columns:
+            raise ValueError("los_class column missing from bins DataFrame")
+        worst_los = bins['los_class'].max()
     else:
         worst_severity = 'none'
         worst_los = 'A'
@@ -305,4 +307,3 @@ def rate_per_m_per_min_to_rate(rate_per_m_per_min: float, width_m: float) -> flo
     if width_m <= 0:
         raise ValueError(f"width_m must be > 0, got {width_m}")
     return (rate_per_m_per_min / 60.0) * width_m
-

--- a/app/main.py
+++ b/app/main.py
@@ -1196,18 +1196,9 @@ def parse_latest_density_report_segments():
 
 def _determine_los_from_density(peak_areal_density: float) -> str:
     """Determine LOS from peak areal density value."""
-    if peak_areal_density < 0.5:
-        return "A"
-    elif peak_areal_density < 1.0:
-        return "B"
-    elif peak_areal_density < 1.5:
-        return "C"
-    elif peak_areal_density < 2.0:
-        return "D"
-    elif peak_areal_density < 3.0:
-        return "E"
-    else:
-        return "F"
+    from app import rulebook
+    bands = rulebook.get_thresholds("on_course_open").los
+    return rulebook.classify_los(peak_areal_density, bands)
 
 
 def _determine_status_from_los_and_severity(los: str, severity: str) -> str:

--- a/app/new_density_report.py
+++ b/app/new_density_report.py
@@ -342,7 +342,7 @@ def convert_json_to_segment_summary(
                 'worst_bin_t_start': worst_bin.get('t_start'),
                 'worst_bin_rate': worst_bin.get('rate', 0.0),
                 'worst_bin_density': worst_bin.get('density', 0.0),
-                'worst_bin_los': worst_bin.get('los', 'A')
+                'worst_bin_los': worst_bin['los_class']
             }
     
     # Build segment_summary DataFrame

--- a/app/new_density_template_engine.py
+++ b/app/new_density_template_engine.py
@@ -381,7 +381,7 @@ class NewDensityTemplateEngine:
                 
                 # Calculate Util% based on segment schema
                 # Issue #548 Bug 4: Load flow_ref.critical from rulebook dynamically
-                from app.rulebook import get_thresholds, classify_los
+                from app.rulebook import get_thresholds
                 segment_type = row.get('segment_type', 'on_course_open')
                 thresholds = get_thresholds(segment_type)
                 flow_ref_critical = thresholds.flow_ref.critical if thresholds.flow_ref else None
@@ -400,11 +400,8 @@ class NewDensityTemplateEngine:
                 else:
                     peak_rate_display = "N/A"
                 
-                # Bug fix: Recalculate LOS from worst_bin_density to ensure it matches the density shown
-                # The worst_bin_los field is the LOS of the worst bin (by severity), which may not match
-                # the density value shown. Recalculate LOS from the density to ensure consistency.
                 worst_bin_density = row['worst_bin_density']
-                los_from_density = classify_los(worst_bin_density, thresholds.los)
+                worst_bin_los = row['worst_bin_los']
                 
                 # Bug fix: Use consistent round-half-up for percentage formatting
                 flagged_pct = self._round_half_up(row['flagged_percentage'], 1)
@@ -412,7 +409,7 @@ class NewDensityTemplateEngine:
                 lines.append(
                     f"| {row['segment_id']} | {row['seg_label']} | {row['flagged_bins']} | {row['total_bins']} | "
                     f"{flagged_pct:.1f}% | {worst_km} | {worst_time} | {worst_bin_density:.4f} | {peak_rate_display} | {util_display} | "
-                    f"{los_from_density} | {row['worst_severity']} | {row['worst_reason']} |"
+                    f"{worst_bin_los} | {row['worst_severity']} | {row['worst_reason']} |"
                 )
         
         return "\n".join(lines)
@@ -506,7 +503,7 @@ class NewDensityTemplateEngine:
             
             lines.append(
                 f"| {row.get('start_km', 0):.1f} | {row.get('end_km', 0):.1f} | {start_time} | {end_time} | "
-                f"{row['density']:.3f} | {row['rate']:.3f} | {row['los']} |"
+                f"{row['density']:.3f} | {row['rate']:.3f} | {row['los_class']} |"
             )
         
         return "\n".join(lines)

--- a/app/new_flagging.py
+++ b/app/new_flagging.py
@@ -44,90 +44,11 @@ class NewFlaggingConfig:
     require_min_bin_len_m: float = 10.0
 
 
-def get_los_thresholds() -> Dict[str, float]:
-    """Get LOS density thresholds from rulebook."""
-    # These match the current LOS_AREAL_THRESHOLDS
-    return {
-        'A': 0.0,
-        'B': 0.36,
-        'C': 0.54,
-        'D': 0.72,
-        'E': 1.08,
-        'F': 1.63
-    }
-
-
-def classify_density_los(density: float) -> str:
-    """Classify density into LOS level (A-F)."""
-    thresholds = get_los_thresholds()
-    
-    if density < thresholds['B']:
-        return 'A'
-    elif density < thresholds['C']:
-        return 'B'
-    elif density < thresholds['D']:
-        return 'C'
-    elif density < thresholds['E']:
-        return 'D'
-    elif density < thresholds['F']:
-        return 'E'
-    else:
-        return 'F'
-
-
-def meets_density_threshold(density: float, los_threshold: str) -> bool:
-    """Check if density meets or exceeds LOS threshold."""
-    thresholds = get_los_thresholds()
-    threshold_value = thresholds.get(los_threshold, float('inf'))
-    return density >= threshold_value
-
-
 def calculate_rate_per_m_per_min(rate: float, width_m: float) -> float:
     """Calculate rate per meter per minute: (rate / width_m) × 60"""
     if width_m <= 0:
         return 0.0
     return (rate / width_m) * 60.0
-
-
-def classify_flag_reason_new(
-    density: float,
-    rate_per_m_per_min: float,
-    config: NewFlaggingConfig
-) -> Tuple[str, str]:
-    """
-    Classify flag reason and severity based on new Issue #246 logic.
-    
-    Args:
-        density: Areal density (p/m²)
-        rate_per_m_per_min: Rate per meter per minute (p/m/min)
-        config: Flagging configuration
-        
-    Returns:
-        Tuple of (reason, severity)
-        - reason: 'los_high', 'rate_high', 'both', or 'none'
-        - severity: 'critical', 'watch', or 'none'
-    """
-    # Check density conditions
-    density_watch = meets_density_threshold(density, config.density_watch_los)
-    density_critical = meets_density_threshold(density, config.density_critical_los)
-    
-    # Check rate conditions
-    rate_watch = rate_per_m_per_min >= config.rate_warn_threshold
-    rate_critical = rate_per_m_per_min >= config.rate_critical_threshold
-    
-    # Determine reason and severity
-    if density_critical and rate_critical:
-        return 'both', 'critical'
-    elif density_critical or rate_critical:
-        return 'both', 'critical'  # Either condition critical = critical
-    elif density_watch and rate_watch:
-        return 'both', 'watch'
-    elif density_watch:
-        return 'los_high', 'watch'
-    elif rate_watch:
-        return 'rate_high', 'watch'
-    else:
-        return 'none', 'none'
 
 
 def _load_and_apply_segment_metadata(

--- a/app/save_bins.py
+++ b/app/save_bins.py
@@ -307,11 +307,14 @@ def _update_features_with_severity(features: t.List[Feature], rows: t.List[JsonD
     """Update features with severity information if flagging was applied."""
     updated_features = features.copy()
     if len(rows) > 0 and 'flag_severity' in rows[0]:
+        missing_los = [row.get('bin_id') for row in rows if not row.get('los_class')]
+        if missing_los:
+            raise ValueError(f"los_class missing for {len(missing_los)} bins during severity update")
         # Create a lookup for severity data
         severity_lookup = {row['bin_id']: {
             'flag_severity': row.get('flag_severity', 'none'),
             'flag_reason': row.get('flag_reason', 'none'),
-            'los_class': row.get('los_class', 'A'),
+            'los_class': row.get('los_class'),
             'rate_per_m_per_min': row.get('rate_per_m_per_min', 0.0)
         } for row in rows}
         

--- a/config/reporting.yml
+++ b/config/reporting.yml
@@ -8,17 +8,6 @@
 schema_version: "1.1.0"
 density_method: "segments_from_bins"
 
-# LOS (Level of Service) threshold definitions
-# Based on Fruin's pedestrian level of service standards
-# Values represent areal density (people per square meter)
-los:
-  A: 0.0   # Free flow, no restrictions
-  B: 0.5   # Stable flow, minor speed restrictions
-  C: 1.0   # Stable flow, significant speed restrictions
-  D: 1.5   # Unstable flow, severe restrictions
-  E: 2.0   # Very unstable flow, stop-and-go
-  F: 3.0   # Breakdown flow, gridlock
-
 # Flagging rules for operational intelligence
 flagging:
   min_los_flag: "C"              # Flag bins with LOS >= C (1.0 people/m²)


### PR DESCRIPTION
### Motivation

- Enforce the rulebook as the single source of truth for LOS classification so downstream artifacts and reports use a single canonical `los_class` value.
- Remove legacy/inline LOS threshold fallbacks and prevent ad-hoc classification in bin generation to avoid parity drift.
- Make downstream consumers (reports, UI, heatmaps, flagging summaries) rely only on the authoritative `los_class` column.
- Add regression guards to fail fast when `los_class` is missing or legacy LOS logic would be invoked.

### Description

- Prevented `bins_accumulator` from computing LOS and require `los_class` to be set by rulebook flagging by raising on passed thresholds and emitting `los_class=None` from bin generation.
- Updated flagging and intelligence to compute/use `los_class` from the rulebook SSOT via `rulebook.get_thresholds(...).los` and `rulebook.classify_los()`, and replaced legacy `los` usages with `los_class` throughout (`app/bin_intelligence.py`, `app/new_flagging.py`, `app/flagging.py`).
- Tightened artifact and report code to require `los_class` and fail when missing, and switched UI/report templates to consume `los_class` only (changes in `app/core/artifacts/frontend.py`, `app/core/v2/ui_artifacts.py`, `app/density_report.py`, `app/new_density_report.py`, `app/new_density_template_engine.py`, `app/save_bins.py`).
- Reworked `app/los.py` and heatmap helpers to forbid custom thresholds and to call the rulebook SSOT, and removed embedded LOS thresholds from `config/reporting.yml` to centralize thresholds in the rulebook.

### Testing

- Ran `make e2e enable_audit=n` (end-to-end test) but it failed to run in this environment because `docker`/`docker-compose` are not available, so the E2E run did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69601a34445c83229a3bc852d1d80dad)