### PR TITLE
Fix segments heatmap preview paths

### DIFF
--- a/frontend/static/js/map/segments.js
+++ b/frontend/static/js/map/segments.js
@@ -468,7 +468,7 @@ function updateFilterUI(segmentId) {
 
 /**
  * Attempt to show heatmap preview for a segment
- * Looks for runflow/{run_id}/{day}/ui/heatmaps/{seg_id}.png
+ * Looks for runflow/analysis/{run_id}/{day}/ui/visualizations/{seg_id}.png
  */
 async function showHeatmapPreview(segmentId) {
     const overlay = document.getElementById('heatmap-overlay');
@@ -500,11 +500,21 @@ async function showHeatmapPreview(segmentId) {
     const bases = [
         // Preferred mount: FastAPI mounts RUNFLOW_ROOT at /heatmaps
         // Issue #580: Updated path to visualizations/ subdirectory
+        // Issue #682: Updated to use runflow/analysis/{run_id} structure
+        `/heatmaps/analysis/${runId}/${day}/ui/visualizations/`,
+        `/heatmaps/analysis/${runId}/${day}/ui/heatmaps/`,
+        `/heatmaps/analysis/${runId}/heatmaps/`,
+        `/heatmaps/analysis/${runId}/ui/heatmaps/`,
+        // Legacy (pre-#682) runflow root without /analysis
         `/heatmaps/${runId}/${day}/ui/visualizations/`,
         `/heatmaps/${runId}/${day}/ui/heatmaps/`,
         `/heatmaps/${runId}/heatmaps/`,
         `/heatmaps/${runId}/ui/heatmaps/`,
         // Legacy direct paths
+        `/runflow/analysis/${runId}/${day}/ui/visualizations/`,
+        `/runflow/analysis/${runId}/${day}/ui/heatmaps/`,
+        `/runflow/analysis/${runId}/heatmaps/`,
+        `/runflow/analysis/${runId}/ui/heatmaps/`,
         `/runflow/${runId}/${day}/ui/visualizations/`,
         `/runflow/${runId}/${day}/ui/heatmaps/`,
         `/runflow/${runId}/heatmaps/`,

--- a/frontend/templates/pages/segments.html
+++ b/frontend/templates/pages/segments.html
@@ -148,7 +148,7 @@
 
 <!-- External JavaScript modules (cache-busted for latest fixes) -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/segments.js?v=2025-12-13T2125Z"></script>
+<script src="/static/js/map/segments.js?v=2026-01-24T1145Z"></script>
 
 <!-- Table interaction script -->
 <script>


### PR DESCRIPTION
## Summary
- add /analysis-based heatmap path candidates for segment preview tiles
- update cache-buster for segments map script

## Test plan
- [x] Manual: verified heatmap preview appears for efvoaeqAjVfXKJtYw4bQWq (sun)