### PR TITLE
Remove segments.csv notes plumbing

### DIFF
--- a/app/core/density/compute.py
+++ b/app/core/density/compute.py
@@ -235,7 +235,6 @@ def build_segment_context_v2(segment_id: str, segment_data: dict, summary_dict: 
         # Additional v2 data
         "width_m": segment_data.get("width_m", 1.0),
         "direction": segment_data.get("direction", "uni"),
-        "notes": segment_data.get("notes", ""),
     }
     
     return v2_context
@@ -320,7 +319,6 @@ def load_density_cfg(path: str) -> Dict[str, dict]:
             elite_to_km=float(r.get("elite_to_km", 0)) if r.get("elite_to_km") != "" else None,
             open_from_km=float(r.get("open_from_km", 0)) if r.get("open_from_km") != "" else None,
             open_to_km=float(r.get("open_to_km", 0)) if r.get("open_to_km") != "" else None,
-            notes=str(r.get("notes", ""))
         )
     
     return cfg

--- a/app/utils/shared.py
+++ b/app/utils/shared.py
@@ -56,7 +56,7 @@ def load_segments_csv(url_or_path: str) -> pd.DataFrame:
         expected = {"seg_id", "seg_label", "width_m", "direction", "full", "half", "10K",
                    "full_from_km", "full_to_km", "half_from_km", "half_to_km", 
                    "10K_from_km", "10K_to_km", "flow_type", 
-                   "prior_segment_id", "notes"}
+                   "prior_segment_id"}
         if not expected.issubset(df.columns):
             raise ValueError(f"segments_new.csv must have columns {sorted(expected)}; got {df.columns.tolist()}")
     else:


### PR DESCRIPTION
## Summary
- Stop carrying `segments.csv` notes into density config and v2 segment context.
- Relax shared segment loader expectations to no longer require `notes` for segments_new format.

## Test Plan
- Not run (per plan: single E2E on integration branch).

Made with [Cursor](https://cursor.com)