### PR TITLE
Add locations course overlay

### DIFF
--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -215,7 +215,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-01-24T1134Z"></script>
+<script src="/static/js/map/locations.js?v=2026-01-23T1730Z"></script>
 
 <!-- Table interaction script -->
 <script>


### PR DESCRIPTION
## Summary
- render a dashed green segments overlay on the Locations map using the existing day/run geojson endpoint
- keep the overlay beneath markers with subtle styling
- refresh locations.js cache-buster

## Test plan
- [x] Manual: load `http://localhost:8080/locations?day=sun&run_id=<run_id>` and confirm overlay + marker interactivity