### PR TITLE
Enhancement: Stable loc-sheet URL on Cloud (run_id-independent) #737

### DIFF
--- a/app/routes/cloud_ui.py
+++ b/app/routes/cloud_ui.py
@@ -96,6 +96,22 @@ async def check_session(request: Request):
 
 
 # Issue #735: Loc Sheets index (behind auth) and public sheet URLs
+# Issue #737: Short URL (no run_id) for stable Volunteer Local links; register before 3-param route
+@router.get("/locsheets/{day}/{loc_id}", response_class=HTMLResponse)
+async def cloud_locsheet_html_short(request: Request, day: str, loc_id: str):
+    """Serve location one-pager HTML via short URL (no run_id); public. Stable across run updates (Issue #737)."""
+    run_id = _get_cloud_run_id()
+    if day not in ("fri", "sat", "sun", "mon"):
+        raise HTTPException(status_code=400, detail="Invalid day")
+    if not loc_id.replace("_", "").replace("-", "").isalnum():
+        raise HTTPException(status_code=400, detail="Invalid loc_id")
+    run_dir = get_run_directory(run_id)
+    html_path = Path(run_dir) / day / "reports" / "loc_sheets" / "html" / f"{loc_id}.html"
+    if not html_path.exists():
+        raise HTTPException(status_code=404, detail="Location sheet not found")
+    return FileResponse(html_path, media_type="text/html")
+
+
 @router.get("/locsheets", response_class=HTMLResponse)
 async def cloud_locsheets(request: Request, day: Optional[str] = Query(None)):
     """Day-based index of location sheets; requires auth."""

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -338,12 +338,15 @@
     <!-- Issue #314: Frontend session check (supplementary to server-side enforcement) -->
     <script>
     (function() {
-        // Skip session check on password page and public loc sheet URLs (Issue #735)
+        // Skip session check on password page and public loc sheet URLs (Issue #735, #737 short URL)
         const path = window.location.pathname;
         if (path === '/' || path === '/login') {
             return;
         }
         if (path.startsWith('/locsheets/') && path.match(/^\/locsheets\/[^/]+\/(?:fri|sat|sun|mon)\/[^/]+$/)) {
+            return;
+        }
+        if (path.startsWith('/locsheets/') && path.match(/^\/locsheets\/(?:fri|sat|sun|mon)\/[^/]+$/)) {
             return;
         }
         

--- a/frontend/templates/pages/locsheets.html
+++ b/frontend/templates/pages/locsheets.html
@@ -27,7 +27,7 @@
                 <td style="padding: 0.5rem 0.75rem;">{{ s.loc_id }}</td>
                 <td style="padding: 0.5rem 0.75rem;">{{ s.label }}</td>
                 <td style="padding: 0.5rem 0.75rem;">
-                    <a href="/locsheets/{{ run_id }}/{{ day }}/{{ s.loc_id }}" target="_blank" rel="noopener">Open sheet</a>
+                    {% if cloud_mode %}<a href="/locsheets/{{ day }}/{{ s.loc_id }}" target="_blank" rel="noopener">Open sheet</a>{% else %}<a href="/locsheets/{{ run_id }}/{{ day }}/{{ s.loc_id }}" target="_blank" rel="noopener">Open sheet</a>{% endif %}
                 </td>
             </tr>
             {% endfor %}


### PR DESCRIPTION
Closes #737

- Add public route `/locsheets/{day}/{loc_id}` on Cloud UI (run_id resolved from env)
- Loc sheets index uses short URL in cloud mode; long URL on local
- Session check skips auth for short-URL pattern so public sheets load without login

Made with [Cursor](https://cursor.com)