### PR TITLE
Centralize analysis.json loading with an AnalysisContext loader

### DIFF
--- a/app/api/map.py
+++ b/app/api/map.py
@@ -93,13 +93,13 @@ async def get_map_manifest():
         
         from app.utils.run_id import get_latest_run_id
         from app.utils.run_id import get_runflow_root
-        from app.core.v2.analysis_config import load_analysis_json, get_segments_file
+        from app.config.loader import load_analysis_context
 
         run_id = get_latest_run_id()
         runflow_root = get_runflow_root()
         run_path = runflow_root / run_id
-        analysis_config = load_analysis_json(run_path)
-        segments_path = Path(get_segments_file(analysis_config=analysis_config))
+        analysis_context = load_analysis_context(run_path)
+        segments_path = Path(analysis_context.segments_csv_path)
 
         if not segments_path.exists():
             raise HTTPException(status_code=404, detail=f"Segments metadata not found at {segments_path}")
@@ -199,13 +199,13 @@ async def get_map_segments():
         
         from app.utils.run_id import get_latest_run_id
         from app.utils.run_id import get_runflow_root
-        from app.core.v2.analysis_config import load_analysis_json, get_segments_file
+        from app.config.loader import load_analysis_context
 
         run_id = get_latest_run_id()
         runflow_root = get_runflow_root()
         run_path = runflow_root / run_id
-        analysis_config = load_analysis_json(run_path)
-        segments_path = Path(get_segments_file(analysis_config=analysis_config))
+        analysis_context = load_analysis_context(run_path)
+        segments_path = Path(analysis_context.segments_csv_path)
 
         if not segments_path.exists():
             raise HTTPException(status_code=404, detail=f"Segments metadata not found at {segments_path}")

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -1,0 +1,1 @@
+"""Configuration helpers for analysis runtime."""

--- a/app/config/loader.py
+++ b/app/config/loader.py
@@ -1,0 +1,173 @@
+"""
+Analysis configuration loader.
+
+Loads analysis.json once, validates required fields, and resolves runtime paths.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pandas as pd
+
+
+class AnalysisConfigError(ValueError):
+    """Raised when analysis.json is missing required fields or invalid."""
+
+
+@dataclass(frozen=True)
+class AnalysisContext:
+    analysis_config: Dict[str, Any]
+    run_path: Path
+    analysis_json_path: Path
+    data_files: Dict[str, Any]
+    data_dir: Path
+    segments_csv_path: Path
+    flow_csv_path: Path
+    locations_csv_path: Optional[Path]
+
+    def runners_csv_path(self, event_name: str) -> Path:
+        runners = self.data_files.get("runners", {})
+        event_key = event_name.lower()
+        runners_path = runners.get(event_key) or runners.get(event_name)
+        if not runners_path:
+            raise AnalysisConfigError(
+                f"analysis.json missing data_files.runners entry for event '{event_name}'."
+            )
+        return _resolve_path(str(runners_path), self.data_dir)
+
+    def gpx_path(self, event_name: str) -> Path:
+        gpx_files = self.data_files.get("gpx", {})
+        event_key = event_name.lower()
+        gpx_path = gpx_files.get(event_key) or gpx_files.get(event_name)
+        if not gpx_path:
+            raise AnalysisConfigError(
+                f"analysis.json missing data_files.gpx entry for event '{event_name}'."
+            )
+        return _resolve_path(str(gpx_path), self.data_dir)
+
+
+def load_analysis_context(run_path: Path) -> AnalysisContext:
+    """Load analysis.json, validate required fields, and resolve absolute paths."""
+    analysis_json_path = run_path / "analysis.json"
+    if not analysis_json_path.exists():
+        raise FileNotFoundError(f"analysis.json not found at {analysis_json_path}")
+
+    with analysis_json_path.open("r", encoding="utf-8") as handle:
+        analysis_config = json.load(handle)
+
+    return build_analysis_context(analysis_config, run_path, analysis_json_path)
+
+
+def build_analysis_context(
+    analysis_config: Dict[str, Any],
+    run_path: Path,
+    analysis_json_path: Optional[Path] = None,
+) -> AnalysisContext:
+    """Validate analysis_config and return a resolved AnalysisContext."""
+    if analysis_json_path is None:
+        analysis_json_path = run_path / "analysis.json"
+
+    data_dir_value = analysis_config.get("data_dir")
+    if not data_dir_value:
+        raise AnalysisConfigError("analysis.json missing required field: data_dir")
+    data_dir = Path(data_dir_value).resolve()
+
+    data_files = analysis_config.get("data_files")
+    if not isinstance(data_files, dict):
+        raise AnalysisConfigError("analysis.json missing required field: data_files")
+
+    segments_path = _resolve_required_path(data_files, "segments", data_dir)
+    flow_path = _resolve_required_path(data_files, "flow", data_dir)
+    locations_path = _resolve_optional_path(data_files, "locations", data_dir)
+
+    events = analysis_config.get("events", [])
+    if not events:
+        raise AnalysisConfigError("analysis.json missing required field: events")
+
+    for event in events:
+        _require_field(event, "name", "events[*]")
+        _require_field(event, "day", "events[*]")
+        _require_field(event, "start_time", "events[*]")
+        _require_field(event, "event_duration_minutes", "events[*]")
+        _require_field(event, "runners_file", "events[*]")
+        _require_field(event, "gpx_file", "events[*]")
+
+    runners = data_files.get("runners")
+    if not isinstance(runners, dict) or not runners:
+        raise AnalysisConfigError("analysis.json missing required field: data_files.runners")
+
+    gpx = data_files.get("gpx")
+    if not isinstance(gpx, dict) or not gpx:
+        raise AnalysisConfigError("analysis.json missing required field: data_files.gpx")
+
+    _validate_segments_csv_fields(segments_path)
+
+    for event in events:
+        event_name = event.get("name")
+        if event_name:
+            _validate_event_file_mapping(runners, "runners", event_name)
+            _validate_event_file_mapping(gpx, "gpx", event_name)
+
+    return AnalysisContext(
+        analysis_config=analysis_config,
+        run_path=run_path,
+        analysis_json_path=analysis_json_path,
+        data_files=data_files,
+        data_dir=data_dir,
+        segments_csv_path=segments_path,
+        flow_csv_path=flow_path,
+        locations_csv_path=locations_path,
+    )
+
+
+def _resolve_required_path(data_files: Dict[str, Any], key: str, data_dir: Path) -> Path:
+    value = data_files.get(key)
+    if not value:
+        raise AnalysisConfigError(f"analysis.json missing required field: data_files.{key}")
+    return _resolve_path(value, data_dir)
+
+
+def _resolve_optional_path(data_files: Dict[str, Any], key: str, data_dir: Path) -> Optional[Path]:
+    value = data_files.get(key)
+    if not value:
+        return None
+    return _resolve_path(value, data_dir)
+
+
+def _resolve_path(path_value: str, data_dir: Path) -> Path:
+    candidate = Path(path_value)
+    if candidate.is_absolute():
+        return candidate
+    if candidate.parts and candidate.parts[0] == data_dir.name:
+        return candidate.resolve()
+    return (data_dir / candidate).resolve()
+
+
+def _require_field(container: Dict[str, Any], field: str, scope: str) -> None:
+    if container.get(field) in (None, ""):
+        raise AnalysisConfigError(f"analysis.json missing required field: {scope}.{field}")
+
+
+def _validate_segments_csv_fields(segments_path: Path) -> None:
+    if not segments_path.exists():
+        raise FileNotFoundError(f"segments.csv not found at {segments_path}")
+    df = pd.read_csv(segments_path, nrows=0)
+    required_columns = {"seg_id", "seg_label", "schema", "width_m", "direction"}
+    missing = required_columns - set(df.columns)
+    if missing:
+        missing_list = ", ".join(sorted(missing))
+        raise AnalysisConfigError(
+            f"segments.csv missing required columns: {missing_list}"
+        )
+
+
+def _validate_event_file_mapping(mapping: Dict[str, Any], mapping_name: str, event_name: str) -> None:
+    normalized_event = event_name.lower()
+    if normalized_event not in mapping and event_name not in mapping:
+        raise AnalysisConfigError(
+            f"analysis.json missing data_files.{mapping_name} entry for event '{event_name}'"
+        )

--- a/app/core/artifacts/heatmaps.py
+++ b/app/core/artifacts/heatmaps.py
@@ -612,7 +612,7 @@ def load_segments_metadata(reports_dir: Optional[Path] = None, run_id: Optional[
     # Issue #616: Get segments_csv_path from analysis.json
     if reports_dir is not None:
         try:
-            import json
+            from app.config.loader import load_analysis_context
             from app.utils.run_id import get_runflow_root
             runflow_root = get_runflow_root()
             # Navigate from reports_dir back to run_id directory
@@ -621,42 +621,19 @@ def load_segments_metadata(reports_dir: Optional[Path] = None, run_id: Optional[
             run_id_dir = reports_dir.parent.parent  # Go from reports_* -> {day} -> {run_id}
             if run_id_dir.name in ["reports_temp", "reports_heatmaps"]:
                 run_id_dir = reports_dir.parent
-            analysis_json_path = run_id_dir / "analysis.json"
-            if not analysis_json_path.exists() and run_id:
-                # Try alternative: use run_id directly
-                analysis_json_path = runflow_root / run_id / "analysis.json"
-            if analysis_json_path.exists():
-                with open(analysis_json_path, 'r') as af:
-                    analysis_config = json.load(af)
-                    data_files = analysis_config.get("data_files", {})
-                    segments_csv_path = data_files.get("segments")
-                    if not segments_csv_path:
-                        segments_file = analysis_config.get("segments_file")
-                        data_dir = analysis_config.get("data_dir", "data")
-                        if segments_file:
-                            segments_csv_path = f"{data_dir}/{segments_file}"
-                    if segments_csv_path:
-                        segments_path = Path(segments_csv_path)
+            if not (run_id_dir / "analysis.json").exists() and run_id:
+                run_id_dir = runflow_root / run_id
+            analysis_context = load_analysis_context(run_id_dir)
+            segments_path = Path(analysis_context.segments_csv_path)
         except Exception as e:
             print(f"   ⚠️  Could not load segments_csv_path from analysis.json: {e}")
     elif run_id:
         try:
-            import json
+            from app.config.loader import load_analysis_context
             from app.utils.run_id import get_runflow_root
             runflow_root = get_runflow_root()
-            analysis_json_path = runflow_root / run_id / "analysis.json"
-            if analysis_json_path.exists():
-                with open(analysis_json_path, 'r') as af:
-                    analysis_config = json.load(af)
-                    data_files = analysis_config.get("data_files", {})
-                    segments_csv_path = data_files.get("segments")
-                    if not segments_csv_path:
-                        segments_file = analysis_config.get("segments_file")
-                        data_dir = analysis_config.get("data_dir", "data")
-                        if segments_file:
-                            segments_csv_path = f"{data_dir}/{segments_file}"
-                    if segments_csv_path:
-                        segments_path = Path(segments_csv_path)
+            analysis_context = load_analysis_context(runflow_root / run_id)
+            segments_path = Path(analysis_context.segments_csv_path)
         except Exception as e:
             print(f"   ⚠️  Could not load segments_csv_path from analysis.json: {e}")
     

--- a/app/main.py
+++ b/app/main.py
@@ -1340,13 +1340,13 @@ async def get_segments():
     try:
         from app.utils.run_id import get_latest_run_id
         from app.utils.run_id import get_runflow_root
-        from app.core.v2.analysis_config import load_analysis_json, get_segments_file
+        from app.config.loader import load_analysis_context
 
         run_id = get_latest_run_id()
         runflow_root = get_runflow_root()
         run_path = runflow_root / run_id
-        analysis_config = load_analysis_json(run_path)
-        segments_csv_path = get_segments_file(analysis_config=analysis_config)
+        analysis_context = load_analysis_context(run_path)
+        segments_csv_path = str(analysis_context.segments_csv_path)
 
         # Issue #237: Load operational intelligence from tooltips.json
         tooltips_data = _load_tooltips_json()

--- a/app/routes/api_density.py
+++ b/app/routes/api_density.py
@@ -306,11 +306,11 @@ def _build_segment_record(
 
 def _get_segments_csv_path_for_run(run_id: str) -> str:
     from app.utils.run_id import get_runflow_root
-    from app.core.v2.analysis_config import get_segments_file
+    from app.config.loader import load_analysis_context
 
     runflow_root = get_runflow_root()
     run_path = runflow_root / run_id
-    return get_segments_file(run_path=run_path)
+    return str(load_analysis_context(run_path).segments_csv_path)
 
 
 @router.get("/api/density/segments")

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -475,7 +475,7 @@ async def get_analysis_config(request: Request, run_id: str):
     
     try:
         from app.utils.run_id import get_runflow_root
-        from app.core.v2.analysis_config import load_analysis_json
+        from app.config.loader import load_analysis_context
         
         runflow_root = get_runflow_root()
         run_path = runflow_root / run_id
@@ -486,8 +486,8 @@ async def get_analysis_config(request: Request, run_id: str):
                 detail=f"Run ID {run_id} not found"
             )
         
-        analysis_config = load_analysis_json(run_path)
-        return JSONResponse(content=analysis_config)
+        analysis_context = load_analysis_context(run_path)
+        return JSONResponse(content=analysis_context.analysis_config)
         
     except FileNotFoundError:
         raise HTTPException(
@@ -500,4 +500,3 @@ async def get_analysis_config(request: Request, run_id: str):
             status_code=500,
             detail=f"Failed to load analysis configuration: {str(e)}"
         )
-

--- a/app/routes/v2/analyze.py
+++ b/app/routes/v2/analyze.py
@@ -68,7 +68,6 @@ def run_analysis_background(
         )
         
         # Update metadata.json files with response payload
-        from app.core.v2.analysis_config import load_analysis_json
         from pathlib import Path
         import json
         
@@ -254,4 +253,3 @@ async def analyze_v2(request: V2AnalyzeRequest, background_tasks: BackgroundTask
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             content=error_response.model_dump()
         )
-

--- a/tests/v2/test_analysis_context_loader.py
+++ b/tests/v2/test_analysis_context_loader.py
@@ -1,0 +1,82 @@
+import json
+from pathlib import Path
+
+import pytest
+
+from app.config.loader import AnalysisConfigError, load_analysis_context
+
+
+def _write_analysis_json(run_path: Path, payload: dict) -> None:
+    analysis_path = run_path / "analysis.json"
+    analysis_path.write_text(json.dumps(payload), encoding="utf-8")
+
+
+def test_missing_segments_columns_raises(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    segments_csv = data_dir / "segments.csv"
+    segments_csv.write_text(
+        "seg_id,seg_label,width_m,direction\nA1,Start,4,uni\n",
+        encoding="utf-8",
+    )
+
+    analysis_payload = {
+        "data_dir": str(data_dir),
+        "data_files": {
+            "segments": "segments.csv",
+            "flow": "flow.csv",
+            "locations": "locations.csv",
+            "runners": {"full": "full_runners.csv"},
+            "gpx": {"full": "full.gpx"},
+        },
+        "events": [
+            {
+                "name": "full",
+                "day": "sun",
+                "start_time": 420,
+                "event_duration_minutes": 180,
+                "runners_file": "full_runners.csv",
+                "gpx_file": "full.gpx",
+            }
+        ],
+    }
+
+    _write_analysis_json(tmp_path, analysis_payload)
+
+    with pytest.raises(AnalysisConfigError, match="segments.csv missing required columns"):
+        load_analysis_context(tmp_path)
+
+
+def test_missing_event_fields_fail_fast(tmp_path: Path) -> None:
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    segments_csv = data_dir / "segments.csv"
+    segments_csv.write_text(
+        "seg_id,seg_label,schema,width_m,direction\nA1,Start,on_course_open,4,uni\n",
+        encoding="utf-8",
+    )
+
+    analysis_payload = {
+        "data_dir": str(data_dir),
+        "data_files": {
+            "segments": "segments.csv",
+            "flow": "flow.csv",
+            "locations": "locations.csv",
+            "runners": {"full": "full_runners.csv"},
+            "gpx": {"full": "full.gpx"},
+        },
+        "events": [
+            {
+                "name": "full",
+                "day": "sun",
+                "start_time": 420,
+                "runners_file": "full_runners.csv",
+                "gpx_file": "full.gpx",
+            }
+        ],
+    }
+
+    _write_analysis_json(tmp_path, analysis_payload)
+
+    with pytest.raises(AnalysisConfigError, match="events\\[\\*\\]\\.event_duration_minutes"):
+        load_analysis_context(tmp_path)


### PR DESCRIPTION
### Motivation

- Centralize parsing and validation of `analysis.json` to provide a single source of truth and avoid duplicated file reads across pipeline, API, and artifact code paths.
- Resolve `data_files` entries to absolute runtime paths and enforce presence/shape of required fields so runs fail fast on misconfiguration.
- Replace ad-hoc `json.load`/`Path` logic with a composable `analysis_context` object that callers can accept or be passed explicit file paths.
- Add a lightweight unit test to lock down loader validation behavior (missing columns/fields fail-fast).

### Description

- Add `app/config/loader.py` which implements `load_analysis_context`, `build_analysis_context`, `AnalysisContext`, and explicit `AnalysisConfigError` validation and path resolution utilities.
- Wire the new loader into the v2 pipeline and bin generation so `create_full_analysis_pipeline` and `generate_bins_v2` use a single `analysis_context` (and accept it as an optional param) instead of reloading config repeatedly.
- Replace scattered `analysis.json` reads in API and artifact entrypoints with `load_analysis_context` usages (notable files updated: `app/core/v2/pipeline.py`, `app/core/v2/bins.py`, `app/api/map.py`, `app/main.py`, `app/routes/ui.py`, `app/routes/api_dashboard.py`, `app/routes/api_density.py`, `app/core/artifacts/frontend.py`, `app/core/artifacts/heatmaps.py`).
- Add unit tests `tests/v2/test_analysis_context_loader.py` that validate missing `segments.csv` columns and missing event fields raise `AnalysisConfigError`.

### Testing

- Ran `pytest tests/v2/test_analysis_context_loader.py` (initial run failed with `ModuleNotFoundError` due to `PYTHONPATH` not being set in that invocation). 
- Re-ran with `PYTHONPATH=/workspace/run-density pytest tests/v2/test_analysis_context_loader.py` and the new loader tests passed (`2 passed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c54295a483229ef9d0fc6a50c15e)