### PR TITLE
Enforce SSOT fail-fast behavior, centralize AnalysisContext DataFrames, and remove silent fallbacks

### DIFF
--- a/app/api/map.py
+++ b/app/api/map.py
@@ -213,7 +213,7 @@ async def get_map_segments():
         if not segments_path.exists():
             raise HTTPException(status_code=404, detail=f"Segments metadata not found at {segments_path}")
 
-        segments_df = pd.read_csv(segments_path)
+        segments_df = analysis_context.get_segments_df()
         
         # Load GPX centerlines
         try:

--- a/app/core/artifacts/frontend.py
+++ b/app/core/artifacts/frontend.py
@@ -605,7 +605,6 @@ def generate_segments_geojson(reports_dir: Path) -> Dict[str, Any]:
         GeoJSON FeatureCollection with real course coordinates in Web Mercator (EPSG:3857)
     """
     from app.core.gpx.processor import load_all_courses, generate_segment_coordinates, create_geojson_from_segments
-    from app.io.loader import load_segments
     from pyproj import Transformer
     from app.utils.run_id import get_runflow_root
     
@@ -653,7 +652,7 @@ def generate_segments_geojson(reports_dir: Path) -> Dict[str, Any]:
     
     # Load segments data to get segment definitions
     try:
-        segments_df = load_segments(segments_csv_path)
+        segments_df = analysis_context.get_segments_df()
         segments_list = []
         for _, seg in segments_df.iterrows():
             seg_id = seg.get("seg_id")

--- a/app/core/artifacts/heatmaps.py
+++ b/app/core/artifacts/heatmaps.py
@@ -608,6 +608,7 @@ def load_segments_metadata(reports_dir: Optional[Path] = None, run_id: Optional[
         Dictionary mapping seg_id to metadata
     """
     segments_path = None
+    analysis_context = None
     
     # Issue #616: Get segments_csv_path from analysis.json
     if reports_dir is not None:
@@ -643,7 +644,10 @@ def load_segments_metadata(reports_dir: Optional[Path] = None, run_id: Optional[
     segments_meta = {}
     if segments_path.exists():
         try:
-            df = pd.read_csv(segments_path)
+            if analysis_context is not None:
+                df = analysis_context.get_segments_df()
+            else:
+                df = pd.read_csv(segments_path)
             for _, row in df.iterrows():
                 segments_meta[row.get('seg_id', '')] = {
                     'label': row.get('label', ''),

--- a/app/core/density/compute.py
+++ b/app/core/density/compute.py
@@ -176,7 +176,11 @@ def build_segment_context_v2(segment_id: str, segment_data: dict, summary_dict: 
         # Calculate flow rate from peak concurrency
         # Use active_peak_concurrency which is the correct field name
         peak_concurrency = summary_dict.get("active_peak_concurrency", 0)
-        width_m = segment_data.get("width_m", 1.0)
+        width_m = segment_data.get("width_m")
+        if width_m is None or (isinstance(width_m, float) and pd.isna(width_m)) or width_m <= 0:
+            raise ValueError(
+                f"Segment {segment_id} missing valid width_m for flow rate computation."
+            )
         from app.utils.constants import DEFAULT_BIN_TIME_WINDOW_SECONDS
         bin_seconds = DEFAULT_BIN_TIME_WINDOW_SECONDS  # Use constant (Issue #512)
         flow_rate = compute_flow_rate(peak_concurrency, width_m, bin_seconds)
@@ -201,7 +205,7 @@ def build_segment_context_v2(segment_id: str, segment_data: dict, summary_dict: 
         "segment_id": segment_id,
         "seg_label": segment_data.get("seg_label", "Unknown"),
         "segment_type": segment_data.get("segment_type", None),  # Optional field (not used for schema resolution)
-        "flow_type": segment_data.get("flow_type", "default"),
+        "flow_type": segment_data.get("flow_type"),
         
         # Schema information
         "schema_name": schema_name,

--- a/app/core/v2/pipeline.py
+++ b/app/core/v2/pipeline.py
@@ -798,7 +798,7 @@ def create_full_analysis_pipeline(
 
         # Load segments DataFrame
         segments_path_str = str(analysis_context.segments_csv_path)
-        segments_df = load_segments(segments_path_str)
+        segments_df = analysis_context.get_segments_df()
         logger.info(f"Loaded {len(segments_df)} segments from {segments_path_str}")
         
         # Load all runners for events (Phase 4)

--- a/app/core/v2/reports.py
+++ b/app/core/v2/reports.py
@@ -294,22 +294,10 @@ def generate_density_report_v2(
         
         # Get day-filtered segments
         if segments_df is None:
-            from app.io.loader import load_segments
-            # Issue #616: Use segments_file_path from analysis.json, fail if not provided
-            if segments_file_path is None:
-                error_msg = (
-                    "segments_df is None in generate_density_report_v2 and no segments_file_path provided. "
-                    "This should not happen in v2 pipeline - segments_df should be passed from pipeline. "
-                    "Cannot fall back to default CSV as it may not match the analysis configuration."
-                )
-                logger.error(error_msg)
-                raise ValueError(error_msg)
-            logger.warning(
-                f"segments_df is None in generate_density_report_v2 - falling back to {segments_file_path}. "
-                "This should not happen in v2 pipeline - segments_df should be passed from pipeline."
+            raise ValueError(
+                "segments_df is required in generate_density_report_v2. "
+                "Pass day-filtered segments from the pipeline; no CSV fallback is allowed."
             )
-            all_segments_df = load_segments(segments_file_path)
-            segments_df = filter_segments_by_events(all_segments_df, day_events)
         
         # Get list of day segment IDs
         day_segment_ids = set(segments_df['seg_id'].astype(str).unique())
@@ -666,22 +654,10 @@ def generate_locations_report_v2(
         # Issue #616: Get day-filtered segments if not provided
         # In v2 pipeline, segments_df should always be provided - this is a fallback only
         if segments_df is None:
-            from app.io.loader import load_segments
-            # Issue #616: Use segments_file_path from analysis.json if provided, otherwise fail
-            if segments_file_path is None:
-                error_msg = (
-                    "segments_df is None in generate_locations_report_v2 and no segments_file_path provided. "
-                    "This should not happen in v2 pipeline - segments_df should be passed from pipeline. "
-                    "Cannot fall back to default CSV as it may not match the analysis configuration."
-                )
-                logger.error(error_msg)
-                raise ValueError(error_msg)
-            logger.warning(
-                f"segments_df is None in generate_locations_report_v2 - falling back to {segments_file_path}. "
-                "This should not happen in v2 pipeline - segments_df should be passed from pipeline."
+            raise ValueError(
+                "segments_df is required in generate_locations_report_v2. "
+                "Pass day-filtered segments from the pipeline; no CSV fallback is allowed."
             )
-            all_segments_df = load_segments(segments_file_path)
-            segments_df = filter_segments_by_events(all_segments_df, day_events)
         
         # Get day segment IDs
         day_segment_ids = set(segments_df['seg_id'].astype(str).unique())
@@ -787,7 +763,10 @@ def generate_locations_report_v2(
                     output_dir=str(reports_path),
                     run_id=run_id,  # Issue #598: Pass run_id for flag propagation (loads flags.json)
                     day=day.value,  # Issue #598: Pass day for day-scoped flags.json path
-                    gpx_paths=gpx_paths
+                    gpx_paths=gpx_paths,
+                    locations_df=day_locations_df,
+                    runners_df=day_runners_df,
+                    segments_df=segments_df
                 )
                 logger.info(f"generate_location_report returned for day {day.value}: ok={result.get('ok', False)}")
             except Exception as e:

--- a/app/geo_utils.py
+++ b/app/geo_utils.py
@@ -251,7 +251,6 @@ def generate_bins_geojson(segments_data: Dict[str, SegmentBinData], analysis_con
     # Load real segment coordinates from GPX data
     try:
         from app.core.gpx.processor import load_all_courses, generate_segment_coordinates
-        from app.io.loader import load_segments
 
         if not analysis_context:
             raise ValueError("analysis_context is required for generate_bins_geojson.")
@@ -275,7 +274,7 @@ def generate_bins_geojson(segments_data: Dict[str, SegmentBinData], analysis_con
         courses = load_all_courses(gpx_paths)
 
         # Load segments data to get segment definitions
-        segments_df = load_segments(segments_csv_path)
+        segments_df = analysis_context.get_segments_df()
         segments_list = []
         for _, seg in segments_df.iterrows():
             seg_id = seg.get("seg_id")

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -647,7 +647,10 @@ def generate_location_report(
     output_dir: str = "reports",
     run_id: Optional[str] = None,
     day: Optional[str] = None,  # Issue #598: Day code for loading flags.json
-    gpx_paths: Optional[Dict[str, str]] = None
+    gpx_paths: Optional[Dict[str, str]] = None,
+    locations_df: Optional[pd.DataFrame] = None,
+    runners_df: Optional[pd.DataFrame] = None,
+    segments_df: Optional[pd.DataFrame] = None
 ) -> Dict[str, Any]:
     """
     Generate locations report with arrival modeling and operational timing.
@@ -677,11 +680,13 @@ def generate_location_report(
     
     logger.info("Starting location report generation...")
     
-    # Load data
     try:
-        locations_df = load_locations(locations_csv)
-        runners_df = load_runners(runners_csv)
-        segments_df = load_segments(segments_csv)
+        if locations_df is None:
+            locations_df = load_locations(locations_csv)
+        if runners_df is None:
+            runners_df = load_runners(runners_csv)
+        if segments_df is None:
+            segments_df = load_segments(segments_csv)
         if not gpx_paths:
             raise ValueError("gpx_paths is required for location report GPX loading.")
         courses = load_all_courses(gpx_paths)

--- a/app/rulebook.py
+++ b/app/rulebook.py
@@ -184,17 +184,13 @@ def get_thresholds(schema_key: str, path: Optional[str] = None) -> SchemaThresho
     """
     Get thresholds for a specific schema.
     
-    If schema_key not found, returns conservative defaults with no rate flagging.
+    Raises if schema_key is missing to prevent silent fallback.
     """
     idx = _threshold_index(path)
     if schema_key not in idx:
-        logger.warning(f"Schema '{schema_key}' not found in rulebook, using defaults")
-        # Fallback: use a conservative default LOS; no rate flags
-        return SchemaThresholds(
-            schema_key=schema_key,
-            los=LosBands(A=0.5, B=0.9, C=1.6, D=2.3, E=3.0, F=99.0),
-            flow_ref=None,
-            label=None
+        raise ValueError(
+            f"Schema '{schema_key}' not found in rulebook. "
+            "All schema keys must be defined; no defaults are allowed."
         )
     return idx[schema_key]
 

--- a/tests/v2/test_ssot_failfast.py
+++ b/tests/v2/test_ssot_failfast.py
@@ -1,0 +1,59 @@
+import pandas as pd
+import pytest
+
+from app.core.v2.flow import create_flow_segments_from_flow_csv
+from app.core.v2.models import Day, Event
+from app.new_flagging import _load_and_apply_segment_metadata
+from app.rulebook import get_thresholds
+
+
+def test_rulebook_missing_schema_raises() -> None:
+    with pytest.raises(ValueError, match="Schema 'unknown' not found"):
+        get_thresholds("unknown")
+
+
+def test_new_flagging_requires_width_m() -> None:
+    result_df = pd.DataFrame(
+        {
+            "segment_id": ["A1"],
+            "density": [1.0],
+            "rate": [0.5],
+        }
+    )
+    segments_df = pd.DataFrame(
+        {
+            "seg_id": ["A1"],
+            "seg_label": ["Start"],
+            "width_m": [None],
+            "schema": ["on_course_open"],
+        }
+    )
+
+    with pytest.raises(ValueError, match="Missing width_m for segments"):
+        _load_and_apply_segment_metadata(result_df, segments_df)
+
+
+def test_flow_segments_require_flow_type() -> None:
+    flow_rows = pd.DataFrame(
+        {
+            "seg_id": ["A1"],
+            "event_a": ["full"],
+            "event_b": ["half"],
+            "from_km_a": [0.0],
+            "to_km_a": [1.0],
+            "from_km_b": [0.0],
+            "to_km_b": [1.0],
+        }
+    )
+    segments_df = pd.DataFrame(
+        {
+            "seg_id": ["A1"],
+            "width_m": [4.0],
+            "direction": ["uni"],
+        }
+    )
+    event_a = Event(name="full", day=Day.SUN, start_time=0, gpx_file="full.gpx", runners_file="full.csv")
+    event_b = Event(name="half", day=Day.SUN, start_time=0, gpx_file="half.gpx", runners_file="half.csv")
+
+    with pytest.raises(ValueError, match="flow_type is required"):
+        create_flow_segments_from_flow_csv(flow_rows, event_a, event_b, segments_df)


### PR DESCRIPTION
### Motivation

- Finish Phase 5 SSOT enforcement by removing remaining silent fallbacks and making missing/invalid config fail fast. 
- Ensure `AnalysisContext` is the single source of truth for parsed data to eliminate redundant CSV reads and inconsistent internal reloads. 
- Harden flagging/flow/density/rulebook code paths so physical metadata (e.g., `width_m`, `direction`, `flow_type`, schema keys) cannot silently default. 
- Make v2 report flows pass shared DataFrames to legacy helpers to avoid internal file re-loads and preserve SSOT semantics.

### Description

- Add cached DataFrame accessors to `AnalysisContext` (`get_segments_df`, `get_flow_df`, `get_locations_df`, `get_runners_df`) and use them across the pipeline and artifact generation to avoid repeated CSV reads (`app/config/loader.py`, `app/core/v2/pipeline.py`, `app/api/map.py`, `app/core/artifacts/frontend.py`, `app/core/artifacts/heatmaps.py`, `app/geo_utils.py`).
- Replace silent default fallbacks with explicit errors in key code paths by enforcing presence/validity of `width_m`, `direction`, `flow_type`, and schema keys (`app/new_flagging.py`, `app/core/v2/flow.py`, `app/rulebook.py`, `app/core/density/compute.py`).
- Require `segments_df` to be passed from pipeline into v2 report generators and pass shared DataFrames into `generate_location_report` to avoid internal CSV reloads (`app/core/v2/reports.py`, `app/location_report.py`).
- Add a unit test file `tests/v2/test_ssot_failfast.py` that asserts fail-fast behavior for missing schema thresholds, missing `width_m`, and missing `flow_type` during flow creation.

### Testing

- Added unit tests at `tests/v2/test_ssot_failfast.py` covering rulebook lookup, flagging width validation, and flow `flow_type` validation. 
- No automated test run was executed as part of this change; CI/test execution should be performed after PR creation. 
- Static verification and local linting were not run within this rollout, so please run the repository test suite (`pytest`) and CI to validate integration with existing tests. 
- Manual inspection confirmed updated call sites now use `AnalysisContext` accessors instead of inline CSV reads.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69622b5be5108322bb36ea0cecc8b46c)