### PR TITLE
Add bidirectional overlap reports and UI (Issue #720)

### DIFF
--- a/app/api/bidirectional.py
+++ b/app/api/bidirectional.py
@@ -1,0 +1,149 @@
+"""
+API Routes for Bidirectional Overlap Data (Issue #720)
+"""
+
+from fastapi import APIRouter, HTTPException, Query
+from fastapi.responses import JSONResponse
+from typing import Any, Dict, List, Optional
+import csv
+import logging
+
+from app.storage import create_runflow_storage
+from app.utils.constants import REPORTS_OVERLAPS_DIRNAME, REPORTS_OVERLAPS_SUMMARY_FILENAME
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _empty_overlap_payload(selected_day: str, available_days: List[str]) -> JSONResponse:
+    return JSONResponse(content={
+        "selected_day": selected_day,
+        "available_days": available_days,
+        "overlaps": {
+            "analyzed_count": 0,
+            "overlap_count": 0,
+            "segments": []
+        }
+    })
+
+
+def _load_overlap_summary(storage, selected_day: str) -> Optional[Dict[str, Any]]:
+    summary_path = f"{selected_day}/reports/{REPORTS_OVERLAPS_DIRNAME}/{REPORTS_OVERLAPS_SUMMARY_FILENAME}"
+    if not storage.exists(summary_path):
+        return None
+    try:
+        return storage.read_json(summary_path)
+    except Exception as e:
+        logger.warning(f"Failed to load overlaps_summary.json for {selected_day}: {e}")
+        return None
+
+
+@router.get("/api/bidirectional/segments")
+async def get_bidirectional_segments(
+    run_id: Optional[str] = Query(None, description="Run ID (defaults to latest)"),
+    day: Optional[str] = Query(None, description="Day code (fri|sat|sun|mon)")
+):
+    try:
+        from app.utils.run_id import get_latest_run_id, resolve_selected_day
+
+        if not run_id:
+            run_id = get_latest_run_id()
+        selected_day, available_days = resolve_selected_day(run_id, day)
+        storage = create_runflow_storage(run_id)
+
+        summary = _load_overlap_summary(storage, selected_day)
+        if not summary:
+            return _empty_overlap_payload(selected_day, available_days)
+
+        response = JSONResponse(content={
+            "selected_day": selected_day,
+            "available_days": available_days,
+            "overlaps": {
+                "analyzed_count": summary.get("analyzed_count", 0),
+                "overlap_count": summary.get("overlap_count", 0),
+                "segments": summary.get("segments", []),
+            }
+        })
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return response
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error loading bidirectional segments: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to load bidirectional segments: {str(e)}")
+
+
+@router.get("/api/bidirectional/segment/{seg_id}")
+async def get_bidirectional_segment_detail(
+    seg_id: str,
+    run_id: Optional[str] = Query(None, description="Run ID (defaults to latest)"),
+    day: Optional[str] = Query(None, description="Day code (fri|sat|sun|mon)"),
+    event_a: Optional[str] = Query(None, description="Event A name"),
+    event_b: Optional[str] = Query(None, description="Event B name"),
+):
+    try:
+        from app.utils.run_id import get_latest_run_id, resolve_selected_day
+
+        if not run_id:
+            run_id = get_latest_run_id()
+        selected_day, available_days = resolve_selected_day(run_id, day)
+        storage = create_runflow_storage(run_id)
+
+        summary = _load_overlap_summary(storage, selected_day)
+        if not summary:
+            raise HTTPException(status_code=404, detail="No overlap summary available")
+
+        segments = summary.get("segments", [])
+        seg_matches = [
+            seg for seg in segments
+            if str(seg.get("seg_id")) == str(seg_id)
+            and (event_a is None or str(seg.get("event_a")) == str(event_a))
+            and (event_b is None or str(seg.get("event_b")) == str(event_b))
+        ]
+        if not seg_matches:
+            raise HTTPException(status_code=404, detail=f"Segment {seg_id} not found in overlap summary")
+        if len(seg_matches) > 1 and (event_a is None or event_b is None):
+            raise HTTPException(status_code=400, detail="event_a and event_b are required for this segment")
+
+        segment = seg_matches[0]
+        if not segment.get("event_a_label"):
+            segment["event_a_label"] = segment.get("event_a")
+        if not segment.get("event_b_label"):
+            segment["event_b_label"] = segment.get("event_b")
+        csv_filename = segment.get("csv_filename")
+        if not csv_filename:
+            raise HTTPException(status_code=404, detail="Overlap CSV not found for segment")
+
+        csv_path = f"{selected_day}/reports/{REPORTS_OVERLAPS_DIRNAME}/{csv_filename}"
+        if not storage.exists(csv_path):
+            raise HTTPException(status_code=404, detail="Overlap CSV missing")
+
+        csv_text = storage.read_text(csv_path)
+        reader = csv.DictReader(csv_text.splitlines())
+        rows = []
+        for row in reader:
+            parsed = dict(row)
+            for key, value in row.items():
+                if key.endswith("_count") or key.endswith("_entries") or key.endswith("_exits"):
+                    try:
+                        parsed[key] = int(value)
+                    except Exception:
+                        parsed[key] = 0
+            rows.append(parsed)
+
+        response = JSONResponse(content={
+            "selected_day": selected_day,
+            "available_days": available_days,
+            "segment": segment,
+            "rows": rows
+        })
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return response
+    except HTTPException:
+        raise
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error(f"Error loading bidirectional segment detail: {e}")
+        raise HTTPException(status_code=500, detail=f"Failed to load bidirectional segment: {str(e)}")

--- a/app/core/v2/overlaps.py
+++ b/app/core/v2/overlaps.py
@@ -1,0 +1,307 @@
+"""
+Bidirectional overlap reports for Flow UI (Issue #720).
+
+Generates per-minute counts, entries, and exits for event pairs marked
+as bidirectional in flow.csv, and writes CSVs + summary metadata.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+import csv
+import logging
+import math
+
+import numpy as np
+import pandas as pd
+
+from app.core.v2.models import Day, Event
+from app.utils.constants import (
+    REPORTS_OVERLAPS_DIRNAME,
+    REPORTS_OVERLAPS_SUMMARY_FILENAME,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class OverlapSummary:
+    seg_id: str
+    seg_label: str
+    event_a: str
+    event_b: str
+    event_a_label: str
+    event_b_label: str
+    from_km_a: float
+    to_km_a: float
+    from_km_b: float
+    to_km_b: float
+    overlap_start: str
+    overlap_end: str
+    overlap_duration_minutes: float
+    peak_concurrent_a: int
+    peak_concurrent_b: int
+    csv_filename: str
+
+
+def _require_columns(df: pd.DataFrame, columns: List[str], label: str) -> None:
+    missing = [col for col in columns if col not in df.columns]
+    if missing:
+        raise ValueError(f"{label} missing required columns: {', '.join(missing)}")
+
+
+def _normalize_event_name(value: Any) -> str:
+    return str(value).strip().lower()
+
+
+def _format_hhmm_from_seconds(seconds_since_midnight: float) -> str:
+    minutes = int(max(0, seconds_since_midnight) // 60)
+    hours = minutes // 60
+    mins = minutes % 60
+    return f"{hours:02d}:{mins:02d}"
+
+
+def _compute_entry_exit_seconds(
+    runners_df: pd.DataFrame,
+    start_time_minutes: float,
+    from_km: float,
+    to_km: float,
+) -> Tuple[np.ndarray, np.ndarray]:
+    _require_columns(runners_df, ["pace", "start_offset"], "runners data")
+    pace_values = pd.to_numeric(runners_df["pace"], errors="coerce")
+    if pace_values.isna().any() or (pace_values <= 0).any():
+        raise ValueError("runners data missing valid pace values for overlap report generation.")
+    pace_sec_per_km = pace_values.to_numpy() * 60.0
+    start_offset_sec = pd.to_numeric(runners_df["start_offset"], errors="coerce").fillna(0).to_numpy()
+    start_time_sec = float(start_time_minutes) * 60.0
+    entry_times = start_time_sec + start_offset_sec + pace_sec_per_km * float(from_km)
+    exit_times = start_time_sec + start_offset_sec + pace_sec_per_km * float(to_km)
+    return entry_times, exit_times
+
+
+def _minute_series(
+    entry_times: np.ndarray,
+    exit_times: np.ndarray,
+    start_sec: float,
+    end_sec: float,
+) -> Tuple[List[float], List[Dict[str, int]]]:
+    if entry_times.size == 0 or exit_times.size == 0:
+        return [], []
+
+    entry_sorted = np.sort(entry_times)
+    exit_sorted = np.sort(exit_times)
+
+    start_floor = int(math.floor(start_sec / 60.0) * 60)
+    end_ceil = int(math.ceil(end_sec / 60.0) * 60)
+    if end_ceil <= start_floor:
+        return [], []
+
+    minute_starts = list(range(start_floor, end_ceil, 60))
+    metrics: List[Dict[str, int]] = []
+
+    for minute_start in minute_starts:
+        minute_end = minute_start + 60
+        entries = int(np.searchsorted(entry_sorted, minute_end, side="left") - np.searchsorted(entry_sorted, minute_start, side="left"))
+        exits = int(np.searchsorted(exit_sorted, minute_end, side="left") - np.searchsorted(exit_sorted, minute_start, side="left"))
+        concurrent = int(np.searchsorted(entry_sorted, minute_end, side="left") - np.searchsorted(exit_sorted, minute_start, side="left"))
+        metrics.append({"concurrent": concurrent, "entries": entries, "exits": exits})
+
+    return [float(s) for s in minute_starts], metrics
+
+
+def _write_overlap_csv(
+    output_dir: Path,
+    seg_id: str,
+    event_a: str,
+    event_b: str,
+    event_a_label: str,
+    event_b_label: str,
+    minute_starts: List[float],
+    metrics_a: List[Dict[str, int]],
+    metrics_b: List[Dict[str, int]],
+) -> str:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    csv_filename = f"{seg_id}_per_minute.csv"
+    csv_path = output_dir / csv_filename
+
+    headers = [
+        "minute_start",
+        "minute_end",
+        f"{event_a_label}_count",
+        f"{event_a_label}_entries",
+        f"{event_a_label}_exits",
+        f"{event_b_label}_count",
+        f"{event_b_label}_entries",
+        f"{event_b_label}_exits",
+    ]
+
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.writer(handle)
+        writer.writerow(headers)
+        for idx, minute_start in enumerate(minute_starts):
+            minute_end = minute_start + 60
+            row = [
+                _format_hhmm_from_seconds(minute_start),
+                _format_hhmm_from_seconds(minute_end),
+                metrics_a[idx]["concurrent"],
+                metrics_a[idx]["entries"],
+                metrics_a[idx]["exits"],
+                metrics_b[idx]["concurrent"],
+                metrics_b[idx]["entries"],
+                metrics_b[idx]["exits"],
+            ]
+            writer.writerow(row)
+
+    return csv_filename
+
+
+def generate_bidirectional_overlap_reports(
+    *,
+    run_id: str,
+    day: Day,
+    day_events: List[Event],
+    analysis_context: Any,
+    all_runners_df: pd.DataFrame,
+    reports_dir: Path,
+    segments_df: Optional[pd.DataFrame] = None,
+) -> Dict[str, Any]:
+    """
+    Generate per-minute overlap CSVs and a summary JSON for bidirectional segments.
+    """
+    if analysis_context is None:
+        raise ValueError("analysis_context is required for overlap report generation.")
+
+    flow_df = analysis_context.get_flow_df()
+    _require_columns(
+        flow_df,
+        ["seg_id", "event_a", "event_b", "from_km_a", "to_km_a", "from_km_b", "to_km_b", "direction"],
+        "flow.csv",
+    )
+    _require_columns(all_runners_df, ["event", "pace", "start_offset"], "runners data")
+
+    day_event_names = {event.name.lower() for event in day_events}
+    flow_df = flow_df.copy()
+    flow_df["event_a_norm"] = flow_df["event_a"].map(_normalize_event_name)
+    flow_df["event_b_norm"] = flow_df["event_b"].map(_normalize_event_name)
+    flow_df["direction_norm"] = flow_df["direction"].astype(str).str.strip().str.lower()
+
+    eligible = flow_df[
+        flow_df["event_a_norm"].isin(day_event_names)
+        & flow_df["event_b_norm"].isin(day_event_names)
+        & (flow_df["direction_norm"] == "bi")
+    ].copy()
+
+    analyzed_count = int(len(eligible))
+    overlap_count = 0
+    summaries: List[OverlapSummary] = []
+
+    start_times = {event.name.lower(): float(event.start_time) for event in day_events}
+    overlaps_dir = reports_dir / REPORTS_OVERLAPS_DIRNAME
+
+    for _, row in eligible.iterrows():
+        seg_id = str(row["seg_id"])
+        event_a = str(row["event_a_norm"])
+        event_b = str(row["event_b_norm"])
+        event_a_label = event_a
+        event_b_label = event_b
+        if event_a == event_b:
+            event_a_label = f"{event_a}_a"
+            event_b_label = f"{event_b}_b"
+
+        if event_a not in start_times or event_b not in start_times:
+            raise ValueError(f"Missing start_time for event pair {event_a}/{event_b} in day {day.value}.")
+
+        runners_a = all_runners_df[all_runners_df["event"].astype(str).str.lower() == event_a]
+        runners_b = all_runners_df[all_runners_df["event"].astype(str).str.lower() == event_b]
+        if runners_a.empty or runners_b.empty:
+            continue
+
+        from_km_a = float(row["from_km_a"])
+        to_km_a = float(row["to_km_a"])
+        from_km_b = float(row["from_km_b"])
+        to_km_b = float(row["to_km_b"])
+
+        entry_a, exit_a = _compute_entry_exit_seconds(runners_a, start_times[event_a], from_km_a, to_km_a)
+        entry_b, exit_b = _compute_entry_exit_seconds(runners_b, start_times[event_b], from_km_b, to_km_b)
+        if entry_a.size == 0 or entry_b.size == 0:
+            continue
+
+        overlap_start = max(float(entry_a.min()), float(entry_b.min()))
+        overlap_end = min(float(exit_a.max()), float(exit_b.max()))
+        if overlap_end <= overlap_start:
+            continue
+
+        overlap_count += 1
+
+        time_start = min(float(entry_a.min()), float(entry_b.min()))
+        time_end = max(float(exit_a.max()), float(exit_b.max()))
+        minute_starts, metrics_a = _minute_series(entry_a, exit_a, time_start, time_end)
+        _, metrics_b = _minute_series(entry_b, exit_b, time_start, time_end)
+
+        csv_filename = _write_overlap_csv(
+            overlaps_dir,
+            seg_id,
+            event_a,
+            event_b,
+            event_a_label,
+            event_b_label,
+            minute_starts,
+            metrics_a,
+            metrics_b,
+        )
+
+        seg_label = str(row.get("seg_label") or "")
+        if not seg_label and segments_df is not None and "seg_label" in segments_df.columns:
+            seg_match = segments_df[segments_df["seg_id"] == seg_id]
+            if not seg_match.empty:
+                seg_label = str(seg_match.iloc[0].get("seg_label", ""))
+
+        summaries.append(
+            OverlapSummary(
+                seg_id=seg_id,
+                seg_label=seg_label,
+                event_a=event_a,
+                event_b=event_b,
+                event_a_label=event_a_label,
+                event_b_label=event_b_label,
+                from_km_a=from_km_a,
+                to_km_a=to_km_a,
+                from_km_b=from_km_b,
+                to_km_b=to_km_b,
+                overlap_start=_format_hhmm_from_seconds(overlap_start),
+                overlap_end=_format_hhmm_from_seconds(overlap_end),
+                overlap_duration_minutes=round((overlap_end - overlap_start) / 60.0, 2),
+                peak_concurrent_a=max(m["concurrent"] for m in metrics_a) if metrics_a else 0,
+                peak_concurrent_b=max(m["concurrent"] for m in metrics_b) if metrics_b else 0,
+                csv_filename=csv_filename,
+            )
+        )
+
+    summary_payload = {
+        "run_id": run_id,
+        "day": day.value,
+        "analyzed_count": analyzed_count,
+        "overlap_count": overlap_count,
+        "segments": [summary.__dict__ for summary in summaries],
+    }
+
+    overlaps_dir.mkdir(parents=True, exist_ok=True)
+    summary_path = overlaps_dir / REPORTS_OVERLAPS_SUMMARY_FILENAME
+    summary_path.write_text(
+        json_dumps(summary_payload),
+        encoding="utf-8",
+    )
+
+    logger.info(
+        f"✅ Bidirectional overlap reports generated for day {day.value}: "
+        f"{overlap_count}/{analyzed_count} segments with overlap"
+    )
+    return summary_payload
+
+
+def json_dumps(payload: Dict[str, Any]) -> str:
+    import json
+
+    return json.dumps(payload, indent=2)

--- a/app/main.py
+++ b/app/main.py
@@ -29,6 +29,7 @@ from app.routes.api_dashboard import router as api_dashboard_router
 from app.routes.api_health import router as api_health_router
 from app.routes.api_density import router as api_density_router
 from app.routes.api_flow import router as api_flow_router
+from app.routes.api_bidirectional import router as api_bidirectional_router
 from app.routes.api_reports import router as api_reports_router
 from app.routes.api_bins import router as api_bins_router
 # Phase 3 cleanup: Removed api_heatmaps_router import (endpoint unused)
@@ -142,6 +143,7 @@ app.include_router(api_dashboard_router)
 app.include_router(api_health_router)
 app.include_router(api_density_router)
 app.include_router(api_flow_router)
+app.include_router(api_bidirectional_router)
 app.include_router(api_reports_router)
 app.include_router(api_bins_router)
 # Phase 3 cleanup: Removed api_heatmaps_router registration (endpoint unused, frontend uses static file serving)

--- a/app/routes/api_bidirectional.py
+++ b/app/routes/api_bidirectional.py
@@ -1,0 +1,9 @@
+"""
+DEPRECATED - Logic moved to api/bidirectional.py
+
+This module is maintained for backward compatibility.
+All functionality has been moved to the api package.
+"""
+
+# DEPRECATED – logic moved to api/bidirectional.py
+from app.api.bidirectional import *  # noqa: F401,F403

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -177,6 +177,10 @@ GCS_BUCKET_RUNFLOW = "runflow"  # New UUID-based structure
 RUNFLOW_ROOT_LOCAL = "/Users/jthompson/Documents/runflow"  # Must match docker-compose.yml volume mount
 RUNFLOW_ROOT_CONTAINER = "/app/runflow"
 
+# Reports subdirectories
+REPORTS_OVERLAPS_DIRNAME = "overlaps"
+REPORTS_OVERLAPS_SUMMARY_FILENAME = "overlaps_summary.json"
+
 # Data directory path (Issue #596)
 DATA_DIR = "data"
 

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -9,6 +9,54 @@
     {% endif %}
 </div>
 
+<!-- Flow Overlaps -->
+<div class="card">
+    <h3 style="margin-bottom: 0.5rem;">Flow Overlaps</h3>
+    <p id="overlap-note" style="margin-bottom: 1rem; color: #7f8c8d; font-size: 0.875rem;">
+        Loading overlap summary...
+    </p>
+    <div class="scrollable-table-container overlap-table-container">
+        <table id="overlap-table" class="table-sticky-header">
+            <thead>
+                <tr>
+                    <th>ID</th>
+                    <th>NAME</th>
+                    <th>EVENTS</th>
+                    <th>OVERLAP</th>
+                    <th>DURATION</th>
+                    <th>PEAK</th>
+                </tr>
+            </thead>
+            <tbody id="overlap-tbody">
+                <tr>
+                    <td colspan="6" class="placeholder">Loading overlap data...</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <div id="overlap-detail" class="overlap-detail" style="display:none;">
+        <h4 style="margin: 1rem 0 0.5rem 0;">Bidirectional Overlap</h4>
+        <div id="overlap-detail-meta" style="margin-bottom: 0.75rem; color: #2c3e50;"></div>
+        <div id="overlap-chart" class="overlap-chart"></div>
+        <div class="scrollable-table-container overlap-detail-table-container" style="margin-top: 0.75rem;">
+            <table id="overlap-detail-table" class="table-sticky-header">
+                <thead>
+                    <tr>
+                        <th>MINUTE</th>
+                        <th id="overlap-col-a">A</th>
+                        <th id="overlap-col-b">B</th>
+                    </tr>
+                </thead>
+                <tbody id="overlap-detail-tbody">
+                    <tr>
+                        <td colspan="3" class="placeholder">Select a segment to view per-minute overlaps.</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
+    </div>
+</div>
+
 <!-- Flow Metrics Table -->
 <div class="card">
     <h3 style="margin-bottom: 1rem;">Segment Flow Metrics</h3>
@@ -86,11 +134,13 @@
 <script>
     let flowData = {};
     let currentSort = { column: null, direction: 'asc' }; // 'asc' or 'desc' (Issue #596: Fix - moved outside DOMContentLoaded)
+    let overlapSummary = null;
     
     // Load flow data on page load
     document.addEventListener('DOMContentLoaded', function() {
         initializeSorting();
         loadFlowData();
+        loadOverlapData();
     });
     
     function loadFlowData() {
@@ -394,6 +444,237 @@
         const tbody = document.getElementById('flow-tbody');
         tbody.innerHTML = '<tr><td colspan="9" class="placeholder">Error loading flow data</td></tr>';
     }
+
+    function loadOverlapData() {
+        const params = new URLSearchParams(window.location.search);
+        const dayParam = params.get('day');
+        const runParam = params.get('run_id');
+        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
+        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
+
+        if (!day || !run_id) {
+            console.error('❌ Refusing to fetch overlap data without day+run_id', { day, run_id });
+            showOverlapError();
+            return;
+        }
+
+        const apiUrl = `/api/bidirectional/segments?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        fetch(apiUrl, { cache: 'no-store' })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`API returned ${response.status}: ${response.statusText}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                overlapSummary = data.overlaps || { analyzed_count: 0, overlap_count: 0, segments: [] };
+                renderOverlapTable(overlapSummary);
+            })
+            .catch(error => {
+                console.error('Error loading overlap data:', error);
+                showOverlapError();
+            });
+    }
+
+    function renderOverlapTable(overlaps) {
+        const tbody = document.getElementById('overlap-tbody');
+        const note = document.getElementById('overlap-note');
+        tbody.innerHTML = '';
+
+        const analyzed = overlaps.analyzed_count || 0;
+        const overlapCount = overlaps.overlap_count || 0;
+        note.textContent = `${analyzed} flow segments analyzed for overlaps, ${overlapCount} segments with non-zero overlaps`;
+
+        const segments = overlaps.segments || [];
+        if (segments.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="6" class="placeholder">No bidirectional overlaps detected</td></tr>';
+            return;
+        }
+
+        segments.forEach(segment => {
+            const row = document.createElement('tr');
+            row.className = 'overlap-row';
+            row.dataset.segId = segment.seg_id;
+            row.dataset.eventA = segment.event_a;
+            row.dataset.eventB = segment.event_b;
+            row.innerHTML = `
+                <td>${segment.seg_id || "—"}</td>
+                <td>${segment.seg_label || "—"}</td>
+                <td>${segment.event_a || "—"} / ${segment.event_b || "—"}</td>
+                <td>${segment.overlap_start || "—"}–${segment.overlap_end || "—"}</td>
+                <td>${segment.overlap_duration_minutes || 0} min</td>
+                <td>${segment.peak_concurrent_a || 0} / ${segment.peak_concurrent_b || 0}</td>
+            `;
+            row.addEventListener('click', function() {
+                loadOverlapDetail(segment);
+                highlightSelectedOverlapRow(row);
+            });
+            tbody.appendChild(row);
+        });
+    }
+
+    function highlightSelectedOverlapRow(row) {
+        document.querySelectorAll('.overlap-row').forEach(r => r.classList.remove('selected'));
+        row.classList.add('selected');
+    }
+
+    function loadOverlapDetail(segment) {
+        const params = new URLSearchParams(window.location.search);
+        const dayParam = params.get('day');
+        const runParam = params.get('run_id');
+        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
+        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
+        if (!day || !run_id) {
+            showOverlapError();
+            return;
+        }
+
+        const apiUrl = `/api/bidirectional/segment/${encodeURIComponent(segment.seg_id)}?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}&event_a=${encodeURIComponent(segment.event_a)}&event_b=${encodeURIComponent(segment.event_b)}`;
+        fetch(apiUrl, { cache: 'no-store' })
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error(`API returned ${response.status}: ${response.statusText}`);
+                }
+                return response.json();
+            })
+            .then(data => {
+                renderOverlapDetail(data.segment, data.rows || []);
+            })
+            .catch(error => {
+                console.error('Error loading overlap detail:', error);
+                showOverlapError();
+            });
+    }
+
+    function renderOverlapDetail(segment, rows) {
+        const detail = document.getElementById('overlap-detail');
+        const meta = document.getElementById('overlap-detail-meta');
+        const chart = document.getElementById('overlap-chart');
+        const tbody = document.getElementById('overlap-detail-tbody');
+        const colA = document.getElementById('overlap-col-a');
+        const colB = document.getElementById('overlap-col-b');
+
+        detail.style.display = '';
+        meta.innerHTML = buildOverlapMeta(segment);
+        const eventKeyA = segment.event_a_label || segment.event_a;
+        const eventKeyB = segment.event_b_label || segment.event_b;
+        colA.textContent = `${eventKeyA} (count / entries / exits)`;
+        colB.textContent = `${eventKeyB} (count / entries / exits)`;
+
+        tbody.innerHTML = '';
+        if (!rows || rows.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="3" class="placeholder">No per-minute overlap data available</td></tr>';
+            chart.innerHTML = '';
+            return;
+        }
+
+        rows.forEach(row => {
+            const tr = document.createElement('tr');
+            tr.innerHTML = `
+                <td>${row.minute_start}–${row.minute_end}</td>
+                <td class="numeric-pair">${row[`${eventKeyA}_count`]} / ${row[`${eventKeyA}_entries`]} / ${row[`${eventKeyA}_exits`]}</td>
+                <td class="numeric-pair">${row[`${eventKeyB}_count`]} / ${row[`${eventKeyB}_entries`]} / ${row[`${eventKeyB}_exits`]}</td>
+            `;
+            tbody.appendChild(tr);
+        });
+
+        chart.innerHTML = buildOverlapChart(rows, segment, eventKeyA, eventKeyB);
+    }
+
+    function buildOverlapMeta(segment) {
+        const segLabel = segment.seg_label ? ` — ${segment.seg_label}` : '';
+        const rangeA = `${segment.event_a} ${segment.from_km_a}–${segment.to_km_a} km`;
+        const rangeB = `${segment.event_b} ${segment.from_km_b}–${segment.to_km_b} km`;
+        const title = `Bidirectional Overlap — ${segment.seg_id}${segLabel} (${rangeA}, ${rangeB})`;
+        const timeRange = `${segment.overlap_start}–${segment.overlap_end}`;
+        return `<div class="overlap-title">${escapeHtml(title)}</div><div class="overlap-time">${escapeHtml(timeRange)}</div>`;
+    }
+
+    function buildOverlapChart(rows, segment, eventKeyA, eventKeyB) {
+        const width = 1050;
+        const height = 210;
+        const padding = 39;
+        const eventA = segment.event_a;
+        const eventB = segment.event_b;
+        const countsA = rows.map(r => r[`${eventKeyA}_count`] || 0);
+        const countsB = rows.map(r => r[`${eventKeyB}_count`] || 0);
+        const overlapCounts = countsA.map((val, idx) => Math.min(val, countsB[idx]));
+        const maxCount = Math.max(1, ...countsA, ...countsB);
+        const xStep = rows.length > 1 ? (width - padding * 2) / (rows.length - 1) : 0;
+        const axisY = height - padding;
+        const axisX = padding;
+        const labelY = height - 12;
+
+        const points = (counts, color) => {
+            const path = counts.map((val, idx) => {
+                const x = padding + idx * xStep;
+                const y = height - padding - (val / maxCount) * (height - padding * 2);
+                return `${idx === 0 ? 'M' : 'L'}${x.toFixed(1)},${y.toFixed(1)}`;
+            }).join(' ');
+            return `<path d="${path}" fill="none" stroke="${color}" stroke-width="2" />`;
+        };
+
+        const area = (counts, color) => {
+            const top = counts.map((val, idx) => {
+                const x = padding + idx * xStep;
+                const y = height - padding - (val / maxCount) * (height - padding * 2);
+                return `${x.toFixed(1)},${y.toFixed(1)}`;
+            });
+            const bottom = counts.map((_, idx) => {
+                const x = padding + (counts.length - 1 - idx) * xStep;
+                return `${x.toFixed(1)},${axisY.toFixed(1)}`;
+            });
+            const path = `M${top.join(' L')} L${bottom.join(' L')} Z`;
+            return `<path d="${path}" fill="${color}" opacity="0.25" />`;
+        };
+
+        const startLabel = rows[0] ? rows[0].minute_start : '';
+        const totalSpan = rows.length - 1;
+        const midIndex = Math.floor(totalSpan / 2);
+        const q1Index = Math.floor(totalSpan / 4);
+        const q3Index = Math.floor((totalSpan * 3) / 4);
+        const midLabel = rows[midIndex] ? rows[midIndex].minute_start : '';
+        const q1Label = rows[q1Index] ? rows[q1Index].minute_start : '';
+        const q3Label = rows[q3Index] ? rows[q3Index].minute_start : '';
+        const endLabel = rows[rows.length - 1] ? rows[rows.length - 1].minute_end : '';
+        const xStart = padding;
+        const xQ1 = padding + q1Index * xStep;
+        const xMid = padding + midIndex * xStep;
+        const xQ3 = padding + q3Index * xStep;
+        const xEnd = padding + totalSpan * xStep;
+
+        return `
+            <svg width="${width}" height="${height}" viewBox="0 0 ${width} ${height}">
+                <rect x="0" y="0" width="${width}" height="${height}" fill="#fff" />
+                <line x1="${axisX}" y1="${axisY}" x2="${width - padding}" y2="${axisY}" stroke="#e0e0e0" />
+                <line x1="${axisX}" y1="${padding}" x2="${axisX}" y2="${axisY}" stroke="#e0e0e0" />
+                ${area(overlapCounts, '#9ec5fe')}
+                ${points(countsA, '#1f77b4')}
+                ${points(countsB, '#ff7f0e')}
+                <text x="${axisX}" y="${padding - 8}" font-size="10" fill="#555">Concurrent runners</text>
+                <text x="${axisX + 160}" y="${padding - 8}" font-size="10" fill="#1f77b4">${eventKeyA} concurrent</text>
+                <text x="${axisX + 320}" y="${padding - 8}" font-size="10" fill="#ff7f0e">${eventKeyB} concurrent</text>
+                <text x="${axisX + 500}" y="${padding - 8}" font-size="10" fill="#4c7bd9">Overlap</text>
+                <line x1="${xStart}" y1="${axisY}" x2="${xStart}" y2="${axisY + 4}" stroke="#9ca3af" />
+                <line x1="${xQ1}" y1="${axisY}" x2="${xQ1}" y2="${axisY + 4}" stroke="#9ca3af" />
+                <line x1="${xMid}" y1="${axisY}" x2="${xMid}" y2="${axisY + 4}" stroke="#9ca3af" />
+                <line x1="${xQ3}" y1="${axisY}" x2="${xQ3}" y2="${axisY + 4}" stroke="#9ca3af" />
+                <line x1="${xEnd}" y1="${axisY}" x2="${xEnd}" y2="${axisY + 4}" stroke="#9ca3af" />
+                <text x="${xStart - 8}" y="${labelY}" font-size="10" fill="#555">${startLabel}</text>
+                <text x="${xQ1 - 8}" y="${labelY}" font-size="10" fill="#555">${q1Label}</text>
+                <text x="${xMid - 8}" y="${labelY}" font-size="10" fill="#555">${midLabel}</text>
+                <text x="${xQ3 - 8}" y="${labelY}" font-size="10" fill="#555">${q3Label}</text>
+                <text x="${xEnd - 8}" y="${labelY}" font-size="10" fill="#555">${endLabel}</text>
+            </svg>
+        `;
+    }
+
+    function showOverlapError() {
+        const tbody = document.getElementById('overlap-tbody');
+        const note = document.getElementById('overlap-note');
+        tbody.innerHTML = '<tr><td colspan="6" class="placeholder">Error loading overlap data</td></tr>';
+        note.textContent = 'Bidirectional overlap data unavailable';
+    }
 </script>
 {% endblock %}
 
@@ -525,6 +806,58 @@
         color: #495057;
         padding: 0.75rem 1rem;
     }
+
+    #overlap-table th,
+    #overlap-table td,
+    #overlap-detail-table th,
+    #overlap-detail-table td {
+        padding: 0.75rem 1rem;
+        text-align: left;
+        border-bottom: 1px solid #e0e0e0;
+    }
+
+    #overlap-table th,
+    #overlap-detail-table th {
+        background: #f8f9fa;
+        font-weight: 600;
+        color: #2c3e50;
+    }
+
+    .overlap-row:hover {
+        background: #f8f9fa;
+        cursor: pointer;
+    }
+
+    .overlap-row.selected {
+        background: #eef5ff;
+    }
+
+    .overlap-chart {
+        border: 1px solid #e0e0e0;
+        border-radius: 4px;
+        padding: 0.5rem;
+        background: #fff;
+    }
+
+    .overlap-title {
+        font-weight: 600;
+        margin-bottom: 0.25rem;
+    }
+
+    .overlap-time {
+        color: #6b7280;
+        font-size: 0.9rem;
+    }
+
+.overlap-table-container {
+    max-height: 220px;
+    overflow-y: auto;
+}
+
+.overlap-detail-table-container {
+    max-height: 200px;
+    overflow-y: auto;
+}
     
 </style>
 {% endblock %}


### PR DESCRIPTION
## Summary
- generate per-minute bidirectional overlap reports and summary output
- add bidirectional overlap API endpoints and router registration
- render Flow Overlaps table + chart with axis ticks and overlap shading

## Test plan
- Manual: confirmed in UI by requester

Made with [Cursor](https://cursor.com)