### PR TITLE
Enforce analysis.json-driven file paths and strict segment validation

### DIFF
--- a/app/core/density/compute.py
+++ b/app/core/density/compute.py
@@ -279,24 +279,23 @@ def load_density_cfg(path: str) -> Dict[str, dict]:
         schema_raw = r.get("schema")
         if schema_raw is not None and pd.notna(schema_raw):
             schema = str(schema_raw).strip()
-            if schema:
-                # Validate schema value (must be valid rulebook schema)
-                valid_schemas = {'start_corral', 'on_course_narrow', 'on_course_open'}
-                if schema not in valid_schemas:
-                    logger.warning(
-                        f"Invalid schema value '{schema}' for segment {r['seg_id']} in segments CSV. "
-                        f"Must be one of: {valid_schemas}. Defaulting to 'on_course_open'."
-                    )
-                    schema = 'on_course_open'
-            else:
-                # Empty string after stripping
-                schema = None
+            if not schema:
+                raise ValueError(f"Segment {r['seg_id']} missing schema in segments CSV.")
+            # Validate schema value (must be valid rulebook schema)
+            valid_schemas = {'start_corral', 'on_course_narrow', 'on_course_open'}
+            if schema not in valid_schemas:
+                raise ValueError(
+                    f"Invalid schema value '{schema}' for segment {r['seg_id']} in segments CSV. "
+                    f"Must be one of: {valid_schemas}."
+                )
         else:
-            # No schema provided (None or NaN) - will fallback to schema_resolver if needed
-            schema = None
+            raise ValueError(f"Segment {r['seg_id']} missing schema in segments CSV.")
+        seg_label = r.get("seg_label")
+        if not seg_label:
+            raise ValueError(f"Segment {r['seg_id']} missing seg_label in segments CSV.")
         
         cfg[r["seg_id"]] = dict(
-            seg_label=str(r.get("seg_label", "")),
+            seg_label=str(seg_label),
             width_m=float(r["width_m"]),
             direction=str(r.get("direction", "uni")),
             schema=schema,  # Issue #616: Include schema from CSV (SSOT for this analysis run)

--- a/app/core/v2/bins.py
+++ b/app/core/v2/bins.py
@@ -110,8 +110,7 @@ def generate_bins_v2(
         day: Day enum
         events: List of events for this day
         data_dir: Base directory for data files (used as fallback)
-        segments_csv_path: Optional path to segments CSV file. If None, defaults to data_dir/segments.csv.
-                          Issue #616: Should be provided from analysis.json segments_file.
+        segments_csv_path: Path to segments CSV file (from analysis.json).
         analysis_context: Optional analysis context loaded from analysis.json to avoid reloading config.
         
     Returns:

--- a/app/core/v2/flow.py
+++ b/app/core/v2/flow.py
@@ -107,23 +107,21 @@ def get_shared_segments(
 
 
 def load_flow_csv(
-    flow_file: str,
-    data_dir: str
+    flow_path: str
 ) -> pd.DataFrame:
     """
     Load flow.csv as the authoritative source for event pairs, ordering, and distance ranges.
     
     Args:
-        flow_file: Name of flow CSV file (default: "flow.csv")
-        data_dir: Base directory for data files (default: "data")
+        flow_path: Full path to flow CSV file
         
     Returns:
         DataFrame with flow.csv data
     """
-    flow_path = Path(data_dir) / flow_file
-    
+    flow_path = Path(flow_path)
+
     if not flow_path.exists():
-        raise FileNotFoundError(f"Flow file '{flow_file}' not found in {data_dir}/")
+        raise FileNotFoundError(f"Flow file not found at {flow_path}")
     
     try:
         flow_df = pd.read_csv(flow_path)

--- a/app/core/v2/reports.py
+++ b/app/core/v2/reports.py
@@ -56,7 +56,8 @@ def generate_reports_per_day(
     data_dir: str,  # Data directory for loading runner files
     segments_file_path: Optional[str] = None,  # Issue #553 Phase 6.2: Path to segments file
     flow_file_path: Optional[str] = None,  # Issue #553 Phase 6.2: Path to flow file
-    locations_file_path: Optional[str] = None  # Issue #553 Phase 6.2: Path to locations file
+    locations_file_path: Optional[str] = None,  # Issue #553 Phase 6.2: Path to locations file
+    gpx_paths: Optional[Dict[str, str]] = None
 ) -> Dict[Day, Dict[str, str]]:
     """
     Generate all reports per day in day-partitioned structure.
@@ -110,6 +111,11 @@ def generate_reports_per_day(
         raise ValueError(
             "flow_file_path is required in v2 pipeline. "
             "It should be provided from analysis.json flow_file."
+        )
+    if not gpx_paths:
+        raise ValueError(
+            "gpx_paths are required in v2 pipeline. "
+            "They should be provided from analysis.json data_files.gpx."
         )
     # locations_file_path can be None if locations_file is not provided (optional)
     # But if it's provided, it should come from analysis.json
@@ -780,7 +786,8 @@ def generate_locations_report_v2(
                     start_times=start_times,
                     output_dir=str(reports_path),
                     run_id=run_id,  # Issue #598: Pass run_id for flag propagation (loads flags.json)
-                    day=day.value  # Issue #598: Pass day for day-scoped flags.json path
+                    day=day.value,  # Issue #598: Pass day for day-scoped flags.json path
+                    gpx_paths=gpx_paths
                 )
                 logger.info(f"generate_location_report returned for day {day.value}: ok={result.get('ok', False)}")
             except Exception as e:

--- a/app/flow_report.py
+++ b/app/flow_report.py
@@ -322,11 +322,19 @@ def generate_segment_section(
     content = []
     
     # Segment header
-    seg_id = segment.get("seg_id", "Unknown")
-    seg_label = segment.get("segment_label", "Unknown")
-    flow_type = segment.get("flow_type", "Unknown")
-    event_a = segment.get("event_a", "Unknown")
-    event_b = segment.get("event_b", "Unknown")
+    seg_id = segment.get("seg_id")
+    if not seg_id:
+        raise ValueError("Flow segment missing seg_id for report generation.")
+    seg_label = segment.get("segment_label")
+    if not seg_label:
+        raise ValueError(f"Segment {seg_id} missing segment_label for flow report generation.")
+    flow_type = segment.get("flow_type")
+    if not flow_type:
+        raise ValueError(f"Segment {seg_id} missing flow_type for flow report generation.")
+    event_a = segment.get("event_a")
+    event_b = segment.get("event_b")
+    if not event_a or not event_b:
+        raise ValueError(f"Segment {seg_id} missing event pair for flow report generation.")
     has_convergence = segment.get("has_convergence", False)
     
     content.append(f"## {seg_id}: {seg_label}")
@@ -454,17 +462,12 @@ def generate_basic_info_table(segment: Dict[str, Any]) -> List[str]:
     total_a = segment.get("total_a", 0)
     total_b = segment.get("total_b", 0)
     
-    # Get width from segments.csv - fix NA values (Issue #616: This function is deprecated, but kept for backward compatibility)
-    # In v2 pipeline, width should come from segments_df passed to generate_segment_info_table
-    seg_id = segment.get("seg_id", "")
-    from app.utils.constants import DEFAULT_CONFLICT_LENGTH_METERS
-    width_m = DEFAULT_CONFLICT_LENGTH_METERS  # Default width
-    # Note: This function should be refactored to accept segments_df as a parameter
-    # For now, use default width to avoid hardcoded fallback
-    logger.debug(
-        f"generate_basic_info_table: Using default width for segment {seg_id}. "
-        "This function should be refactored to accept segments_df parameter."
-    )
+    seg_id = segment.get("seg_id")
+    width_m = segment.get("width_m")
+    if not seg_id:
+        raise ValueError("Segment missing seg_id for basic info table.")
+    if width_m is None or (isinstance(width_m, float) and pd.isna(width_m)):
+        raise ValueError(f"Segment {seg_id} missing width_m for basic info table.")
     
     # Get event names
     event_a = segment.get("event_a", "A")
@@ -789,7 +792,9 @@ def export_temporal_flow_csv(results: Dict[str, Any], output_path: str, start_ti
     zone_rows = []
     
     for segment in segments:
-        seg_id = segment.get("seg_id", "")
+        seg_id = segment.get("seg_id")
+        if not seg_id:
+            raise ValueError("Flow segment missing seg_id for flow report export.")
         zones = segment.get("zones", [])
         
         if not zones:
@@ -797,26 +802,28 @@ def export_temporal_flow_csv(results: Dict[str, Any], output_path: str, start_ti
             continue
         
         # Get segment-level metadata (repeated for each zone)
-        segment_label = segment.get("segment_label", "")
-        event_a = segment.get("event_a", "")
-        event_b = segment.get("event_b", "")
+        segment_label = segment.get("segment_label")
+        if not segment_label:
+            raise ValueError(f"Segment {seg_id} missing segment_label for flow report export.")
+        event_a = segment.get("event_a")
+        event_b = segment.get("event_b")
+        if not event_a or not event_b:
+            raise ValueError(f"Segment {seg_id} missing event pair for flow report export.")
         total_a = segment.get("total_a", 0)
         total_b = segment.get("total_b", 0)
-        flow_type = segment.get("flow_type", "")
+        flow_type = segment.get("flow_type")
+        if not flow_type:
+            raise ValueError(f"Segment {seg_id} missing flow_type for flow report export.")
         has_convergence = segment.get("has_convergence", False)
         
         # Get width from segments.csv
         seg_row = segments_df[segments_df['seg_id'] == seg_id]
-        if not seg_row.empty:
-            width_val = seg_row['width_m'].iloc[0]
-            if pd.isna(width_val) or width_val == '':
-                from app.utils.constants import DEFAULT_CONFLICT_LENGTH_METERS
-                width_m = DEFAULT_CONFLICT_LENGTH_METERS
-            else:
-                width_m = float(width_val)
-        else:
-            from app.utils.constants import DEFAULT_CONFLICT_LENGTH_METERS
-            width_m = DEFAULT_CONFLICT_LENGTH_METERS
+        if seg_row.empty:
+            raise ValueError(f"Segment {seg_id} missing from segments.csv for flow report export.")
+        width_val = seg_row['width_m'].iloc[0]
+        if pd.isna(width_val) or width_val == '':
+            raise ValueError(f"Segment {seg_id} missing width_m in segments.csv for flow report export.")
+        width_m = float(width_val)
         
         # Process each zone in this segment
         # Sort zones by zone_index to ensure consistent ordering
@@ -1443,13 +1450,19 @@ def generate_flow_audit_csv(
         for segment in segments:
             if "flow_audit_data" in segment:
                 audit_data = segment["flow_audit_data"]
-                audit_data["seg_id"] = segment.get("seg_id", "")
-                audit_data["segment_label"] = segment.get("segment_label", "")
+                seg_id = segment.get("seg_id")
+                seg_label = segment.get("segment_label")
+                if not seg_id:
+                    raise ValueError("Flow audit segment missing seg_id.")
+                if not seg_label:
+                    raise ValueError(f"Segment {seg_id} missing segment_label for flow audit.")
+                audit_data["seg_id"] = seg_id
+                audit_data["segment_label"] = seg_label
                 
                 # Write row with all 33 columns
                 writer.writerow([
-                    audit_data.get("seg_id", ""),
-                    audit_data.get("segment_label", ""),
+                    audit_data["seg_id"],
+                    audit_data["segment_label"],
                     audit_data.get("event_a", ""),
                     audit_data.get("event_b", ""),
                     audit_data.get("spatial_zone_exists", False),

--- a/app/io/loader.py
+++ b/app/io/loader.py
@@ -28,7 +28,7 @@ def load_segments(path: str):
 def load_runners(path: str):
     return pd.read_csv(path)
 
-def load_runners_by_event(event_name: str, data_dir: str):
+def load_runners_by_event(runners_path: str):
     """
     Load runners for a specific event from event-specific CSV file.
     
@@ -36,8 +36,7 @@ def load_runners_by_event(event_name: str, data_dir: str):
     Normalizes event name to lowercase for consistent file naming.
     
     Args:
-        event_name: Event name (e.g., "full", "half", "10k") - will be normalized to lowercase
-        data_dir: Base directory for data files (default: "data")
+        runners_path: Path to event-specific runners CSV file
         
     Returns:
         DataFrame with runner data for the specified event
@@ -47,16 +46,11 @@ def load_runners_by_event(event_name: str, data_dir: str):
     """
     from pathlib import Path
     
-    # Normalize event name to lowercase
-    event_name = event_name.lower()
-    
-    # Construct filename: {event}_runners.csv
-    runners_file = f"{event_name}_runners.csv"
-    runners_path = Path(data_dir) / runners_file
-    
+    runners_path = Path(runners_path)
+
     if not runners_path.exists():
         raise FileNotFoundError(
-            f"Runner file '{runners_file}' not found in {data_dir}/ directory for event '{event_name}'"
+            f"Runner file not found at {runners_path}"
         )
     
     return pd.read_csv(runners_path)

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -646,7 +646,8 @@ def generate_location_report(
     start_times: Optional[Dict[str, float]] = None,
     output_dir: str = "reports",
     run_id: Optional[str] = None,
-    day: Optional[str] = None  # Issue #598: Day code for loading flags.json
+    day: Optional[str] = None,  # Issue #598: Day code for loading flags.json
+    gpx_paths: Optional[Dict[str, str]] = None
 ) -> Dict[str, Any]:
     """
     Generate locations report with arrival modeling and operational timing.
@@ -660,6 +661,7 @@ def generate_location_report(
         start_times: Dictionary of event start times in minutes (default: from constants)
         output_dir: Output directory for report
         run_id: Optional run ID for runflow structure
+        gpx_paths: Mapping of event name to GPX file path (required)
         
     Returns:
         Dictionary with report results and file path
@@ -680,7 +682,9 @@ def generate_location_report(
         locations_df = load_locations(locations_csv)
         runners_df = load_runners(runners_csv)
         segments_df = load_segments(segments_csv)
-        courses = load_all_courses(os.path.dirname(segments_csv))
+        if not gpx_paths:
+            raise ValueError("gpx_paths is required for location report GPX loading.")
+        courses = load_all_courses(gpx_paths)
     except FileNotFoundError as e:
         logger.error(f"Required input file not found: {e}")
         return {"ok": False, "error": str(e), "error_type": "file_not_found"}

--- a/app/new_density_template_engine.py
+++ b/app/new_density_template_engine.py
@@ -359,7 +359,10 @@ class NewDensityTemplateEngine:
                 'on_course_narrow': 'on_course_narrow',
                 'on_course_open': 'on_course_open'
             }
-            flagged_with_schema['segment_type'] = flagged_with_schema['schema_key'].map(schema_to_type).fillna('on_course_open')
+            flagged_with_schema['segment_type'] = flagged_with_schema['schema_key'].map(schema_to_type)
+            if flagged_with_schema['segment_type'].isna().any():
+                missing = flagged_with_schema[flagged_with_schema['segment_type'].isna()]['segment_id'].tolist()
+                raise ValueError(f"Missing schema_key mapping for segments: {missing}")
         
         if len(flagged_with_schema) == 0:
             lines.append("| *No flagged segments* | | | | | | | | | | | | |")

--- a/app/validation/location_projection.py
+++ b/app/validation/location_projection.py
@@ -31,7 +31,7 @@ WGS84_TO_UTM = Transformer.from_crs("EPSG:4326", "EPSG:32619", always_xy=True)
 def validate_location_projections(
     locations_file: str,
     segments_file: str,
-    data_dir: str,
+    gpx_paths: Dict[str, str],
     output_file: Optional[str] = None
 ) -> Dict[str, Any]:
     """
@@ -43,7 +43,7 @@ def validate_location_projections(
     Args:
         locations_file: Path to locations CSV file (required)
         segments_file: Path to segments CSV file (required)
-        data_dir: Data directory path
+        gpx_paths: Mapping of event name to GPX file path
         output_file: Optional path to save bad_segments.json export
         
     Returns:
@@ -57,7 +57,9 @@ def validate_location_projections(
     try:
         locations_df = load_locations(locations_file)
         segments_df = load_segments(segments_file)
-        courses = load_all_courses(data_dir)
+        if not gpx_paths:
+            raise ValueError("gpx_paths is required for location projection validation.")
+        courses = load_all_courses(gpx_paths)
     except Exception as e:
         logger.error(f"Failed to load data files: {e}")
         return {


### PR DESCRIPTION
### Motivation

- Remove implicit defaults and silent fallbacks for data files and segment metadata so the v2 pipeline uses `analysis.json` as single source-of-truth. 
- Fail fast on missing or malformed segment metadata (`schema`, `width_m`, `seg_label`) to avoid producing misleading map/bin/report artifacts. 
- Ensure GPX loaders and helpers accept explicit paths and mappings rather than constructing `data/...` defaults. 
- Tighten v2 payload/file validation so missing file references are rejected early during validation.

### Description

- Route all GPX/segment/runner file resolution through the `AnalysisContext`/`analysis.json` paths and require explicit GPX mappings (e.g., `gpx_paths`) for GPX loaders, replacing directory-default behavior in `app/core/gpx/processor.py`, `app/geo_utils.py`, `app/api/map.py`, and `app/location_report.py`.
- Replace silent fallback logic with explicit validation errors for missing `schema`, `width_m`, or `seg_label` across reporting and flagging code paths, including `app/density_report.py`, `app/core/density/compute.py`, `app/core/v2/bins.py`, and `app/core/artifacts/frontend.py`.
- Update IO and runner helpers to accept explicit paths and stop computing defaults: changed `load_runners_by_event()` signature in `app/io/loader.py`, updated `combine_runners_for_events()` and `load_all_runners_for_events()` in `app/core/v2/density.py`, and adjusted callers in the v2 pipeline to pass `runners_paths` and `gpx_paths` from `analysis_context`.
- Tightened v2 API validation (`app/core/v2/validation.py`) to require `segments_file` and `flow_file` and to only allow optional `locations_file`; added file-existence checks and stricter extension validation.
- Updated bin/geojson/report generation to require `analysis_context` (or explicit paths) and to call `generate_bins_geojson(..., analysis_context=...)` and related functions so all artifact generation relies on `analysis.json`-driven paths (files changed include `app/geo_utils.py`, `app/density_report.py`, `app/core/v2/reports.py`, and others).
- Misc: added defensive checks and small API changes to flow/report modules to surface missing metadata as errors (e.g., `app/flow_report.py`, `app/core/v2/flow.py`).

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961c87ebd3c83229e123f1a96e10043)