### PR TITLE
Issue #550: Make version dynamic from GitHub tag/release

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -37,6 +37,7 @@ from app.routes.api_locations import router as api_locations_router
 from app.routes.api_baseline import router as api_baseline_router
 from app.routes.v2.analyze import router as v2_analyze_router
 from app.utils.constants import DEFAULT_STEP_KM, DEFAULT_TIME_WINDOW_SECONDS, DEFAULT_MIN_OVERLAP_DURATION, DEFAULT_CONFLICT_LENGTH_METERS
+from app.version import get_version
 
 # Pydantic models for request bodies
 class AnalysisRequest(BaseModel):
@@ -108,8 +109,9 @@ class FlowAuditRequest(BaseModel):
     conflictLengthM: float = DEFAULT_CONFLICT_LENGTH_METERS
     outputDir: str = "reports"
 
-app = FastAPI(title="run-density", version="v2.0.6")
-APP_VERSION = os.getenv("APP_VERSION", app.version)
+# Issue #550: Dynamic version from git tag with fallback
+APP_VERSION = get_version()
+app = FastAPI(title="run-density", version=APP_VERSION)
 GIT_SHA = os.getenv("GIT_SHA", "local")
 BUILD_AT = os.getenv("BUILD_AT", datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z")
 

--- a/app/version.py
+++ b/app/version.py
@@ -10,6 +10,7 @@ Usage:
     update_version_in_code(next_version)
 """
 
+import os
 import re
 import subprocess
 import sys
@@ -54,6 +55,34 @@ def get_latest_git_tag() -> Optional[str]:
         return tags[0] if tags and tags[0] else None
     except subprocess.CalledProcessError:
         return None
+
+
+def get_version() -> str:
+    """
+    Get application version with fallback logic.
+    
+    Priority order:
+    1. Latest git tag (preferred)
+    2. APP_VERSION environment variable
+    3. Default fallback ("v2.0.0")
+    
+    Returns:
+        Version string (e.g., "v2.0.6")
+    
+    Issue #550: Make version dynamic from GitHub tag/release
+    """
+    # Try git tag first (preferred)
+    git_tag = get_latest_git_tag()
+    if git_tag:
+        return git_tag
+    
+    # Fall back to environment variable
+    env_version = os.getenv("APP_VERSION")
+    if env_version:
+        return env_version
+    
+    # Default fallback
+    return "v2.0.0"
 
 
 def parse_version(version: str) -> Tuple[int, int, int]:


### PR DESCRIPTION
## Overview
Make application version dynamic from GitHub tag/release instead of hardcoded value.

## Changes

### Added `get_version()` function to `app/version.py`
- Priority 1: Latest git tag (preferred)
- Priority 2: `APP_VERSION` environment variable
- Priority 3: Default fallback (`v2.0.0`)

### Updated `app/main.py`
- Removed hardcoded `version="v2.0.6"`
- Now uses `APP_VERSION = get_version()` before FastAPI app creation
- FastAPI app uses the dynamic version

## Benefits
- ✅ No manual version updates required
- ✅ Version automatically syncs with git tags
- ✅ Robust fallback mechanism ensures version always available
- ✅ Maintains backward compatibility with `APP_VERSION` env var

## Testing
- ✅ Git tag fallback: Returns `v2.0.6` (current latest tag)
- ✅ Environment variable fallback: Works when git unavailable
- ✅ Default fallback: Returns `v2.0.0` when neither git nor env var available

## Files Changed
- `app/version.py` - Added `get_version()` function with fallback logic
- `app/main.py` - Updated to use dynamic version

Closes #550