### PR TITLE
Issue #743: finish_times waves + finish-area demand PDF

### DIFF
--- a/app/core/v2/pipeline.py
+++ b/app/core/v2/pipeline.py
@@ -1459,7 +1459,8 @@ def create_full_analysis_pipeline(
         density_summary = {}
         flow_summary_by_day = {}
         day_metadata_map: Dict[str, Dict[str, Any]] = {}
-        
+        runners_df_by_day: Dict[str, pd.DataFrame] = {}
+
         for day, day_events in events_by_day.items():
             day_code = day.value
             days_processed.append(day_code)
@@ -1505,6 +1506,8 @@ def create_full_analysis_pipeline(
                 from app.core.v2.density import combine_runners_for_events
                 event_names = [e.name.lower() for e in day_events]
                 day_runners_df = combine_runners_for_events(event_names, day_code, runner_paths)
+                if day_runners_df.empty:
+                    day_runners_df = filter_runners_by_day(all_runners_df, day, day_events)
                 if not day_runners_df.empty:
                     # event column should be lowercase
                     participants_by_event = (
@@ -1512,6 +1515,7 @@ def create_full_analysis_pipeline(
                     )
             except Exception as e:
                 logger.warning(f"Could not compute participants per event for {day_code}: {e}")
+            runners_df_by_day[day_code] = day_runners_df
             
             # Create metadata.json per day with v1 parity + events
             metadata = create_metadata_json(
@@ -1710,6 +1714,19 @@ def create_full_analysis_pipeline(
                     reports_dir=reports_path,
                     segments_df=segments_df
                 )
+
+                # Issue #743: Predicted finish waves (20-minute buckets; same runner math as timings)
+                dr_day = runners_df_by_day.get(day_code)
+                if analysis_config is not None and dr_day is not None and not dr_day.empty:
+                    from app.core.v2.timings import build_runner_finish_times_df, write_finish_times_csv
+
+                    ft_df = build_runner_finish_times_df(
+                        events=day_events,
+                        analysis_config=analysis_config,
+                        runners_df=dr_day,
+                    )
+                    if ft_df is not None and not ft_df.empty:
+                        write_finish_times_csv(reports_path / "finish_times.csv", day_code, ft_df)
             
             # Update metadata verification after reports are generated
             # Bug fix: Metadata was created before reports, causing false FAIL status

--- a/app/core/v2/pipeline.py
+++ b/app/core/v2/pipeline.py
@@ -1726,7 +1726,42 @@ def create_full_analysis_pipeline(
                         runners_df=dr_day,
                     )
                     if ft_df is not None and not ft_df.empty:
-                        write_finish_times_csv(reports_path / "finish_times.csv", day_code, ft_df)
+                        ft_path = reports_path / "finish_times.csv"
+                        write_finish_times_csv(ft_path, day_code, ft_df)
+                        try:
+                            from app.finish_area_pdf import (
+                                expected_runners_for_day,
+                                generate_finish_area_demand_pdf,
+                            )
+
+                            _day_pdf_titles = {
+                                "fri": "Friday",
+                                "sat": "Saturday",
+                                "sun": "Sunday",
+                                "mon": "Monday",
+                            }
+                            day_pdf_title = _day_pdf_titles.get(
+                                day_code, day_code.upper()
+                            )
+                            exp_total = (
+                                expected_runners_for_day(analysis_config, day_code)
+                                if analysis_config
+                                else None
+                            )
+                            generate_finish_area_demand_pdf(
+                                finish_times_csv=ft_path,
+                                output_pdf=reports_path / "finish_area_demand.pdf",
+                                day_display_name=day_pdf_title,
+                                run_id=run_id,
+                                expected_runner_total=exp_total,
+                            )
+                        except Exception as exc:
+                            logger.warning(
+                                "finish_area_demand.pdf failed for %s: %s",
+                                day_code,
+                                exc,
+                                exc_info=True,
+                            )
             
             # Update metadata verification after reports are generated
             # Bug fix: Metadata was created before reports, causing false FAIL status

--- a/app/core/v2/timings.py
+++ b/app/core/v2/timings.py
@@ -7,21 +7,172 @@ Uses vectorized pandas operations for efficient computation across thousands of 
 Issue #638: Correct implementation of predicted_timings using runner finish times
 instead of bin window timestamps.
 
+Issue #743: Finish-time waves CSV aggregates runner finish_time_sec into 20-minute blocks.
+
 Core Principles:
 - Compute finish times directly from runner data (pace, distance, start_offset)
 - Use vectorized operations (NO loops over runners)
-- Return dict only (no file writes)
 - Use Event.start_time as primary source, analysis_config for fallback durations
 """
 
 from typing import Dict, List, Any, Optional
+from pathlib import Path
+import csv
+import math
 import pandas as pd
-import numpy as np
 import logging
 
 from app.core.v2.models import Event
 
 logger = logging.getLogger(__name__)
+
+_FINISH_BUCKET_SECONDS = 20 * 60
+
+
+def finish_bucket_start_sec(finish_time_sec: float) -> int:
+    """
+    Map finish time (seconds since naive midnight) to the start of its 20-minute clock bucket.
+
+    Buckets align within each hour: [0,19:59], [20:00,39:59], [40:00,59:59].
+    Boundary rule (half-open): finish at exactly HH:20:00 belongs to the second block.
+    """
+    s = max(0, int(math.floor(float(finish_time_sec))))
+    hour_start = (s // 3600) * 3600
+    offset_in_hour = s % 3600
+    slot = offset_in_hour // _FINISH_BUCKET_SECONDS  # 0, 1, or 2
+    return hour_start + slot * _FINISH_BUCKET_SECONDS
+
+
+def _format_seconds_to_hhmmss(seconds_from_midnight: float) -> str:
+    """Format seconds from midnight to HH:MM:SS (supports hour >= 24 if needed)."""
+    try:
+        total_seconds = max(0, int(float(seconds_from_midnight)))
+        hours = total_seconds // 3600
+        minutes = (total_seconds % 3600) // 60
+        secs = total_seconds % 60
+        return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+    except (ValueError, TypeError):
+        return "00:00:00"
+
+
+def build_runner_finish_times_df(
+    *,
+    events: List[Event],
+    analysis_config: Dict[str, Any],
+    runners_df: pd.DataFrame,
+) -> Optional[pd.DataFrame]:
+    """
+    One row per runner with predicted finish_time_sec (seconds since naive midnight).
+
+    Issue #743: Same formula as compute_predicted_timings — gun/start + offset + pace * distance.
+    Events with no runner rows do not appear in the frame (handled upstream for aggregates).
+
+    Returns:
+        DataFrame with columns runner_id, event (lowercase), finish_time_sec; or None if unusable input.
+        Empty DataFrame if no runners could be scored (caller may treat like no data).
+    """
+    required_columns = ["runner_id", "event", "pace", "distance"]
+    optional_warn = ["start_offset"]
+    missing_required = [col for col in required_columns if col not in runners_df.columns]
+    missing_optional = [col for col in optional_warn if col not in runners_df.columns]
+    if missing_required:
+        logger.warning(
+            "Issue #743: Missing columns for finish times: %s (have %s)",
+            missing_required,
+            list(runners_df.columns),
+        )
+        if runners_df.empty or "pace" not in runners_df.columns or "distance" not in runners_df.columns:
+            return None
+    elif missing_optional:
+        logger.debug(
+            "Issue #743: Optional columns missing for finish times: %s",
+            missing_optional,
+        )
+
+    work = runners_df.copy()
+    if "event" in work.columns:
+        work["event"] = work["event"].astype(str).str.lower()
+
+    frames: List[pd.DataFrame] = []
+    for event in events:
+        event_name = event.name.lower()
+        event_start_min = event.start_time
+        event_runners = work[work["event"] == event_name].copy()
+        if event_runners.empty:
+            continue
+        if "pace" not in event_runners.columns or "distance" not in event_runners.columns:
+            logger.warning("Issue #743: Missing pace or distance for event %s", event_name)
+            continue
+
+        event_runners["pace_sec_per_km"] = event_runners["pace"] * 60.0
+        if "start_offset" in event_runners.columns:
+            event_runners["start_offset_sec"] = event_runners["start_offset"].fillna(0).astype(float)
+        else:
+            event_runners["start_offset_sec"] = 0.0
+        event_runners["runner_start_sec"] = (event_start_min * 60.0) + event_runners["start_offset_sec"]
+        event_runners["finish_time_sec"] = (
+            event_runners["runner_start_sec"]
+            + (event_runners["pace_sec_per_km"] * event_runners["distance"])
+        )
+        frames.append(event_runners[["runner_id", "event", "finish_time_sec"]])
+
+    if not frames:
+        return pd.DataFrame(columns=["runner_id", "event", "finish_time_sec"])
+    return pd.concat(frames, ignore_index=True)
+
+
+def write_finish_times_csv(output_path: Path, day_code: str, finish_df: pd.DataFrame) -> bool:
+    """
+    Issue #743: Aggregate predicted finishes into 20-minute waves; non-zero rows only plus ``all``.
+
+    Inserts a blank line between consecutive buckets when the clock hour changes (Excel-friendly).
+
+    Returns:
+        True if file was written with at least one data row; False if nothing to emit.
+    """
+    if finish_df is None or finish_df.empty:
+        return False
+
+    bucket_col = finish_df["finish_time_sec"].map(finish_bucket_start_sec)
+    tmp = finish_df.assign(_bucket=bucket_col)
+
+    grouped = tmp.groupby(["_bucket", "event"], observed=False).size().reset_index(name="count")
+    grouped = grouped[grouped["count"] > 0].sort_values(["_bucket", "event"])
+
+    if grouped.empty:
+        return False
+
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+
+    prev_hour: Optional[int] = None
+    rows_written = 0
+    with open(output_path, "w", encoding="utf-8", newline="") as fh:
+        writer = csv.writer(fh)
+        writer.writerow(["day", "time_window_start", "time_window_end", "event", "count"])
+
+        for bucket_start in sorted(grouped["_bucket"].unique()):
+            chunk = grouped[grouped["_bucket"] == bucket_start]
+            hour = bucket_start // 3600
+            if prev_hour is not None and hour != prev_hour:
+                writer.writerow([])
+            prev_hour = hour
+
+            window_start_str = _format_seconds_to_hhmmss(bucket_start)
+            window_end_str = _format_seconds_to_hhmmss(bucket_start + _FINISH_BUCKET_SECONDS - 1)
+
+            total = int(chunk["count"].sum())
+            for _, row in chunk.sort_values("event").iterrows():
+                writer.writerow([day_code, window_start_str, window_end_str, row["event"], int(row["count"])])
+                rows_written += 1
+            writer.writerow([day_code, window_start_str, window_end_str, "all", total])
+            rows_written += 1
+
+    logger.info(
+        "Issue #743: Wrote finish_times.csv (%s rows incl. all): %s",
+        rows_written,
+        output_path,
+    )
+    return True
 
 
 def _format_seconds_to_hhmm(seconds_from_midnight: float) -> str:
@@ -75,28 +226,10 @@ def compute_predicted_timings(
         }
     """
     try:
-        # Validate required columns
-        required_columns = ['runner_id', 'event', 'pace', 'distance', 'start_offset']
-        missing_columns = [col for col in required_columns if col not in runners_df.columns]
-        if missing_columns:
-            logger.warning(
-                f"Issue #638: Missing required columns in runners_df: {missing_columns}. "
-                f"Available columns: {list(runners_df.columns)}"
-            )
-            # If runners_df is completely empty or missing critical columns, return None
-            if runners_df.empty or 'pace' not in runners_df.columns or 'distance' not in runners_df.columns:
-                return None
-        
-        # Normalize event names to lowercase (v2 convention)
-        if 'event' in runners_df.columns:
-            runners_df = runners_df.copy()
-            runners_df['event'] = runners_df['event'].str.lower()
-        
         # Build lookup from Event objects (primary source for start times)
         event_start_times = {event.name.lower(): event.start_time for event in events}
-        
+
         # Build lookup from analysis_config for fallback durations
-        # Note: analysis_config["events"] is a list, not a dict
         event_durations = {}
         if analysis_config and "events" in analysis_config:
             for event_data in analysis_config["events"]:
@@ -104,76 +237,64 @@ def compute_predicted_timings(
                     event_name = event_data.get("name", "").lower()
                     if event_name and "event_duration_minutes" in event_data:
                         event_durations[event_name] = event_data["event_duration_minutes"]
-        
-        # Initialize result dictionaries
+
+        finish_df = build_runner_finish_times_df(
+            events=events,
+            analysis_config=analysis_config,
+            runners_df=runners_df,
+        )
+        if finish_df is None:
+            return None
+
         event_first_finisher = {}
         event_last_finisher = {}
         actual_event_duration = {}
-        
-        # Process each event
+
         for event in events:
             event_name = event.name.lower()
             event_start_min = event.start_time  # minutes after midnight
-            
-            # Filter runners for this event (vectorized)
-            event_runners = runners_df[runners_df['event'].str.lower() == event_name].copy()
-            
-            if event_runners.empty:
-                # Fallback: use event_duration_minutes if available
+
+            sub = finish_df[finish_df["event"] == event_name] if not finish_df.empty else pd.DataFrame()
+
+            if sub.empty:
                 if event_name in event_durations:
                     duration_minutes = event_durations[event_name]
                     event_last_min = event_start_min + duration_minutes
                     event_last_finisher[event_name] = _format_seconds_to_hhmm(event_last_min * 60)
-                    # Same semantics as with runners: elapsed from official start to last finisher
                     actual_event_duration[event_name] = _format_seconds_to_hhmm(duration_minutes * 60)
-                    # Leave event_first_finisher empty (no runners to compute from)
-                    logger.debug(f"Issue #638: No runners for event {event_name}, using fallback duration")
+                    logger.debug(
+                        "Issue #638: No runners for event %s, using fallback duration",
+                        event_name,
+                    )
                 else:
-                    logger.debug(f"Issue #638: No runners and no duration fallback for event {event_name}")
+                    logger.debug(
+                        "Issue #638: No runners and no duration fallback for event %s",
+                        event_name,
+                    )
                 continue
-            
-            # Validate required columns for computation
-            if 'pace' not in event_runners.columns or 'distance' not in event_runners.columns:
-                logger.warning(f"Issue #638: Missing pace or distance columns for event {event_name}")
-                continue
-            
-            # Vectorized computation of finish times
-            # pace_sec_per_km = pace * 60
-            event_runners['pace_sec_per_km'] = event_runners['pace'] * 60.0
-            
-            # start_offset_sec = start_offset (already in seconds, or 0 if missing)
-            event_runners['start_offset_sec'] = event_runners.get('start_offset', pd.Series([0] * len(event_runners))).fillna(0).astype(float)
-            
-            # runner_start_sec = event_start_min * 60 + start_offset_sec
-            event_runners['runner_start_sec'] = (event_start_min * 60.0) + event_runners['start_offset_sec']
-            
-            # finish_time_sec = runner_start_sec + (pace_sec_per_km * distance_km)
-            event_runners['finish_time_sec'] = (
-                event_runners['runner_start_sec'] + 
-                (event_runners['pace_sec_per_km'] * event_runners['distance'])
-            )
-            
-            # Aggregate per event using vectorized operations
-            event_first_sec = event_runners['finish_time_sec'].min()
-            event_last_sec = event_runners['finish_time_sec'].max()
-            
+
+            event_first_sec = sub["finish_time_sec"].min()
+            event_last_sec = sub["finish_time_sec"].max()
+
             event_first_finisher[event_name] = _format_seconds_to_hhmm(event_first_sec)
             event_last_finisher[event_name] = _format_seconds_to_hhmm(event_last_sec)
-            
-            # Elapsed time from official event start (gun) to last finisher — not (last − first).
+
             event_start_sec = float(event_start_min) * 60.0
             duration_sec = float(event_last_sec) - event_start_sec
             if duration_sec < 0:
                 logger.warning(
-                    f"Issue #638: Negative event duration for {event_name} (last before start); clamping to 0"
+                    "Issue #638: Negative event duration for %s (last before start); clamping to 0",
+                    event_name,
                 )
                 duration_sec = 0.0
             actual_event_duration[event_name] = _format_seconds_to_hhmm(duration_sec)
-            
+
             logger.debug(
-                f"Issue #638: Computed timings for event {event_name}: "
-                f"first={event_first_finisher[event_name]}, last={event_last_finisher[event_name]}, "
-                f"duration(last-start)={actual_event_duration[event_name]}"
+                "Issue #638: Computed timings for event %s: first=%s, last=%s, duration(last-start)=%s",
+                event_name,
+                event_first_finisher[event_name],
+                event_last_finisher[event_name],
+                actual_event_duration[event_name],
             )
         
         # Day-level aggregation

--- a/app/core/v2/timings.py
+++ b/app/core/v2/timings.py
@@ -125,7 +125,7 @@ def write_finish_times_csv(output_path: Path, day_code: str, finish_df: pd.DataF
     """
     Issue #743: Aggregate predicted finishes into 20-minute waves; non-zero rows only plus ``all``.
 
-    Inserts a blank line between consecutive buckets when the clock hour changes (Excel-friendly).
+    Strict CSV (one record per line, RFC 4180-friendly): no blank separator rows.
 
     Returns:
         True if file was written with at least one data row; False if nothing to emit.
@@ -144,7 +144,6 @@ def write_finish_times_csv(output_path: Path, day_code: str, finish_df: pd.DataF
 
     output_path.parent.mkdir(parents=True, exist_ok=True)
 
-    prev_hour: Optional[int] = None
     rows_written = 0
     with open(output_path, "w", encoding="utf-8", newline="") as fh:
         writer = csv.writer(fh)
@@ -152,10 +151,6 @@ def write_finish_times_csv(output_path: Path, day_code: str, finish_df: pd.DataF
 
         for bucket_start in sorted(grouped["_bucket"].unique()):
             chunk = grouped[grouped["_bucket"] == bucket_start]
-            hour = bucket_start // 3600
-            if prev_hour is not None and hour != prev_hour:
-                writer.writerow([])
-            prev_hour = hour
 
             window_start_str = _format_seconds_to_hhmmss(bucket_start)
             window_end_str = _format_seconds_to_hhmmss(bucket_start + _FINISH_BUCKET_SECONDS - 1)

--- a/app/finish_area_pdf.py
+++ b/app/finish_area_pdf.py
@@ -1,0 +1,285 @@
+"""
+Finish-area operational PDF (Issue #743 extension).
+
+Generates one PDF per analysis day from finish_times.csv:
+- Bar chart: predicted finishers by 20-minute block (event=all)
+- Cumulative finishers curve (same ordering as windows)
+- Table: time block, count, operational tier (Low / Moderate / High / Peak)
+
+Uses matplotlib (Agg) + ReportLab; matches existing stack (see one_pager.py).
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+from pathlib import Path
+from typing import Any, List, Optional
+from xml.sax.saxutils import escape
+
+import matplotlib
+
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+import pandas as pd
+from reportlab.lib import colors
+from reportlab.lib.pagesizes import letter
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    Image as RLImage,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+logger = logging.getLogger(__name__)
+
+
+def _operational_tier(count: int, max_count: int) -> str:
+    """Relative-to-peak labels for finish-area demand (same day)."""
+    if count <= 0 or max_count <= 0:
+        return "—"
+    ratio = count / max_count
+    if ratio >= 0.85:
+        return "Peak / surge"
+    if ratio >= 0.45:
+        return "High"
+    if ratio >= 0.12:
+        return "Moderate"
+    return "Low"
+
+
+def _window_label(start: str, end: str) -> str:
+    """Compact label for charts/tables: HH:MM–HH:MM (strip seconds if present)."""
+    def short(t: str) -> str:
+        t = t.strip()
+        if len(t) >= 8 and t.count(":") >= 2:
+            return t[:5]
+        return t
+
+    return f"{short(start)}–{short(end)}"
+
+
+def _build_charts_png(
+    labels: List[str],
+    counts: List[int],
+) -> io.BytesIO:
+    """Stacked bar + cumulative line; returns PNG bytes buffer."""
+    n = len(labels)
+    cum = []
+    s = 0
+    for c in counts:
+        s += c
+        cum.append(s)
+
+    fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(10, 6.5), dpi=120)
+    x = range(n)
+
+    ax1.bar(x, counts, color="#3498db", width=0.85)
+    ax1.set_xticks(list(x))
+    ax1.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+    ax1.set_ylabel("Predicted finishers")
+    ax1.set_title("Predicted finishers by 20-minute block — all events")
+    ax1.grid(axis="y", alpha=0.3)
+    ax1.set_axisbelow(True)
+
+    ax2.plot(x, cum, color="#2980b9", marker="o", markersize=4)
+    ax2.fill_between(list(x), cum, alpha=0.15, color="#3498db")
+    ax2.set_xticks(list(x))
+    ax2.set_xticklabels(labels, rotation=45, ha="right", fontsize=8)
+    ax2.set_ylabel("Cumulative finishers")
+    ax2.set_title("Cumulative predicted finishers")
+    ax2.grid(axis="y", alpha=0.3)
+    ax2.set_axisbelow(True)
+
+    plt.tight_layout()
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", bbox_inches="tight")
+    plt.close(fig)
+    buf.seek(0)
+    return buf
+
+
+def _takeaway_text(
+    day_name: str,
+    labels: List[str],
+    counts: List[int],
+    total_runners: Optional[int],
+) -> str:
+    """Short operational narrative from peaks and sustained high blocks."""
+    if not counts:
+        return ""
+    mx = max(counts)
+    peak_idx = counts.index(mx)
+    peak_label = labels[peak_idx]
+
+    high_thresh = 0.45 * mx
+    surge_windows = [labels[i] for i, c in enumerate(counts) if c >= high_thresh]
+    if len(surge_windows) > 3:
+        surge_span = f"{surge_windows[0]} through {surge_windows[-1]}"
+    elif surge_windows:
+        surge_span = ", ".join(surge_windows)
+    else:
+        surge_span = peak_label
+
+    lines = [
+        f"<b>Peak demand</b> occurs in <b>{peak_label}</b> ({mx} predicted finishers in that 20-minute block).",
+        f"<b>High-demand windows</b> (≥45% of peak): {surge_span}.",
+    ]
+    if total_runners is not None:
+        sum_counts = sum(counts)
+        match = "matches" if sum_counts == total_runners else "should match"
+        lines.append(
+            f"Sum of finish-window totals ({sum_counts}) {match} declared runners for {day_name} ({total_runners}) in analysis.json."
+        )
+    return " ".join(lines)
+
+
+def generate_finish_area_demand_pdf(
+    *,
+    finish_times_csv: Path,
+    output_pdf: Path,
+    day_display_name: str,
+    run_id: str,
+    expected_runner_total: Optional[int] = None,
+) -> bool:
+    """
+    Write operational finish-area PDF next to finish_times.csv.
+
+    Args:
+        finish_times_csv: Path to finish_times.csv for this day
+        output_pdf: e.g. .../reports/finish_area_demand.pdf
+        day_display_name: "Saturday" | "Sunday"
+        run_id: Run identifier for header
+        expected_runner_total: Optional QA total from analysis.json (runners that day)
+
+    Returns:
+        True if PDF written.
+    """
+    if not finish_times_csv.exists():
+        logger.warning("finish_area PDF: missing %s", finish_times_csv)
+        return False
+
+    df = pd.read_csv(finish_times_csv)
+    if df.empty:
+        logger.warning("finish_area PDF: empty CSV %s", finish_times_csv)
+        return False
+
+    all_rows = df[df["event"].astype(str).str.lower() == "all"].copy()
+    if all_rows.empty:
+        logger.warning("finish_area PDF: no 'all' rows in %s", finish_times_csv)
+        return False
+
+    all_rows = all_rows.sort_values(
+        ["time_window_start", "time_window_end"]
+    ).reset_index(drop=True)
+
+    labels = [
+        _window_label(str(r["time_window_start"]), str(r["time_window_end"]))
+        for _, r in all_rows.iterrows()
+    ]
+    counts = [int(r["count"]) for _, r in all_rows.iterrows()]
+    max_c = max(counts)
+
+    tiers = [_operational_tier(c, max_c) for c in counts]
+
+    output_pdf.parent.mkdir(parents=True, exist_ok=True)
+
+    chart_buf = _build_charts_png(labels, counts)
+    styles = getSampleStyleSheet()
+    title_style = ParagraphStyle(
+        "title",
+        parent=styles["Heading1"],
+        fontSize=16,
+        spaceAfter=12,
+    )
+    sub_style = ParagraphStyle(
+        "sub",
+        parent=styles["Normal"],
+        fontSize=9,
+        textColor=colors.HexColor("#555555"),
+        spaceAfter=14,
+    )
+
+    doc = SimpleDocTemplate(
+        str(output_pdf),
+        pagesize=letter,
+        rightMargin=0.75 * inch,
+        leftMargin=0.75 * inch,
+        topMargin=0.65 * inch,
+        bottomMargin=0.65 * inch,
+    )
+    story: List[Any] = []
+
+    story.append(
+        Paragraph(
+            f"{day_display_name} — finish-area demand (predicted)",
+            title_style,
+        )
+    )
+    story.append(
+        Paragraph(
+            f"Run <b>{escape(str(run_id))}</b> · Source: <i>finish_times.csv</i> "
+            "(combined event flow per window)",
+            sub_style,
+        )
+    )
+
+    img = RLImage(chart_buf, width=7 * inch, height=4.55 * inch)
+    story.append(img)
+    story.append(Spacer(1, 14))
+
+    table_data: List[List[str]] = [
+        ["Time block", "Predicted finishers", "Operational signal"],
+    ]
+    for lab, cnt, tier in zip(labels, counts, tiers):
+        table_data.append([lab, str(cnt), tier])
+
+    t = Table(table_data, colWidths=[2.6 * inch, 1.4 * inch, 2.4 * inch])
+    t.setStyle(
+        TableStyle(
+            [
+                ("BACKGROUND", (0, 0), (-1, 0), colors.HexColor("#ecf0f1")),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.HexColor("#2c3e50")),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, -1), 9),
+                ("ALIGN", (1, 1), (1, -1), "RIGHT"),
+                ("VALIGN", (0, 0), (-1, -1), "MIDDLE"),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.HexColor("#bdc3c7")),
+                ("ROWBACKGROUNDS", (0, 1), (-1, -1), [colors.white, colors.HexColor("#fafafa")]),
+                ("TOPPADDING", (0, 0), (-1, -1), 6),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 6),
+            ]
+        )
+    )
+    story.append(t)
+    story.append(Spacer(1, 16))
+
+    takeaway = _takeaway_text(day_display_name, labels, counts, expected_runner_total)
+    story.append(Paragraph("<b>Operational summary</b>", styles["Heading2"]))
+    story.append(Paragraph(takeaway, styles["Normal"]))
+
+    doc.build(story)
+    logger.info("Wrote finish-area PDF: %s", output_pdf)
+    return True
+
+
+def expected_runners_for_day(analysis_config: dict, day_code: str) -> Optional[int]:
+    """Sum analysis.json runners field for events on this day."""
+    if not analysis_config or "events" not in analysis_config:
+        return None
+    total = 0
+    found = False
+    for ev in analysis_config["events"]:
+        if not isinstance(ev, dict):
+            continue
+        if str(ev.get("day", "")).lower() != day_code.lower():
+            continue
+        n = ev.get("runners")
+        if n is not None:
+            total += int(n)
+            found = True
+    return total if found else None

--- a/app/routes/api_reports.py
+++ b/app/routes/api_reports.py
@@ -183,7 +183,12 @@ async def get_reports_list(
                     continue
                 
                 filename = report_file.name
-                description = _get_file_description_from_extension(filename)
+                report_descriptions = {
+                    "finish_times.csv": "Predicted finisher counts by 20-minute clock window (per event and all)",
+                }
+                description = report_descriptions.get(
+                    filename, _get_file_description_from_extension(filename)
+                )
                 
                 # Get file metadata
                 stat = report_file.stat()

--- a/app/routes/api_reports.py
+++ b/app/routes/api_reports.py
@@ -185,6 +185,7 @@ async def get_reports_list(
                 filename = report_file.name
                 report_descriptions = {
                     "finish_times.csv": "Predicted finisher counts by 20-minute clock window (per event and all)",
+                    "finish_area_demand.pdf": "Finish-area operational PDF: bar chart, cumulative curve, demand table (event=all)",
                 }
                 description = report_descriptions.get(
                     filename, _get_file_description_from_extension(filename)

--- a/frontend/templates/pages/reports.html
+++ b/frontend/templates/pages/reports.html
@@ -87,13 +87,14 @@
         
         // Filter and categorize files
         const relevantReports = reports.filter(r => {
-            // Include Density, Flow, Locations, and finish_times (Issue #743) — .md / .csv only
+            // Include Density, Flow, Locations, finish_times, finish-area PDF (Issue #743)
             const isRelevantReport = (
                 r.name.includes('Density') ||
                 r.name.includes('Flow') ||
                 r.name.includes('Locations') ||
-                r.name === 'finish_times.csv'
-            ) && (r.name.endsWith('.md') || r.name.endsWith('.csv'));
+                r.name === 'finish_times.csv' ||
+                r.name === 'finish_area_demand.pdf'
+            ) && (r.name.endsWith('.md') || r.name.endsWith('.csv') || r.name === 'finish_area_demand.pdf');
             
             // Exclude technical files
             const isTechnicalFile = r.name.includes('bins.') || 
@@ -187,6 +188,7 @@
                     if (name === 'Flow.csv') return 1;
                     if (name === 'Locations.csv') return 2;
                     if (name === 'finish_times.csv') return 3;
+                    if (name === 'finish_area_demand.pdf') return 4;
                     return 50;
                 };
                 dayReports.sort((a, b) => {

--- a/frontend/templates/pages/reports.html
+++ b/frontend/templates/pages/reports.html
@@ -13,7 +13,7 @@
 <div class="card">
     <h3 style="margin-bottom: 1rem;">Reports</h3>
     <p style="margin-bottom: 1rem; color: #666; font-size: 0.9rem;">
-        Generated Density, Flow, and Locations analysis reports, sorted by most recent first.
+        Generated Density, Flow, Locations, and finish-time wave reports (grouped by day).
     </p>
     <div id="reports-list">
         <p class="placeholder">Loading reports...</p>
@@ -87,9 +87,13 @@
         
         // Filter and categorize files
         const relevantReports = reports.filter(r => {
-            // Include Density, Flow, and Locations reports (.md and .csv files)
-            const isRelevantReport = (r.name.includes('Density') || r.name.includes('Flow') || r.name.includes('Locations')) && 
-                                   (r.name.endsWith('.md') || r.name.endsWith('.csv'));
+            // Include Density, Flow, Locations, and finish_times (Issue #743) — .md / .csv only
+            const isRelevantReport = (
+                r.name.includes('Density') ||
+                r.name.includes('Flow') ||
+                r.name.includes('Locations') ||
+                r.name === 'finish_times.csv'
+            ) && (r.name.endsWith('.md') || r.name.endsWith('.csv'));
             
             // Exclude technical files
             const isTechnicalFile = r.name.includes('bins.') || 
@@ -178,6 +182,18 @@
             
             sortedDays.forEach(day => {
                 const dayReports = reportsByDay[day];
+                const reportNameOrder = (name) => {
+                    if (name === 'Density.md') return 0;
+                    if (name === 'Flow.csv') return 1;
+                    if (name === 'Locations.csv') return 2;
+                    if (name === 'finish_times.csv') return 3;
+                    return 50;
+                };
+                dayReports.sort((a, b) => {
+                    const d = reportNameOrder(a.name) - reportNameOrder(b.name);
+                    if (d !== 0) return d;
+                    return (b.mtime || 0) - (a.mtime || 0);
+                });
                 const dayLabel = day.toUpperCase();
                 
                 reportsHtml += `<div style="margin-bottom: 2rem;">`;

--- a/tests/v2/test_finish_area_pdf.py
+++ b/tests/v2/test_finish_area_pdf.py
@@ -1,0 +1,58 @@
+"""Smoke tests for finish-area operational PDF (Issue #743 extension)."""
+
+from pathlib import Path
+
+import pandas as pd
+
+from app.finish_area_pdf import (
+    expected_runners_for_day,
+    generate_finish_area_demand_pdf,
+    _operational_tier,
+)
+
+
+def test_operational_tier_thresholds():
+    assert _operational_tier(0, 100) == "—"
+    assert _operational_tier(90, 100) == "Peak / surge"
+    assert _operational_tier(50, 100) == "High"
+    assert _operational_tier(15, 100) == "Moderate"
+    assert _operational_tier(5, 100) == "Low"
+
+
+def test_expected_runners_for_day():
+    cfg = {
+        "events": [
+            {"day": "sat", "runners": 100},
+            {"day": "sun", "runners": 200},
+            {"day": "sun", "runners": 50},
+        ]
+    }
+    assert expected_runners_for_day(cfg, "sat") == 100
+    assert expected_runners_for_day(cfg, "sun") == 250
+    assert expected_runners_for_day({}, "sat") is None
+
+
+def test_generate_finish_area_demand_pdf_writes_file(tmp_path: Path):
+    csv_path = tmp_path / "finish_times.csv"
+    pdf_path = tmp_path / "finish_area_demand.pdf"
+    df = pd.DataFrame(
+        {
+            "day": ["sat", "sat", "sat", "sat"],
+            "time_window_start": ["08:00:00", "08:00:00", "08:20:00", "08:20:00"],
+            "time_window_end": ["08:19:59", "08:19:59", "08:39:59", "08:39:59"],
+            "event": ["full", "all", "full", "all"],
+            "count": [10, 10, 5, 5],
+        }
+    )
+    df.to_csv(csv_path, index=False)
+
+    ok = generate_finish_area_demand_pdf(
+        finish_times_csv=csv_path,
+        output_pdf=pdf_path,
+        day_display_name="Saturday",
+        run_id="test-run",
+        expected_runner_total=15,
+    )
+    assert ok is True
+    assert pdf_path.is_file()
+    assert pdf_path.stat().st_size > 500

--- a/tests/v2/test_finish_times_report.py
+++ b/tests/v2/test_finish_times_report.py
@@ -1,0 +1,91 @@
+"""Issue #743: finish_times.csv aggregation (20-minute naive-clock buckets)."""
+
+import pandas as pd
+import pytest
+
+from app.core.v2.models import Day, Event
+from app.core.v2.timings import (
+    build_runner_finish_times_df,
+    finish_bucket_start_sec,
+    write_finish_times_csv,
+)
+
+
+def test_finish_bucket_start_sec_boundary():
+    # End of first 20-minute slot within 08:xx hour
+    s_end = 8 * 3600 + 19 * 60 + 59
+    assert finish_bucket_start_sec(s_end) == 8 * 3600
+
+    # Exact start of second slot
+    s_second = 8 * 3600 + 20 * 60
+    assert finish_bucket_start_sec(s_second) == 8 * 3600 + 20 * 60
+
+    # Third slot in hour
+    s_third = 8 * 3600 + 45 * 60
+    assert finish_bucket_start_sec(s_third) == 8 * 3600 + 40 * 60
+
+
+def test_build_runner_finish_times_df_matches_formula():
+    events = [
+        Event(
+            name="full",
+            day=Day.SUN,
+            start_time=420,
+            gpx_file="f.gpx",
+            runners_file="f.csv",
+        ),
+    ]
+    analysis_config = {}
+    runners_df = pd.DataFrame(
+        [
+            {"runner_id": "a", "event": "full", "pace": 10.0, "distance": 1.0, "start_offset": 0},
+        ]
+    )
+    df = build_runner_finish_times_df(
+        events=events, analysis_config=analysis_config, runners_df=runners_df
+    )
+    assert df is not None and len(df) == 1
+    # 420 min gun -> 25200 s + pace 10 min/km * 1 km -> 600 s
+    assert pytest.approx(df.iloc[0]["finish_time_sec"], rel=1e-9) == 25200 + 600
+
+
+def test_write_finish_times_csv_nonzero_rows_and_all(tmp_path):
+    finish_df = pd.DataFrame(
+        {
+            "runner_id": ["1", "2", "3"],
+            "event": ["full", "full", "half"],
+            "finish_time_sec": [
+                8 * 3600 + 5 * 60,
+                8 * 3600 + 10 * 60,
+                8 * 3600 + 8 * 60,
+            ],
+        }
+    )
+    out = tmp_path / "finish_times.csv"
+    assert write_finish_times_csv(out, "sun", finish_df) is True
+    text = out.read_text(encoding="utf-8")
+    lines = [ln for ln in text.splitlines() if ln.strip()]
+    # header + 2 event rows + all row (same window)
+    assert lines[0].startswith("day,time_window_start")
+    body = lines[1:]
+    assert len(body) == 3
+    assert any(",full,2" in ln for ln in body)
+    assert any(",half,1" in ln for ln in body)
+    assert any(",all,3" in ln for ln in body)
+
+
+def test_write_finish_times_csv_blank_line_between_hours(tmp_path):
+    finish_df = pd.DataFrame(
+        {
+            "runner_id": ["1", "2"],
+            "event": ["full", "full"],
+            "finish_time_sec": [
+                8 * 3600 + 15 * 60,
+                9 * 3600 + 5 * 60,
+            ],
+        }
+    )
+    out = tmp_path / "finish_times.csv"
+    assert write_finish_times_csv(out, "sun", finish_df) is True
+    raw = out.read_text(encoding="utf-8")
+    assert "\n\n" in raw

--- a/tests/v2/test_finish_times_report.py
+++ b/tests/v2/test_finish_times_report.py
@@ -74,7 +74,8 @@ def test_write_finish_times_csv_nonzero_rows_and_all(tmp_path):
     assert any(",all,3" in ln for ln in body)
 
 
-def test_write_finish_times_csv_blank_line_between_hours(tmp_path):
+def test_write_finish_times_csv_no_blank_lines_between_hours(tmp_path):
+    """Strict CSV: no empty rows when buckets span different clock hours."""
     finish_df = pd.DataFrame(
         {
             "runner_id": ["1", "2"],
@@ -88,4 +89,7 @@ def test_write_finish_times_csv_blank_line_between_hours(tmp_path):
     out = tmp_path / "finish_times.csv"
     assert write_finish_times_csv(out, "sun", finish_df) is True
     raw = out.read_text(encoding="utf-8")
-    assert "\n\n" in raw
+    assert "\n\n" not in raw
+    lines = [ln for ln in raw.splitlines() if ln.strip()]
+    # header + (full + all) per bucket × 2 buckets
+    assert len(lines) == 1 + 4


### PR DESCRIPTION
## Summary

- `finish_times.csv`: predicted finisher counts by 20-minute clock window (per event and `all`), aligned with timings math; strict CSV without blank separator rows.
- Reports UI/API: surface `finish_times.csv`; include `finish_area_demand.pdf` in the curated list with description.
- `finish_area_demand.pdf`: per-day PDF from `finish_times.csv` (bar chart, cumulative curve, demand table for `event=all`), generated in Phase 10 after the CSV.
- Tests: finish-time CSV shape; PDF smoke and tier helpers.

Closes #743

Made with [Cursor](https://cursor.com)