### PR TITLE
Issue #691: Add clarifications to Flow Reference table for same-event, short segments

### DIFF
--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -66,7 +66,7 @@
             </tr>
             <tr>
                 <td><strong>Overtaking A / Overtaking B</strong></td>
-                <td>The number of overtake events detected where runners in Event A (or B) passed participants from the paired event within that segment.</td>
+                <td>The number of overtake events detected where runners in Event A (or B) passed participants from the paired event within that segment.<br><br><em><strong>Note:</strong> When Event A = Event B, particularly on short segments near the start of a race, overtaking counts may be influenced by start offsets (staggered start times). Faster runners starting later can legitimately overtake slower runners who started earlier, even when average pace data is used.</em></td>
             </tr>
             <tr>
                 <td><strong>Pct A / Pct B</strong></td>
@@ -74,7 +74,7 @@
             </tr>
             <tr>
                 <td><strong>Co-presence A / Co-presence B</strong></td>
-                <td>The number of times participants from Event A and Event B occupied the same segment simultaneously (a measure of concurrent use or congestion).</td>
+                <td>The number of times participants from Event A and Event B occupied the same segment simultaneously (a measure of concurrent use or congestion).<br><br><em><strong>Note:</strong> When Event A = Event B on short, early-race segments, co-presence counts can be elevated due to dense start conditions and staggered start offsets, where many participants occupy the segment simultaneously before spacing naturally increases.</em></td>
             </tr>
         </tbody>
     </table>


### PR DESCRIPTION
## Summary

Adds clarifying notes to the Flow Reference table explaining why overtaking and co-presence counts may be elevated on same-event, short segments near the race start.

## Changes

- Added note to **Overtaking A / Overtaking B** definition explaining start offset effects
- Added note to **Co-presence A / Co-presence B** definition explaining elevated counts due to dense start conditions

## Rationale

Users viewing the Flow UI may be surprised by high overtaking and co-presence counts on same-event segments (Event A = Event B) that are short and near the start line. These notes clarify that:

1. High counts are legitimate and reflect real runner dynamics
2. Start offsets (staggered start times) can influence overtaking counts
3. Dense start conditions create elevated co-presence on early-race segments

## Related

- Issue #690 - Validated that overtaking counts are correct as designed
- Investigation confirmed start_offset is primary factor (see Issue #690 comments)

## Testing

- ✅ Manual review of HTML formatting
- ✅ Notes appear in correct location within reference table
- ✅ Wording matches Issue #691 specifications

Closes #691