### PR TITLE
Require and validate analysis.json in E2E tests; update dev env, Postman, and docs

### DIFF
--- a/dev.env
+++ b/dev.env
@@ -4,6 +4,9 @@
 # Bin Dataset Generation
 ENABLE_BIN_DATASET=true
 
+# Analysis data directory (explicit config path for analysis.json)
+DATA_ROOT=/app/data
+
 # Output Directory
 OUTPUT_DIR=reports
 
@@ -17,4 +20,3 @@ GCS_UPLOAD=false
 
 # Issue #314: Dashboard Password Gate
 DASHBOARD_PASSWORD=47THFM2026
-

--- a/docs/dev-guides/developer-guide.md
+++ b/docs/dev-guides/developer-guide.md
@@ -247,10 +247,23 @@ def load_segments(segments_file: str, data_dir: str = "data") -> pd.DataFrame:
   "data_files": {
     "segments": "data/segments.csv",
     "flow": "data/flow.csv",
-    "locations": "data/locations.csv"
+    "locations": "data/locations.csv",
+    "runners": {
+      "elite": "data/elite_runners.csv"
+    },
+    "gpx": {
+      "elite": "data/elite.gpx"
+    }
   }
 }
 ```
+
+**Required fields (fail-fast):**
+- `data_dir`, `segments_file`, `flow_file`, `data_files`, `events` must be present in `analysis.json`.
+- `data_files` must include `segments`, `flow`, `locations`, plus `runners` and `gpx` entries for every event.
+- Each `events[*]` entry must include `name`, `day`, `start_time`, `event_duration_minutes`, `runners_file`, and `gpx_file`.
+
+Missing or invalid fields cause the analysis config loader (`app/config/loader.py`) to fail fast before the pipeline runs.
 
 ### Helper Functions
 
@@ -624,4 +637,3 @@ print(f"Exists: {Path(flow_file).exists()}")
 **Version:** v2.0.2+  
 **Last Updated:** 2025-12-25  
 **Issue:** #553
-

--- a/postman/collections/Runflow-v2-API.postman_collection.json
+++ b/postman/collections/Runflow-v2-API.postman_collection.json
@@ -1,536 +1,587 @@
 {
-	"info": {
-		"_postman_id": "runflow-v2-api-collection",
-		"name": "Runflow v2 API",
-		"description": "Complete test collection for Runflow v2 API endpoints. Includes all E2E test scenarios and error cases.\n\n**Version:** v2.0.2+\n**Source:** Based on tests/v2/e2e.py\n**Last Updated:** 2025-01-26",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"item": [
-		{
-			"name": "Health & Status",
-			"item": [
-				{
-					"name": "Health Check",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response time is less than 500ms\", function () {",
-									"    pm.expect(pm.response.responseTime).to.be.below(500);",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/health",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"health"
-							]
-						},
-						"description": "Health check endpoint to verify server is running."
-					},
-					"response": []
-				},
-				{
-					"name": "Debug Ping",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response is ping/pong\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.eql({ping: \"pong\"});",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "GET",
-						"header": [],
-						"url": {
-							"raw": "{{base_url}}/debug",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"debug"
-							]
-						},
-						"description": "Debug ping endpoint for coverage testing."
-					},
-					"response": []
-				}
-			],
-			"description": "Health and status endpoints"
-		},
-		{
-			"name": "Analysis Endpoints",
-			"item": [
-				{
-					"name": "Saturday Only Scenario",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"// Clear previous run_id",
-									"pm.environment.unset(\"run_id\");"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response has run_id\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property(\"run_id\");",
-									"    pm.environment.set(\"run_id\", jsonData.run_id);",
-									"});",
-									"",
-									"pm.test(\"Response has status success\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.status).to.eql(\"success\");",
-									"});",
-									"",
-									"pm.test(\"Response contains sat day\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.days).to.include(\"sat\");",
-									"});",
-									"",
-									"pm.test(\"Response has output_paths for sat\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.output_paths).to.have.property(\"sat\");",
-									"    pm.expect(jsonData.output_paths.sat).to.have.property(\"reports\");",
-									"    pm.expect(jsonData.output_paths.sat).to.have.property(\"bins\");",
-									"    pm.expect(jsonData.output_paths.sat).to.have.property(\"ui\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-					"body": {
-						"mode": "raw",
-						"raw": "{\n  \"description\": \"Saturday only scenario test with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sat-elite\": \"elite\",\n    \"sat-open\": \"open\"\n  },\n  \"events\": [\n    {\n      \"name\": \"elite\",\n      \"day\": \"sat\",\n      \"start_time\": 480,\n      \"event_duration_minutes\": 45,\n      \"runners_file\": \"elite_runners.csv\",\n      \"gpx_file\": \"elite.gpx\"\n    },\n    {\n      \"name\": \"open\",\n      \"day\": \"sat\",\n      \"start_time\": 510,\n      \"event_duration_minutes\": 75,\n      \"runners_file\": \"open_runners.csv\",\n      \"gpx_file\": \"open.gpx\"\n    }\n  ]\n}"
-					},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test Saturday-only workflow with elite and open events.\n\n**Expected:**\n- Status: 200\n- Response contains run_id\n- Response contains days: [\"sat\"]\n- Response contains output_paths for sat"
-					},
-					"response": []
-				},
-				{
-					"name": "Sunday Only Scenario",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"pm.environment.unset(\"run_id\");"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response has run_id\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property(\"run_id\");",
-									"    pm.environment.set(\"run_id\", jsonData.run_id);",
-									"});",
-									"",
-									"pm.test(\"Response contains sun day\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.days).to.include(\"sun\");",
-									"});",
-									"",
-									"pm.test(\"Response has output_paths for sun\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.output_paths).to.have.property(\"sun\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-					"body": {
-						"mode": "raw",
-						"raw": "{\n  \"description\": \"Sunday only scenario test with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 440,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 460,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
-					},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test Sunday-only workflow with full, 10k, and half events.\n\n**Expected:**\n- Status: 200\n- Response contains days: [\"sun\"]\n- All three events processed"
-					},
-					"response": []
-				},
-				{
-					"name": "Sat+Sun Combined Scenario",
-					"event": [
-						{
-							"listen": "prerequest",
-							"script": {
-								"exec": [
-									"pm.environment.unset(\"run_id\");"
-								],
-								"type": "text/javascript"
-							}
-						},
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 200\", function () {",
-									"    pm.response.to.have.status(200);",
-									"});",
-									"",
-									"pm.test(\"Response has run_id\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property(\"run_id\");",
-									"    pm.environment.set(\"run_id\", jsonData.run_id);",
-									"});",
-									"",
-									"pm.test(\"Response contains both sat and sun days\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.days).to.include(\"sat\");",
-									"    pm.expect(jsonData.days).to.include(\"sun\");",
-									"});",
-									"",
-									"pm.test(\"Response has output_paths for both days\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.output_paths).to.have.property(\"sat\");",
-									"    pm.expect(jsonData.output_paths).to.have.property(\"sun\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-					"body": {
-						"mode": "raw",
-						"raw": "{\n  \"description\": \"Sat+Sun analysis test with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sat-elite\": \"elite\",\n    \"sat-open\": \"open\",\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"elite\",\n      \"day\": \"sat\",\n      \"start_time\": 480,\n      \"event_duration_minutes\": 45,\n      \"runners_file\": \"elite_runners.csv\",\n      \"gpx_file\": \"elite.gpx\"\n    },\n    {\n      \"name\": \"open\",\n      \"day\": \"sat\",\n      \"start_time\": 510,\n      \"event_duration_minutes\": 75,\n      \"runners_file\": \"open_runners.csv\",\n      \"gpx_file\": \"open.gpx\"\n    },\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 440,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 460,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
-					},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test sat+sun analysis in single run_id with all events.\n\n**Expected:**\n- Status: 200\n- Response contains days: [\"sat\", \"sun\"]\n- Both day outputs present"
-					},
-					"response": []
-				}
-			],
-			"description": "Main analysis endpoint test scenarios"
-		},
-		{
-			"name": "Error Cases",
-			"item": [
-				{
-					"name": "Missing Required Field - segments_file",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 400\", function () {",
-									"    pm.response.to.have.status(400);",
-									"});",
-									"",
-									"pm.test(\"Response has error status\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.status).to.eql(\"ERROR\");",
-									"});",
-									"",
-									"pm.test(\"Response contains error message\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData).to.have.property(\"error\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"description\": \"Missing segments_file test\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    }\n  ]\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test error handling for missing required field.\n\n**Expected:**\n- Status: 400 Bad Request\n- Error message indicating missing field"
-					},
-					"response": []
-				},
-				{
-					"name": "Invalid Start Time - Below Minimum",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 422\", function () {",
-									"    pm.response.to.have.status(422);",
-									"});",
-									"",
-									"pm.test(\"Response has error status\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.status).to.eql(\"ERROR\");",
-									"});",
-									"",
-									"pm.test(\"Error message mentions start_time\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.error).to.include(\"start_time\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"description\": \"Invalid start_time test\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 200,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    }\n  ]\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test validation error for start_time below minimum (300).\n\n**Expected:**\n- Status: 422 Unprocessable Entity\n- Error message indicating invalid start_time"
-					},
-					"response": []
-				},
-				{
-					"name": "Invalid Start Time - Above Maximum",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 422\", function () {",
-									"    pm.response.to.have.status(422);",
-									"});",
-									"",
-									"pm.test(\"Response has error status\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.status).to.eql(\"ERROR\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"description\": \"Invalid start_time test - too high\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 1300,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    }\n  ]\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test validation error for start_time above maximum (1200).\n\n**Expected:**\n- Status: 422 Unprocessable Entity"
-					},
-					"response": []
-				},
-				{
-					"name": "Empty Events Array",
-					"event": [
-						{
-							"listen": "test",
-							"script": {
-								"exec": [
-									"pm.test(\"Status code is 400 or 422\", function () {",
-									"    pm.expect([400, 422]).to.include(pm.response.code);",
-									"});",
-									"",
-									"pm.test(\"Response has error status\", function () {",
-									"    var jsonData = pm.response.json();",
-									"    pm.expect(jsonData.status).to.eql(\"ERROR\");",
-									"});"
-								],
-								"type": "text/javascript"
-							}
-						}
-					],
-					"request": {
-						"method": "POST",
-						"header": [
-							{
-								"key": "Content-Type",
-								"value": "application/json"
-							}
-						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"description\": \"Empty events array test\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": []\n}"
-						},
-						"url": {
-							"raw": "{{base_url}}/runflow/v2/analyze",
-							"host": [
-								"{{base_url}}"
-							],
-							"path": [
-								"runflow",
-								"v2",
-								"analyze"
-							]
-						},
-						"description": "Test validation error for empty events array.\n\n**Expected:**\n- Status: 400 or 422\n- Error message indicating events array is empty"
-					},
-					"response": []
-				}
-			],
-			"description": "Error handling and validation test cases"
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "base_url",
-			"value": "http://localhost:8080",
-			"type": "string"
-		}
-	]
+  "info": {
+    "_postman_id": "runflow-v2-api-collection",
+    "name": "Runflow v2 API",
+    "description": "Complete test collection for Runflow v2 API endpoints. Includes all E2E test scenarios and error cases.\n\n**Version:** v2.0.2+\n**Source:** Based on tests/v2/e2e.py\n**Last Updated:** 2025-01-26",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Health & Status",
+      "item": [
+        {
+          "name": "Health Check",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response time is less than 500ms\", function () {",
+                  "    pm.expect(pm.response.responseTime).to.be.below(500);",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/health",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "health"
+              ]
+            },
+            "description": "Health check endpoint to verify server is running."
+          },
+          "response": []
+        },
+        {
+          "name": "Debug Ping",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response is ping/pong\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.eql({ping: \"pong\"});",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/debug",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "debug"
+              ]
+            },
+            "description": "Debug ping endpoint for coverage testing."
+          },
+          "response": []
+        }
+      ],
+      "description": "Health and status endpoints"
+    },
+    {
+      "name": "Analysis Endpoints",
+      "item": [
+        {
+          "name": "Saturday Only Scenario",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "// Clear previous run_id",
+                  "pm.environment.unset(\"run_id\");"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has run_id\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property(\"run_id\");",
+                  "    pm.environment.set(\"run_id\", jsonData.run_id);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has status success\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.status).to.eql(\"success\");",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains sat day\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.days).to.include(\"sat\");",
+                  "});",
+                  "",
+                  "pm.test(\"Response has output_paths for sat\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.output_paths).to.have.property(\"sat\");",
+                  "    pm.expect(jsonData.output_paths.sat).to.have.property(\"reports\");",
+                  "    pm.expect(jsonData.output_paths.sat).to.have.property(\"bins\");",
+                  "    pm.expect(jsonData.output_paths.sat).to.have.property(\"ui\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Saturday only scenario test with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sat-elite\": \"elite\",\n    \"sat-open\": \"open\"\n  },\n  \"events\": [\n    {\n      \"name\": \"elite\",\n      \"day\": \"sat\",\n      \"start_time\": 480,\n      \"event_duration_minutes\": 45,\n      \"runners_file\": \"elite_runners.csv\",\n      \"gpx_file\": \"elite.gpx\"\n    },\n    {\n      \"name\": \"open\",\n      \"day\": \"sat\",\n      \"start_time\": 510,\n      \"event_duration_minutes\": 75,\n      \"runners_file\": \"open_runners.csv\",\n      \"gpx_file\": \"open.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test Saturday-only workflow with elite and open events.\n\n**Expected:**\n- Status: 200\n- Response contains run_id\n- Response contains days: [\"sat\"]\n- Response contains output_paths for sat"
+          },
+          "response": []
+        },
+        {
+          "name": "Sunday Only Scenario",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "pm.environment.unset(\"run_id\");"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has run_id\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property(\"run_id\");",
+                  "    pm.environment.set(\"run_id\", jsonData.run_id);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains sun day\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.days).to.include(\"sun\");",
+                  "});",
+                  "",
+                  "pm.test(\"Response has output_paths for sun\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.output_paths).to.have.property(\"sun\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Sunday only scenario test with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 440,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 460,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test Sunday-only workflow with full, 10k, and half events.\n\n**Expected:**\n- Status: 200\n- Response contains days: [\"sun\"]\n- All three events processed"
+          },
+          "response": []
+        },
+        {
+          "name": "Sat+Sun Combined Scenario",
+          "event": [
+            {
+              "listen": "prerequest",
+              "script": {
+                "exec": [
+                  "pm.environment.unset(\"run_id\");"
+                ],
+                "type": "text/javascript"
+              }
+            },
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 200\", function () {",
+                  "    pm.response.to.have.status(200);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has run_id\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property(\"run_id\");",
+                  "    pm.environment.set(\"run_id\", jsonData.run_id);",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains both sat and sun days\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.days).to.include(\"sat\");",
+                  "    pm.expect(jsonData.days).to.include(\"sun\");",
+                  "});",
+                  "",
+                  "pm.test(\"Response has output_paths for both days\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.output_paths).to.have.property(\"sat\");",
+                  "    pm.expect(jsonData.output_paths).to.have.property(\"sun\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Sat+Sun analysis test with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sat-elite\": \"elite\",\n    \"sat-open\": \"open\",\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"elite\",\n      \"day\": \"sat\",\n      \"start_time\": 480,\n      \"event_duration_minutes\": 45,\n      \"runners_file\": \"elite_runners.csv\",\n      \"gpx_file\": \"elite.gpx\"\n    },\n    {\n      \"name\": \"open\",\n      \"day\": \"sat\",\n      \"start_time\": 510,\n      \"event_duration_minutes\": 75,\n      \"runners_file\": \"open_runners.csv\",\n      \"gpx_file\": \"open.gpx\"\n    },\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 440,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 460,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test sat+sun analysis in single run_id with all events.\n\n**Expected:**\n- Status: 200\n- Response contains days: [\"sat\", \"sun\"]\n- Both day outputs present"
+          },
+          "response": []
+        },
+        {
+          "name": "Sat+Sun Combined Scenario (Alternate Config - 616)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Sat+Sun analysis test with audit (alternate config)\",\n  \"segments_file\": \"segments_616.csv\",\n  \"flow_file\": \"flow_616.csv\",\n  \"locations_file\": \"locations_616.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sat-elite\": \"elite\",\n    \"sat-open\": \"open\",\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"elite\",\n      \"day\": \"sat\",\n      \"start_time\": 480,\n      \"event_duration_minutes\": 45,\n      \"runners_file\": \"elite_runners.csv\",\n      \"gpx_file\": \"elite.gpx\"\n    },\n    {\n      \"name\": \"open\",\n      \"day\": \"sat\",\n      \"start_time\": 510,\n      \"event_duration_minutes\": 75,\n      \"runners_file\": \"open_runners.csv\",\n      \"gpx_file\": \"open.gpx\"\n    },\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 440,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 460,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            }
+          }
+        },
+        {
+          "name": "Fetch Analysis Config",
+          "request": {
+            "method": "GET",
+            "header": [],
+            "url": {
+              "raw": "{{base_url}}/api/analysis/{{run_id}}/config",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "api",
+                "analysis",
+                "{{run_id}}",
+                "config"
+              ]
+            }
+          }
+        }
+      ],
+      "description": "Main analysis endpoint test scenarios"
+    },
+    {
+      "name": "Error Cases",
+      "item": [
+        {
+          "name": "Missing Required Field - segments_file",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 400\", function () {",
+                  "    pm.response.to.have.status(400);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has error status\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.status).to.eql(\"ERROR\");",
+                  "});",
+                  "",
+                  "pm.test(\"Response contains error message\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData).to.have.property(\"error\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Missing segments_file test\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test error handling for missing required field.\n\n**Expected:**\n- Status: 400 Bad Request\n- Error message indicating missing field"
+          },
+          "response": []
+        },
+        {
+          "name": "Invalid Start Time - Below Minimum",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 422\", function () {",
+                  "    pm.response.to.have.status(422);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has error status\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.status).to.eql(\"ERROR\");",
+                  "});",
+                  "",
+                  "pm.test(\"Error message mentions start_time\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.error).to.include(\"start_time\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Invalid start_time test\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 200,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test validation error for start_time below minimum (300).\n\n**Expected:**\n- Status: 422 Unprocessable Entity\n- Error message indicating invalid start_time"
+          },
+          "response": []
+        },
+        {
+          "name": "Invalid Start Time - Above Maximum",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 422\", function () {",
+                  "    pm.response.to.have.status(422);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has error status\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.status).to.eql(\"ERROR\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Invalid start_time test - too high\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 1300,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    }\n  ]\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test validation error for start_time above maximum (1200).\n\n**Expected:**\n- Status: 422 Unprocessable Entity"
+          },
+          "response": []
+        },
+        {
+          "name": "Empty Events Array",
+          "event": [
+            {
+              "listen": "test",
+              "script": {
+                "exec": [
+                  "pm.test(\"Status code is 400 or 422\", function () {",
+                  "    pm.expect([400, 422]).to.include(pm.response.code);",
+                  "});",
+                  "",
+                  "pm.test(\"Response has error status\", function () {",
+                  "    var jsonData = pm.response.json();",
+                  "    pm.expect(jsonData.status).to.eql(\"ERROR\");",
+                  "});"
+                ],
+                "type": "text/javascript"
+              }
+            }
+          ],
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Content-Type",
+                "value": "application/json"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"description\": \"Empty events array test\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"events\": []\n}"
+            },
+            "url": {
+              "raw": "{{base_url}}/runflow/v2/analyze",
+              "host": [
+                "{{base_url}}"
+              ],
+              "path": [
+                "runflow",
+                "v2",
+                "analyze"
+              ]
+            },
+            "description": "Test validation error for empty events array.\n\n**Expected:**\n- Status: 400 or 422\n- Error message indicating events array is empty"
+          },
+          "response": []
+        }
+      ],
+      "description": "Error handling and validation test cases"
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8080",
+      "type": "string"
+    },
+    {
+      "key": "run_id",
+      "value": "REPLACE_WITH_RUN_ID",
+      "type": "string"
+    }
+  ]
 }

--- a/postman/collections/Runflow-v2-StartTime-Manipulation.postman_collection.json
+++ b/postman/collections/Runflow-v2-StartTime-Manipulation.postman_collection.json
@@ -1,314 +1,314 @@
 {
-	"info": {
-		"_postman_id": "runflow-v2-starttime-manipulation",
-		"name": "Runflow v2 - Start Time Manipulation Tests",
-		"description": "Test collection focused on start-time manipulation patterns to validate system behavior changes.\n\n**Purpose:** Validate that the system behaves differently when start_time parameters change, with clear expectations for flow, density, and co-presence impacts.\n\n**Test Cases:**\n1. WIDEN - Increasing start-time gaps (reduce overlap)\n2. COMPRESS - Tightly packed start times (force overlap)\n3. UNIFORM - Identical start times (maximum co-located flow)\n\n**Version:** v2.0.2+\n**Last Updated:** 2025-01-26",
-		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
-	},
-	"item": [
-		{
-			"name": "Test Case 1: WIDEN Start-Time Gaps (Reduce Overlap)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"// Clear previous run_id",
-							"pm.environment.unset(\"run_id\");",
-							"pm.environment.unset(\"test_case\");",
-							"",
-							"// Store test case identifier",
-							"pm.environment.set(\"test_case\", \"WIDEN\");"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has run_id\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData).to.have.property(\"run_id\");",
-							"    pm.environment.set(\"run_id\", jsonData.run_id);",
-							"    console.log(\"Run ID: \" + jsonData.run_id);",
-							"});",
-							"",
-							"pm.test(\"Response has status success\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.status).to.eql(\"success\");",
-							"});",
-							"",
-							"pm.test(\"Response contains sun day\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.days).to.include(\"sun\");",
-							"});",
-							"",
-							"// Store test metadata for validation",
-							"var jsonData = pm.response.json();",
-							"pm.environment.set(\"widen_run_id\", jsonData.run_id);",
-							"",
-							"console.log(\"\\n=== WIDEN Test Case - Validation Instructions ===\");",
-							"console.log(\"Run ID: \" + jsonData.run_id);",
-							"console.log(\"\\nExpected Behavior:\");",
-							"console.log(\"- Total segment co-presence count should DROP\");",
-							"console.log(\"- Segment peak density timestamps should be FURTHER APART\");",
-							"console.log(\"  * Full peak: ~06:40 (start 06:00)\");",
-							"console.log(\"  * 10K peak: ~07:30 (start 07:00)\");",
-							"console.log(\"  * Half peak: ~09:50 (start 09:00)\");",
-							"console.log(\"- No overtake events between events (if tracking enabled)\");",
-							"console.log(\"\\nTo Validate:\");",
-							"console.log(\"1. Check runflow/\" + jsonData.run_id + \"/sun/reports/Flow.csv\");",
-							"console.log(\"2. Check runflow/\" + jsonData.run_id + \"/sun/reports/Density.md\");",
-							"console.log(\"3. Compare co-presence counts with COMPRESS test case\");",
-							"console.log(\"4. Verify peak density timestamps are spread out\");"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"description\": \"Test Case 1: WIDEN Start-Time Gaps (Reduce Overlap) with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-full\": \"full\",\n    \"sun-10k\": \"10k\",\n    \"sun-half\": \"half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 360,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 540,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
-				},
-				"url": {
-					"raw": "{{base_url}}/runflow/v2/analyze",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"runflow",
-						"v2",
-						"analyze"
-					]
-				},
-				"description": "**Test Case 1: WIDEN Start-Time Gaps (Reduce Overlap)**\n\n**Purpose:** Confirm that increasing start-time separation reduces co-presence and lowers segment-level density.\n\n**Input:**\n- Full: 360 (6:00 AM) - 60 min gap\n- 10K: 420 (7:00 AM) - 120 min gap\n- Half: 540 (9:00 AM)\n\n**Expected Assertions:**\n- Total segment co-presence count should **DROP**\n- Segment peak density timestamps should be **FURTHER APART**\n  - Full peak on Bridge segment: ~06:40 (start 06:00)\n  - 10K peak on Bridge segment: ~07:30 (start 07:00)\n  - Half peak on Bridge segment: ~09:50 (start 09:00)\n- No overtake events should be recorded between events (if overtake tracking is part of your system)\n\n**Validation:**\nAfter analysis completes, check:\n- `runflow/{run_id}/sun/reports/Flow.csv` - Co-presence counts\n- `runflow/{run_id}/sun/reports/Density.md` - Peak density timestamps\n- Compare with COMPRESS test case results"
-			},
-			"response": []
-		},
-		{
-			"name": "Test Case 2: COMPRESS Start-Time Gaps (Force Overlap)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"// Clear previous run_id",
-							"pm.environment.unset(\"run_id\");",
-							"pm.environment.unset(\"test_case\");",
-							"",
-							"// Store test case identifier",
-							"pm.environment.set(\"test_case\", \"COMPRESS\");"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has run_id\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData).to.have.property(\"run_id\");",
-							"    pm.environment.set(\"run_id\", jsonData.run_id);",
-							"    console.log(\"Run ID: \" + jsonData.run_id);",
-							"});",
-							"",
-							"pm.test(\"Response has status success\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.status).to.eql(\"success\");",
-							"});",
-							"",
-							"pm.test(\"Response contains sun day\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.days).to.include(\"sun\");",
-							"});",
-							"",
-							"// Store test metadata for validation",
-							"var jsonData = pm.response.json();",
-							"pm.environment.set(\"compress_run_id\", jsonData.run_id);",
-							"",
-							"console.log(\"\\n=== COMPRESS Test Case - Validation Instructions ===\");",
-							"console.log(\"Run ID: \" + jsonData.run_id);",
-							"console.log(\"\\nExpected Behavior:\");",
-							"console.log(\"- Segment co-presence will INCREASE significantly\");",
-							"console.log(\"  * Queen Street shows runners from all three events at 07:15\");",
-							"console.log(\"- Overtake counts INCREASE\");",
-							"console.log(\"  * Especially in shared mid-course segments\");",
-							"console.log(\"  * Half overtake Full tail\");",
-							"console.log(\"- Peak density on shared segments should occur CLOSER TOGETHER\");",
-							"console.log(\"  * Potentially showing cumulative congestion\");",
-							"console.log(\"\\nTo Validate:\");",
-							"console.log(\"1. Check runflow/\" + jsonData.run_id + \"/sun/reports/Flow.csv\");",
-							"console.log(\"2. Check runflow/\" + jsonData.run_id + \"/sun/reports/Density.md\");",
-							"console.log(\"3. Compare co-presence counts with WIDEN test case\");",
-							"console.log(\"4. Verify overtake counts are higher\");",
-							"console.log(\"5. Verify peak density timestamps are closer together\");"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"description\": \"Test Case 2: COMPRESS Start-Time Gaps (Force Overlap) with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 425,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 430,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
-				},
-				"url": {
-					"raw": "{{base_url}}/runflow/v2/analyze",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"runflow",
-						"v2",
-						"analyze"
-					]
-				},
-				"description": "**Test Case 2: COMPRESS Start-Time Gaps (Force Overlap)**\n\n**Purpose:** Confirm that reducing start-time gaps creates higher co-presence, overlapping density, and increases overtaking.\n\n**Input:**\n- Full: 420 (7:00 AM) - 5 min gap\n- 10K: 425 (7:05 AM) - 5 min gap\n- Half: 430 (7:10 AM)\n\n**Expected Assertions:**\n- Segment co-presence will **INCREASE significantly**\n  - Queen Street shows runners from all three events at 07:15\n- Overtake counts **INCREASE**, especially in shared mid-course segments\n  - Half overtake Full tail\n- Peak density on shared segments should occur **CLOSER TOGETHER**\n  - Potentially showing cumulative congestion\n\n**Validation:**\nAfter analysis completes, check:\n- `runflow/{run_id}/sun/reports/Flow.csv` - Co-presence and overtake counts\n- `runflow/{run_id}/sun/reports/Density.md` - Peak density timestamps\n- Compare with WIDEN test case results"
-			},
-			"response": []
-		},
-		{
-			"name": "Test Case 3: UNIFORM Start Times (Maximum Co-located Flow)",
-			"event": [
-				{
-					"listen": "prerequest",
-					"script": {
-						"exec": [
-							"// Clear previous run_id",
-							"pm.environment.unset(\"run_id\");",
-							"pm.environment.unset(\"test_case\");",
-							"",
-							"// Store test case identifier",
-							"pm.environment.set(\"test_case\", \"UNIFORM\");"
-						],
-						"type": "text/javascript"
-					}
-				},
-				{
-					"listen": "test",
-					"script": {
-						"exec": [
-							"pm.test(\"Status code is 200\", function () {",
-							"    pm.response.to.have.status(200);",
-							"});",
-							"",
-							"pm.test(\"Response has run_id\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData).to.have.property(\"run_id\");",
-							"    pm.environment.set(\"run_id\", jsonData.run_id);",
-							"    console.log(\"Run ID: \" + jsonData.run_id);",
-							"});",
-							"",
-							"pm.test(\"Response has status success\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.status).to.eql(\"success\");",
-							"});",
-							"",
-							"pm.test(\"Response contains sun day\", function () {",
-							"    var jsonData = pm.response.json();",
-							"    pm.expect(jsonData.days).to.include(\"sun\");",
-							"});",
-							"",
-							"// Store test metadata for validation",
-							"var jsonData = pm.response.json();",
-							"pm.environment.set(\"uniform_run_id\", jsonData.run_id);",
-							"",
-							"console.log(\"\\n=== UNIFORM Test Case - Validation Instructions ===\");",
-							"console.log(\"Run ID: \" + jsonData.run_id);",
-							"console.log(\"\\nExpected Behavior:\");",
-							"console.log(\"- Density charts for overlapping segments show SUPERIMPOSED SPIKES\");",
-							"console.log(\"- First 30-60 minutes of course show HIGHEST CONCURRENCY\");",
-							"console.log(\"- Aid station timelines and traffic control shift logic maximally synchronized\");",
-							"console.log(\"- All three events start simultaneously at 07:00 (420 minutes)\");",
-							"console.log(\"\\nTo Validate:\");",
-							"console.log(\"1. Check runflow/\" + jsonData.run_id + \"/sun/reports/Density.md\");",
-							"console.log(\"2. Verify density spikes are superimposed (all events at same time)\");",
-							"console.log(\"3. Check runflow/\" + jsonData.run_id + \"/sun/reports/Flow.csv\");",
-							"console.log(\"4. Verify maximum co-presence in first 30-60 minutes\");",
-							"console.log(\"5. Compare with WIDEN and COMPRESS test cases\");"
-						],
-						"type": "text/javascript"
-					}
-				}
-			],
-			"request": {
-				"method": "POST",
-				"header": [
-					{
-						"key": "Content-Type",
-						"value": "application/json"
-					}
-				],
-				"body": {
-					"mode": "raw",
-					"raw": "{\n  \"description\": \"Test Case 3: UNIFORM Start Times (Maximum Co-located Flow) with audit\",\n  \"segments_file\": \"segments.csv\",\n  \"flow_file\": \"flow.csv\",\n  \"locations_file\": \"locations.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
-				},
-				"url": {
-					"raw": "{{base_url}}/runflow/v2/analyze",
-					"host": [
-						"{{base_url}}"
-					],
-					"path": [
-						"runflow",
-						"v2",
-						"analyze"
-					]
-				},
-				"description": "**Test Case 3: UNIFORM Start Times (Maximum Co-located Flow)**\n\n**Purpose:** Confirm system correctly handles identical start times for different events, resulting in total overlapping flow on shared segments.\n\n**Input:**\n- Full: 420 (7:00 AM)\n- 10K: 420 (7:00 AM)\n- Half: 420 (7:00 AM)\n\n**Expected Assertions:**\n- Density charts for overlapping segments should show **SUPERIMPOSED SPIKES**\n- First 30–60 minutes of the course show **HIGHEST CONCURRENCY**\n- Aid station timelines and traffic control shift logic (if modeled) should be **MAXIMALLY SYNCHRONIZED**\n\n**Validation:**\nAfter analysis completes, check:\n- `runflow/{run_id}/sun/reports/Density.md` - Superimposed density spikes\n- `runflow/{run_id}/sun/reports/Flow.csv` - Maximum co-presence in early segments\n- Compare with WIDEN and COMPRESS test cases"
-			},
-			"response": []
-		}
-	],
-	"event": [
-		{
-			"listen": "prerequest",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		},
-		{
-			"listen": "test",
-			"script": {
-				"type": "text/javascript",
-				"exec": [
-					""
-				]
-			}
-		}
-	],
-	"variable": [
-		{
-			"key": "base_url",
-			"value": "http://localhost:8080",
-			"type": "string"
-		}
-	]
+  "info": {
+    "_postman_id": "runflow-v2-starttime-manipulation",
+    "name": "Runflow v2 - Start Time Manipulation Tests",
+    "description": "Test collection focused on start-time manipulation patterns to validate system behavior changes.\n\n**Purpose:** Validate that the system behaves differently when start_time parameters change, with clear expectations for flow, density, and co-presence impacts.\n\n**Test Cases:**\n1. WIDEN - Increasing start-time gaps (reduce overlap)\n2. COMPRESS - Tightly packed start times (force overlap)\n3. UNIFORM - Identical start times (maximum co-located flow)\n\n**Version:** v2.0.2+\n**Last Updated:** 2025-01-26",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+  },
+  "item": [
+    {
+      "name": "Test Case 1: WIDEN Start-Time Gaps (Reduce Overlap)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// Clear previous run_id",
+              "pm.environment.unset(\"run_id\");",
+              "pm.environment.unset(\"test_case\");",
+              "",
+              "// Store test case identifier",
+              "pm.environment.set(\"test_case\", \"WIDEN\");"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has run_id\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property(\"run_id\");",
+              "    pm.environment.set(\"run_id\", jsonData.run_id);",
+              "    console.log(\"Run ID: \" + jsonData.run_id);",
+              "});",
+              "",
+              "pm.test(\"Response has status success\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.status).to.eql(\"success\");",
+              "});",
+              "",
+              "pm.test(\"Response contains sun day\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.days).to.include(\"sun\");",
+              "});",
+              "",
+              "// Store test metadata for validation",
+              "var jsonData = pm.response.json();",
+              "pm.environment.set(\"widen_run_id\", jsonData.run_id);",
+              "",
+              "console.log(\"\\n=== WIDEN Test Case - Validation Instructions ===\");",
+              "console.log(\"Run ID: \" + jsonData.run_id);",
+              "console.log(\"\\nExpected Behavior:\");",
+              "console.log(\"- Total segment co-presence count should DROP\");",
+              "console.log(\"- Segment peak density timestamps should be FURTHER APART\");",
+              "console.log(\"  * Full peak: ~06:40 (start 06:00)\");",
+              "console.log(\"  * 10K peak: ~07:30 (start 07:00)\");",
+              "console.log(\"  * Half peak: ~09:50 (start 09:00)\");",
+              "console.log(\"- No overtake events between events (if tracking enabled)\");",
+              "console.log(\"\\nTo Validate:\");",
+              "console.log(\"1. Check runflow/\" + jsonData.run_id + \"/sun/reports/Flow.csv\");",
+              "console.log(\"2. Check runflow/\" + jsonData.run_id + \"/sun/reports/Density.md\");",
+              "console.log(\"3. Compare co-presence counts with COMPRESS test case\");",
+              "console.log(\"4. Verify peak density timestamps are spread out\");"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"description\": \"Test Case 1: WIDEN Start-Time Gaps (Reduce Overlap) with audit\",\n  \"segments_file\": \"segments_616.csv\",\n  \"flow_file\": \"flow_616.csv\",\n  \"locations_file\": \"locations_616.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-full\": \"full\",\n    \"sun-10k\": \"10k\",\n    \"sun-half\": \"half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 360,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 540,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/runflow/v2/analyze",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "runflow",
+            "v2",
+            "analyze"
+          ]
+        },
+        "description": "**Test Case 1: WIDEN Start-Time Gaps (Reduce Overlap)**\n\n**Purpose:** Confirm that increasing start-time separation reduces co-presence and lowers segment-level density.\n\n**Input:**\n- Full: 360 (6:00 AM) - 60 min gap\n- 10K: 420 (7:00 AM) - 120 min gap\n- Half: 540 (9:00 AM)\n\n**Expected Assertions:**\n- Total segment co-presence count should **DROP**\n- Segment peak density timestamps should be **FURTHER APART**\n  - Full peak on Bridge segment: ~06:40 (start 06:00)\n  - 10K peak on Bridge segment: ~07:30 (start 07:00)\n  - Half peak on Bridge segment: ~09:50 (start 09:00)\n- No overtake events should be recorded between events (if overtake tracking is part of your system)\n\n**Validation:**\nAfter analysis completes, check:\n- `runflow/{run_id}/sun/reports/Flow.csv` - Co-presence counts\n- `runflow/{run_id}/sun/reports/Density.md` - Peak density timestamps\n- Compare with COMPRESS test case results"
+      },
+      "response": []
+    },
+    {
+      "name": "Test Case 2: COMPRESS Start-Time Gaps (Force Overlap)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// Clear previous run_id",
+              "pm.environment.unset(\"run_id\");",
+              "pm.environment.unset(\"test_case\");",
+              "",
+              "// Store test case identifier",
+              "pm.environment.set(\"test_case\", \"COMPRESS\");"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has run_id\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property(\"run_id\");",
+              "    pm.environment.set(\"run_id\", jsonData.run_id);",
+              "    console.log(\"Run ID: \" + jsonData.run_id);",
+              "});",
+              "",
+              "pm.test(\"Response has status success\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.status).to.eql(\"success\");",
+              "});",
+              "",
+              "pm.test(\"Response contains sun day\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.days).to.include(\"sun\");",
+              "});",
+              "",
+              "// Store test metadata for validation",
+              "var jsonData = pm.response.json();",
+              "pm.environment.set(\"compress_run_id\", jsonData.run_id);",
+              "",
+              "console.log(\"\\n=== COMPRESS Test Case - Validation Instructions ===\");",
+              "console.log(\"Run ID: \" + jsonData.run_id);",
+              "console.log(\"\\nExpected Behavior:\");",
+              "console.log(\"- Segment co-presence will INCREASE significantly\");",
+              "console.log(\"  * Queen Street shows runners from all three events at 07:15\");",
+              "console.log(\"- Overtake counts INCREASE\");",
+              "console.log(\"  * Especially in shared mid-course segments\");",
+              "console.log(\"  * Half overtake Full tail\");",
+              "console.log(\"- Peak density on shared segments should occur CLOSER TOGETHER\");",
+              "console.log(\"  * Potentially showing cumulative congestion\");",
+              "console.log(\"\\nTo Validate:\");",
+              "console.log(\"1. Check runflow/\" + jsonData.run_id + \"/sun/reports/Flow.csv\");",
+              "console.log(\"2. Check runflow/\" + jsonData.run_id + \"/sun/reports/Density.md\");",
+              "console.log(\"3. Compare co-presence counts with WIDEN test case\");",
+              "console.log(\"4. Verify overtake counts are higher\");",
+              "console.log(\"5. Verify peak density timestamps are closer together\");"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"description\": \"Test Case 2: COMPRESS Start-Time Gaps (Force Overlap) with audit\",\n  \"segments_file\": \"segments_616.csv\",\n  \"flow_file\": \"flow_616.csv\",\n  \"locations_file\": \"locations_616.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 425,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 430,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/runflow/v2/analyze",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "runflow",
+            "v2",
+            "analyze"
+          ]
+        },
+        "description": "**Test Case 2: COMPRESS Start-Time Gaps (Force Overlap)**\n\n**Purpose:** Confirm that reducing start-time gaps creates higher co-presence, overlapping density, and increases overtaking.\n\n**Input:**\n- Full: 420 (7:00 AM) - 5 min gap\n- 10K: 425 (7:05 AM) - 5 min gap\n- Half: 430 (7:10 AM)\n\n**Expected Assertions:**\n- Segment co-presence will **INCREASE significantly**\n  - Queen Street shows runners from all three events at 07:15\n- Overtake counts **INCREASE**, especially in shared mid-course segments\n  - Half overtake Full tail\n- Peak density on shared segments should occur **CLOSER TOGETHER**\n  - Potentially showing cumulative congestion\n\n**Validation:**\nAfter analysis completes, check:\n- `runflow/{run_id}/sun/reports/Flow.csv` - Co-presence and overtake counts\n- `runflow/{run_id}/sun/reports/Density.md` - Peak density timestamps\n- Compare with WIDEN test case results"
+      },
+      "response": []
+    },
+    {
+      "name": "Test Case 3: UNIFORM Start Times (Maximum Co-located Flow)",
+      "event": [
+        {
+          "listen": "prerequest",
+          "script": {
+            "exec": [
+              "// Clear previous run_id",
+              "pm.environment.unset(\"run_id\");",
+              "pm.environment.unset(\"test_case\");",
+              "",
+              "// Store test case identifier",
+              "pm.environment.set(\"test_case\", \"UNIFORM\");"
+            ],
+            "type": "text/javascript"
+          }
+        },
+        {
+          "listen": "test",
+          "script": {
+            "exec": [
+              "pm.test(\"Status code is 200\", function () {",
+              "    pm.response.to.have.status(200);",
+              "});",
+              "",
+              "pm.test(\"Response has run_id\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData).to.have.property(\"run_id\");",
+              "    pm.environment.set(\"run_id\", jsonData.run_id);",
+              "    console.log(\"Run ID: \" + jsonData.run_id);",
+              "});",
+              "",
+              "pm.test(\"Response has status success\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.status).to.eql(\"success\");",
+              "});",
+              "",
+              "pm.test(\"Response contains sun day\", function () {",
+              "    var jsonData = pm.response.json();",
+              "    pm.expect(jsonData.days).to.include(\"sun\");",
+              "});",
+              "",
+              "// Store test metadata for validation",
+              "var jsonData = pm.response.json();",
+              "pm.environment.set(\"uniform_run_id\", jsonData.run_id);",
+              "",
+              "console.log(\"\\n=== UNIFORM Test Case - Validation Instructions ===\");",
+              "console.log(\"Run ID: \" + jsonData.run_id);",
+              "console.log(\"\\nExpected Behavior:\");",
+              "console.log(\"- Density charts for overlapping segments show SUPERIMPOSED SPIKES\");",
+              "console.log(\"- First 30-60 minutes of course show HIGHEST CONCURRENCY\");",
+              "console.log(\"- Aid station timelines and traffic control shift logic maximally synchronized\");",
+              "console.log(\"- All three events start simultaneously at 07:00 (420 minutes)\");",
+              "console.log(\"\\nTo Validate:\");",
+              "console.log(\"1. Check runflow/\" + jsonData.run_id + \"/sun/reports/Density.md\");",
+              "console.log(\"2. Verify density spikes are superimposed (all events at same time)\");",
+              "console.log(\"3. Check runflow/\" + jsonData.run_id + \"/sun/reports/Flow.csv\");",
+              "console.log(\"4. Verify maximum co-presence in first 30-60 minutes\");",
+              "console.log(\"5. Compare with WIDEN and COMPRESS test cases\");"
+            ],
+            "type": "text/javascript"
+          }
+        }
+      ],
+      "request": {
+        "method": "POST",
+        "header": [
+          {
+            "key": "Content-Type",
+            "value": "application/json"
+          }
+        ],
+        "body": {
+          "mode": "raw",
+          "raw": "{\n  \"description\": \"Test Case 3: UNIFORM Start Times (Maximum Co-located Flow) with audit\",\n  \"segments_file\": \"segments_616.csv\",\n  \"flow_file\": \"flow_616.csv\",\n  \"locations_file\": \"locations_616.csv\",\n  \"enableAudit\": \"y\",\n  \"event_group\": {\n    \"sun-all\": \"full, 10k, half\"\n  },\n  \"events\": [\n    {\n      \"name\": \"full\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 390,\n      \"runners_file\": \"full_runners.csv\",\n      \"gpx_file\": \"full.gpx\"\n    },\n    {\n      \"name\": \"10k\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 120,\n      \"runners_file\": \"10k_runners.csv\",\n      \"gpx_file\": \"10k.gpx\"\n    },\n    {\n      \"name\": \"half\",\n      \"day\": \"sun\",\n      \"start_time\": 420,\n      \"event_duration_minutes\": 180,\n      \"runners_file\": \"half_runners.csv\",\n      \"gpx_file\": \"half.gpx\"\n    }\n  ]\n}"
+        },
+        "url": {
+          "raw": "{{base_url}}/runflow/v2/analyze",
+          "host": [
+            "{{base_url}}"
+          ],
+          "path": [
+            "runflow",
+            "v2",
+            "analyze"
+          ]
+        },
+        "description": "**Test Case 3: UNIFORM Start Times (Maximum Co-located Flow)**\n\n**Purpose:** Confirm system correctly handles identical start times for different events, resulting in total overlapping flow on shared segments.\n\n**Input:**\n- Full: 420 (7:00 AM)\n- 10K: 420 (7:00 AM)\n- Half: 420 (7:00 AM)\n\n**Expected Assertions:**\n- Density charts for overlapping segments should show **SUPERIMPOSED SPIKES**\n- First 30\u201360 minutes of the course show **HIGHEST CONCURRENCY**\n- Aid station timelines and traffic control shift logic (if modeled) should be **MAXIMALLY SYNCHRONIZED**\n\n**Validation:**\nAfter analysis completes, check:\n- `runflow/{run_id}/sun/reports/Density.md` - Superimposed density spikes\n- `runflow/{run_id}/sun/reports/Flow.csv` - Maximum co-presence in early segments\n- Compare with WIDEN and COMPRESS test cases"
+      },
+      "response": []
+    }
+  ],
+  "event": [
+    {
+      "listen": "prerequest",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    },
+    {
+      "listen": "test",
+      "script": {
+        "type": "text/javascript",
+        "exec": [
+          ""
+        ]
+      }
+    }
+  ],
+  "variable": [
+    {
+      "key": "base_url",
+      "value": "http://localhost:8080",
+      "type": "string"
+    }
+  ]
 }


### PR DESCRIPTION
### Motivation

- Move E2E scenarios to the new analysis config loader and enforce explicit `analysis.json` as the single source of truth so pipeline inputs are not implicitly defaulted.
- Make local development explicit about the data root so config paths resolve deterministically in containerized runs.
- Ensure Postman collections supply required config payloads (including alternate configs) and a request to fetch the generated `analysis.json` for debugging.
- Document required `analysis.json` fields and the fail-fast behavior of the new loader so developers understand validation expectations.

### Description

- Tests: `tests/v2/e2e.py` now imports and uses `app.config.loader.load_analysis_context` and `AnalysisConfigError`, and adds `_require_analysis_context()` which asserts `analysis.json` presence and required fields, with calls injected after the API returns `run_id` in all E2E scenarios.
- Dev env: `dev.env` now sets `DATA_ROOT=/app/data` so local runs use an explicit data root for resolving files.
- Postman: refreshed `postman/collections/Runflow-v2-API.postman_collection.json` to add an alternate Sat+Sun payload (616 variant), a `Fetch Analysis Config` GET request, and added a `run_id` variable; and updated `Runflow-v2-StartTime-Manipulation.postman_collection.json` to use the 616 data-file variants.
- Docs: `docs/dev-guides/developer-guide.md` was updated to list required `analysis.json` fields and note the loader’s fail-fast behavior when required fields are missing or invalid.

### Testing

- No automated test runs were executed as part of this change (no CI/test commands were run during the patch); local/manual verification is recommended to exercise `make e2e` / Postman flows against a running dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961cf8bed5c832291a25312cc719638)