### PR TITLE
Remove flow.csv prior segment metadata

### DIFF
--- a/app/core/v2/flow.py
+++ b/app/core/v2/flow.py
@@ -280,7 +280,7 @@ def create_flow_segments_from_flow_csv(
     Uses flow.csv as authoritative source for:
     - Event ordering (event_a, event_b)
     - Distance ranges (from_km_a, to_km_a, from_km_b, to_km_b)
-    - Flow metadata (flow_type, notes, prior_seg_id)
+    - Flow metadata (flow_type, notes)
     
     Args:
         flow_rows: DataFrame with matching rows from flow.csv
@@ -343,7 +343,6 @@ def create_flow_segments_from_flow_csv(
             "direction": direction,  # Issue #549: Always from segments.csv (physical property)
             "width_m": width_m,  # Issue #549: Always from segments.csv (physical property)
             "flow_type": _get_required_flow_type(flow_row, seg_id, event_a, event_b),
-            "prior_segment_id": flow_row.get("prior_seg_id", "") if pd.notna(flow_row.get("prior_seg_id", "")) else "",
             "notes": flow_row.get("notes", ""),
             "length_km": to_km_a - from_km_a if to_km_a > from_km_a else 0
         }

--- a/app/utils/shared.py
+++ b/app/utils/shared.py
@@ -55,8 +55,7 @@ def load_segments_csv(url_or_path: str) -> pd.DataFrame:
         # New format - keep original column names
         expected = {"seg_id", "seg_label", "width_m", "direction", "full", "half", "10K",
                    "full_from_km", "full_to_km", "half_from_km", "half_to_km", 
-                   "10K_from_km", "10K_to_km", "flow_type", 
-                   "prior_segment_id", "notes"}
+                   "10K_from_km", "10K_to_km", "flow_type", "notes"}
         if not expected.issubset(df.columns):
             raise ValueError(f"segments_new.csv must have columns {sorted(expected)}; got {df.columns.tolist()}")
     else:


### PR DESCRIPTION
## Summary
- Stop carrying prior segment metadata from flow.csv into flow computations.
- Remove prior-segment logic from deep-dive analysis and conversion utilities.
- Relax shared segments_new expectations to no longer require prior_segment_id.

## Test Plan
- Not run (per plan: single E2E on integration branch).

Made with [Cursor](https://cursor.com)