### PR TITLE
Remove legacy flow_enabled/flow_rate plumbing

### DIFF
--- a/app/core/density/compute.py
+++ b/app/core/density/compute.py
@@ -137,7 +137,7 @@ def build_segment_context_v2(segment_id: str, segment_data: dict, summary_dict: 
     Returns:
         dict: Complete v2 segment context ready for rendering
     """
-    from app.density_template_engine import get_schema_config, compute_flow_rate, evaluate_triggers
+    from app.density_template_engine import get_schema_config, evaluate_triggers
     from app.schema_resolver import resolve_schema as resolve_schema_from_csv
     
     # Issue #616: Use schema directly from segment_data (loaded from user-specified CSV file)
@@ -170,33 +170,9 @@ def build_segment_context_v2(segment_id: str, segment_data: dict, summary_dict: 
     
     schema_config = get_schema_config(schema_name, rulebook)
     
-    # Get flow rate if enabled for this segment
-    flow_rate = None
-    flow_enabled = segment_data.get("flow_enabled", "n")
-    if flow_enabled == "y" or flow_enabled is True:
-        # Calculate flow rate from peak concurrency
-        # Use active_peak_concurrency which is the correct field name
-        peak_concurrency = summary_dict.get("active_peak_concurrency", 0)
-        width_m = segment_data.get("width_m")
-        if width_m is None or (isinstance(width_m, float) and pd.isna(width_m)) or width_m <= 0:
-            raise ValueError(
-                f"Segment {segment_id} missing valid width_m for flow rate computation."
-            )
-        from app.utils.constants import DEFAULT_BIN_TIME_WINDOW_SECONDS
-        bin_seconds = DEFAULT_BIN_TIME_WINDOW_SECONDS  # Use constant (Issue #512)
-        flow_rate = compute_flow_rate(peak_concurrency, width_m, bin_seconds)
-        
-        # For merge segments, add flow-specific analysis
-        if segment_data.get("flow_type") in ["merge", "parallel", "counterflow"]:
-            # Add flow capacity analysis for merge segments
-            flow_capacity = width_m * 60  # Theoretical max flow (runners/min/m)
-            flow_utilization = (flow_rate / flow_capacity) * 100 if flow_capacity > 0 else 0
-            logger.info(f"Merge segment {segment_id}: flow_rate={flow_rate:.1f} p/min/m, capacity={flow_capacity:.1f}, utilization={flow_utilization:.1f}%")
-    
     # Evaluate triggers
     metrics = {
-        "density": summary_dict.get("peak_areal_density", 0.0),
-        "flow": flow_rate
+        "density": summary_dict.get("peak_areal_density", 0.0)
     }
     fired_actions = evaluate_triggers(segment_id, metrics, schema_name, schema_config, rulebook)
     
@@ -219,12 +195,6 @@ def build_segment_context_v2(segment_id: str, segment_data: dict, summary_dict: 
         "active_duration_s": summary_dict.get("active_duration_s", 0),
         "active_start": summary_dict.get("active_start", "N/A"),
         "active_end": summary_dict.get("active_end", "N/A"),
-        
-        # Flow metrics
-        "flow_rate": flow_rate,
-        "flow_enabled": flow_enabled == "y" or flow_enabled is True,
-        "flow_capacity": flow_capacity if 'flow_capacity' in locals() else None,
-        "flow_utilization": flow_utilization if 'flow_utilization' in locals() else None,
         
         # Trigger results
         "fired_actions": fired_actions,
@@ -305,7 +275,6 @@ def load_density_cfg(path: str) -> Dict[str, dict]:
             direction=str(r.get("direction", "uni")),
             schema=schema,  # Issue #616: Include schema from CSV (SSOT for this analysis run)
             flow_type=str(r.get("flow_type", "default")),
-            flow_enabled=str(r.get("flow_enabled", "n")),
             events=events,
             # v1 events (backward compatibility)
             full_from_km=float(r.get("full_from_km", 0)) if r.get("full_from_km") != "" else None,
@@ -1930,10 +1899,8 @@ def analyze_density_segments(pace_data: pd.DataFrame,
                 
                 # Add v2 data to summary_dict for backward compatibility
                 summary_dict["schema_name"] = v2_context["schema_name"]
-                summary_dict["flow_rate"] = v2_context["flow_rate"]
                 summary_dict["fired_actions"] = v2_context["fired_actions"]
-                
-                logger.info(f"Segment {seg_id}: schema_name={v2_context['schema_name']}, flow_enabled={v2_context['flow_enabled']}, flow_rate={v2_context['flow_rate']}")
+                logger.info(f"Segment {seg_id}: schema_name={v2_context['schema_name']}")
                 
             except Exception as e:
                 import traceback
@@ -1941,7 +1908,6 @@ def analyze_density_segments(pace_data: pd.DataFrame,
                 logger.debug(f"Full traceback for segment {seg_id}:\n{traceback.format_exc()}")
                 summary_dict = summary.__dict__.copy()
                 summary_dict["schema_name"] = "on_course_open"
-                summary_dict["flow_rate"] = None
                 summary_dict["fired_actions"] = []
             
             # Calculate segment length from segment boundaries (Issue #248 fix)

--- a/app/density_template_engine.py
+++ b/app/density_template_engine.py
@@ -95,8 +95,8 @@ def evaluate_triggers(segment_id: str, metrics: dict, schema_name: str, schema: 
             if density_metric is not None and density_metric >= density_value:
                 fired_actions.extend(actions)
         
-        # Check flow trigger
-        if "flow_gte" in when and schema.flow_ref:
+        # Check flow trigger only when flow metric is provided
+        if "flow_gte" in when and schema.flow_ref and metrics.get("flow") is not None:
             flow_threshold = when["flow_gte"]
             if isinstance(flow_threshold, str):
                 # Named threshold (warn, critical)
@@ -109,17 +109,11 @@ def evaluate_triggers(segment_id: str, metrics: dict, schema_name: str, schema: 
             if flow_value is None:
                 flow_value = 0.0
             
-            flow_metric = metrics.get("flow", 0.0)
+            flow_metric = metrics.get("flow")
             if flow_metric is not None and flow_metric >= flow_value:
                 fired_actions.extend(actions)
     
     return fired_actions
-
-
-def compute_flow_rate(runners_crossing: int, width_m: float, bin_seconds: int) -> float:
-    """Compute flow rate in runners/min/m."""
-    minutes = max(bin_seconds / 60.0, 1e-9)
-    return runners_crossing / (width_m * minutes)  # runners/min/m
 
 
 # Phase 3 cleanup: Removed map_los() - not imported or used anywhere

--- a/app/utils/ai_analysis.py
+++ b/app/utils/ai_analysis.py
@@ -65,7 +65,6 @@ def extract_analysis_metrics(run_id: str) -> Dict[str, Any]:
             "units": {
                 "density": "runners/m²",
                 "rate": "runners/min/m",
-                "flow_rate": "runners/s",
                 "time": "ISO 8601 UTC"
             }
         },

--- a/config/density_rulebook.yml
+++ b/config/density_rulebook.yml
@@ -91,10 +91,8 @@ binding:
   # Prefer explicit segment_id if available; otherwise rely on segment_type
   - when: { segment_id: "A1" }
     use_schema: start_corral
-    flow_enabled: true
   - when: { segment_type: [funnel, merge, bridge, finish] }
     use_schema: on_course_narrow
-    flow_enabled: true
   - when: { segment_type: [road, trail, turn] }
     use_schema: on_course_open
 

--- a/docs/ai-analysis/ai-analysis-prompt.md
+++ b/docs/ai-analysis/ai-analysis-prompt.md
@@ -30,7 +30,6 @@ You are an expert race operations assistant analyzing course metrics for the Fre
 
 - **Density:** {units.density} (runners per square meter)
 - **Rate:** {units.rate} (runners per minute per meter of width)
-- **Flow Rate:** {units.flow_rate} (runners per second)
 - **Time:** {units.time} (ISO 8601 UTC format)
 
 ---


### PR DESCRIPTION
## Summary
- Remove flow_enabled/flow_rate plumbing from density computation and reporting.
- Simplify operational status to LOS-only and drop flow-utilization derived metrics.
- Clean up related rulebook and AI analysis prompt references.

## Test Plan
- Not run (per plan: single E2E on integration branch).

Made with [Cursor](https://cursor.com)