### PR TITLE
Locations: loc sheet links, popup first/last runner, reorder (#745)

### DIFF
--- a/app/routes/api_locations.py
+++ b/app/routes/api_locations.py
@@ -27,6 +27,42 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _merge_onepage_into_report_rows(
+    report_data: list,
+    locations_results: Optional[Dict[str, Any]],
+    selected_day: str,
+) -> None:
+    """
+    Issue #745: Add ``onepage`` per row from locations_results.json (SSOT for loc sheets).
+
+    Day matching matches ``build_loc_sheet_entries`` / Loc Sheets index behavior.
+    """
+    sel = (selected_day or "").strip().lower()
+    if not locations_results:
+        for row in report_data:
+            row["onepage"] = "n"
+        return
+
+    onepage_by_id: Dict[str, str] = {}
+    for loc in locations_results.get("locations") or []:
+        if not isinstance(loc, dict):
+            continue
+        loc_day = str(loc.get("day", "")).strip().lower()
+        if loc_day and loc_day != sel:
+            continue
+        lid = loc.get("loc_id")
+        if lid is None or str(lid).strip() == "":
+            continue
+        key = str(lid).strip()
+        raw = str(loc.get("onepage", "")).strip().lower()
+        onepage_by_id[key] = raw if raw else "n"
+
+    for row in report_data:
+        lid = row.get("loc_id")
+        key = str(lid).strip() if lid is not None else ""
+        row["onepage"] = onepage_by_id.get(key, "n")
+
+
 @router.get("/api/locations")
 async def get_locations_report(
     request: Request,
@@ -37,7 +73,8 @@ async def get_locations_report(
     """
     Get locations report data.
     
-    Issue #277: Returns location report as JSON.
+    Issue #277: Returns location report as JSON. Issue #745: each row may include
+    ``onepage`` (y|n) from ``locations_results.json`` for loc sheet link eligibility.
     
     Args:
         run_id: Optional run ID (defaults to latest)
@@ -66,15 +103,16 @@ async def get_locations_report(
         selected_day, available_days = resolve_selected_day(run_id, day)
         storage = create_runflow_storage(run_id)
         
-        # Issue #591: Load resources_available from locations_results.json
+        # Issue #591 / #745: Load locations_results.json for resources_available and onepage (SSOT)
         resources_available = []
+        locations_results: Optional[Dict[str, Any]] = None
         locations_results_path = f"{selected_day}/computation/locations_results.json"
         if storage.exists(locations_results_path):
             try:
                 locations_results = storage.read_json(locations_results_path)
                 resources_available = locations_results.get("resources_available", [])
             except Exception as e:
-                logger.warning(f"Could not load resources_available from {locations_results_path}: {e}")
+                logger.warning(f"Could not load locations_results from {locations_results_path}: {e}")
         
         # Try to load existing report from day-scoped path
         report_path = f"{selected_day}/reports/Locations.csv"
@@ -94,6 +132,7 @@ async def get_locations_report(
                 # Convert flag column: handle both boolean and string representations
                 df['flag'] = df['flag'].apply(lambda x: True if (x is True or str(x).lower() in ['true', '1', 'y', 'yes']) else False)
             report_data = df.to_dict('records')
+            _merge_onepage_into_report_rows(report_data, locations_results, selected_day)
         elif generate:
             # Generate new report
             # Issue #512: Start times must be provided - cannot use hardcoded constants

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -213,6 +213,20 @@ function createLocationPopup(properties) {
     if (locStartFormatted && locEndFormatted) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Operational Window:</strong> ${locStartFormatted} → ${locEndFormatted}</div>`;
     }
+
+    // First/last runner — same rules as Course Resource Timing table (locations.html)
+    const firstRunnerRaw = props.first_runner;
+    const firstRunnerFormatted = (firstRunnerRaw && firstRunnerRaw !== "NA" && firstRunnerRaw !== "null")
+        ? (formatTimeToHHMM(firstRunnerRaw) || "—")
+        : "—";
+    const lastRunnerRaw = props.last_runner;
+    const lastRunnerFormatted = (lastRunnerRaw && lastRunnerRaw !== "NA" && lastRunnerRaw !== "null")
+        ? (formatTimeToHHMM(lastRunnerRaw) || "—")
+        : "—";
+    const firstLastRunner = (firstRunnerFormatted !== "—" && lastRunnerFormatted !== "—")
+        ? `${firstRunnerFormatted} → ${lastRunnerFormatted}`
+        : "—";
+    popup += `<div style="margin-bottom: 0.5rem;"><strong>First/last runner:</strong> ${firstLastRunner}</div>`;
     
     if (duration != null) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Duration:</strong> ${duration} minutes</div>`;

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -44,7 +44,8 @@ function convertToGeoJSON(locations) {
                 flagged_seg_id: loc.flagged_seg_id,  // Issue #598: Include flagged_seg_id
                 flag_severity: loc.flag_severity,     // Issue #598: Include flag_severity
                 flag_worst_los: loc.flag_worst_los,   // Issue #598: Include flag_worst_los
-                flag_note: loc.flag_note              // Issue #598: Include flag_note
+                flag_note: loc.flag_note,             // Issue #598: Include flag_note
+                onepage: loc.onepage                // Issue #745: SSOT for loc sheet links (table)
             };
             
             // Issue #591: Dynamically add all resource count and mins fields

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -202,17 +202,16 @@ function createLocationPopup(properties) {
         }
     }
     
-    let popup = `
-        <div style="font-family: Arial, sans-serif; font-size: 14px; width: 260px;">
-            <h3 style="margin: 0 0 0.5rem 0; font-size: 16px; color: #2c3e50;">${heading}</h3>
-            <div style="margin-bottom: 0.5rem;">
-                <strong>Type:</strong> <span style="color: ${getLocationMarkerColor(locType)}; font-weight: bold;">${locType}</span>
-            </div>
-    `;
-    
-    if (locStartFormatted && locEndFormatted) {
-        popup += `<div style="margin-bottom: 0.5rem;"><strong>Operational Window:</strong> ${locStartFormatted} → ${locEndFormatted}</div>`;
-    }
+    const resourceCounts = [];
+    Object.keys(props).forEach(key => {
+        if (key.endsWith('_count')) {
+            const count = props[key];
+            if (count && count > 0) {
+                const resource = key.replace('_count', '').toUpperCase();
+                resourceCounts.push(`${resource}: ${count}`);
+            }
+        }
+    });
 
     // First/last runner — same rules as Course Resource Timing table (locations.html)
     const firstRunnerRaw = props.first_runner;
@@ -226,33 +225,35 @@ function createLocationPopup(properties) {
     const firstLastRunner = (firstRunnerFormatted !== "—" && lastRunnerFormatted !== "—")
         ? `${firstRunnerFormatted} → ${lastRunnerFormatted}`
         : "—";
-    popup += `<div style="margin-bottom: 0.5rem;"><strong>First/last runner:</strong> ${firstLastRunner}</div>`;
-    
+
+    let popup = `
+        <div style="font-family: Arial, sans-serif; font-size: 14px; width: 260px;">
+            <h3 style="margin: 0 0 0.5rem 0; font-size: 16px; color: #2c3e50;">${heading}</h3>
+            <div style="margin-bottom: 0.5rem;">
+                <strong>Type:</strong> <span style="color: ${getLocationMarkerColor(locType)}; font-weight: bold;">${locType}</span>
+            </div>
+    `;
+
+    if (resourceCounts.length > 0) {
+        popup += `<div style="margin-bottom: 0.5rem;"><strong>Resources:</strong> ${resourceCounts.join(', ')}</div>`;
+    }
+
+    if (locStartFormatted && locEndFormatted) {
+        popup += `<div style="margin-bottom: 0.5rem;"><strong>Operational Window:</strong> ${locStartFormatted} → ${locEndFormatted}</div>`;
+    }
+
     if (duration != null) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Duration:</strong> ${duration} minutes</div>`;
     }
-    
+
+    popup += `<div style="margin-bottom: 0.5rem;"><strong>First/last runner:</strong> ${firstLastRunner}</div>`;
+
     if (peakStartFormatted && peakEndFormatted) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Peak Window:</strong> ${peakStartFormatted} → ${peakEndFormatted}</div>`;
     }
-    
+
     if (props.zone) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Zone:</strong> ${props.zone}</div>`;
-    }
-    
-    // Issue #592: Add resource counts to popup (after Zone, before Source)
-    const resourceCounts = [];
-    Object.keys(props).forEach(key => {
-        if (key.endsWith('_count')) {
-            const count = props[key];
-            if (count && count > 0) {
-                const resource = key.replace('_count', '').toUpperCase();
-                resourceCounts.push(`${resource}: ${count}`);
-            }
-        }
-    });
-    if (resourceCounts.length > 0) {
-        popup += `<div style="margin-bottom: 0.5rem;"><strong>Resources:</strong> ${resourceCounts.join(', ')}</div>`;
     }
     
     // Issue #598: Add flag to popup

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -382,6 +382,7 @@
     <script>
     (function() {
         const CLOUD_MODE = {% if cloud_mode %}true{% else %}false{% endif %};
+        window.CLOUD_UI = CLOUD_MODE;
         const CLOUD_RUN_ID = {{ cloud_run_id_json | default('null') | safe }};
         const CLOUD_AVAILABLE_DAYS = {{ cloud_available_days_json | default('[]') | safe }};
 

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -224,7 +224,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-05-03T745Z2"></script>
+<script src="/static/js/map/locations.js?v=2026-05-03T745Z3"></script>
 
 <!-- Table interaction script -->
 <script>

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -35,6 +35,15 @@
     .location-popup {
         font-size: 0.875rem;
     }
+    
+    #locations-table a.loc-sheet-link {
+        color: #0d6efd;
+        text-decoration: underline;
+        font-weight: 500;
+    }
+    #locations-table a.loc-sheet-link:hover {
+        color: #0a58ca;
+    }
 </style>
 {% endblock %}
 
@@ -215,7 +224,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-01-23T1730Z"></script>
+<script src="/static/js/map/locations.js?v=2026-05-03T745Z"></script>
 
 <!-- Table interaction script -->
 <script>
@@ -334,7 +343,8 @@
                 peak_end: feature.properties.peak_end,
                 timing_source: feature.properties.timing_source,
                 first_runner: feature.properties.first_runner,
-                last_runner: feature.properties.last_runner
+                last_runner: feature.properties.last_runner,
+                onepage: feature.properties.onepage
             };
             // Issue #591: Dynamically add all resource count and mins fields
             // Issue #598: Include flag fields
@@ -389,7 +399,8 @@
                 peak_end: feature.properties.peak_end,
                 timing_source: feature.properties.timing_source,
                 first_runner: feature.properties.first_runner,
-                last_runner: feature.properties.last_runner
+                last_runner: feature.properties.last_runner,
+                onepage: feature.properties.onepage
             };
             // Issue #591: Dynamically add all resource count and mins fields
             // Issue #598: Include flag fields
@@ -1048,6 +1059,50 @@
         });
     }
     
+    function escapeHtml(str) {
+        if (str == null || str === undefined) return '';
+        return String(str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function getRunDayForLocSheets() {
+        const params = new URLSearchParams(window.location.search);
+        const day = (params.get('day') || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
+        const run_id = (params.get('run_id') || (window.runflowDay && window.runflowDay.run_id) || '').trim();
+        return { day, run_id };
+    }
+
+    /**
+     * Issue #745: Location column — link to loc sheet when onepage=y (paths match pages/locsheets.html).
+     */
+    function formatLocationCellHtml(location) {
+        const rawLabel = location.loc_label;
+        const displayText = rawLabel != null && rawLabel !== '' ? String(rawLabel) : '—';
+        const escaped = escapeHtml(displayText);
+        if (String(location.onepage || '').toLowerCase() !== 'y') {
+            return escaped;
+        }
+        const { day, run_id } = getRunDayForLocSheets();
+        if (!day) {
+            return escaped;
+        }
+        const lid = String(location.loc_id);
+        const cloudUi = !!window.CLOUD_UI;
+        let path;
+        if (cloudUi) {
+            path = `/locsheets/${encodeURIComponent(day)}/${encodeURIComponent(lid)}`;
+        } else {
+            if (!run_id) {
+                return escaped;
+            }
+            path = `/locsheets/${encodeURIComponent(run_id)}/${encodeURIComponent(day)}/${encodeURIComponent(lid)}`;
+        }
+        return `<a href="${path}" target="_blank" rel="noopener" class="loc-sheet-link" onclick="event.stopPropagation()">${escaped}</a>`;
+    }
+    
     function renderLocationsTable(locations) {
         const tbody = document.getElementById('locations-tbody');
         tbody.innerHTML = '';
@@ -1059,9 +1114,6 @@
         
         locations.forEach(location => {
             const row = document.createElement('tr');
-            
-            // Format values with fallback to "—" for null/NA
-            const locLabel = location.loc_label || "—";
             
             // Format location type
             const locType = location.loc_type && location.loc_type !== "NA" ? location.loc_type : "—";
@@ -1111,7 +1163,7 @@
             // Column order: ID, Location, Type, Zone, Flag, Operational Window, First/Last Runner, Peak Window
             row.innerHTML = `
                 <td>${locId}</td>
-                <td>${locLabel}</td>
+                <td>${formatLocationCellHtml(location)}</td>
                 <td>${locType}</td>
                 <td>${zone}</td>
                 <td>${flagDisplay}</td>

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -224,7 +224,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-05-03T745Z"></script>
+<script src="/static/js/map/locations.js?v=2026-05-03T745Z2"></script>
 
 <!-- Table interaction script -->
 <script>

--- a/tests/unit/test_api_locations_onepage_merge.py
+++ b/tests/unit/test_api_locations_onepage_merge.py
@@ -1,0 +1,35 @@
+"""Issue #745: onepage merge from locations_results.json into /api/locations rows."""
+
+from app.routes.api_locations import _merge_onepage_into_report_rows
+
+
+def test_merge_sets_y_for_matching_day_and_loc_id():
+    report = [{"loc_id": 73, "loc_label": "A"}]
+    results = {
+        "locations": [
+            {"loc_id": 73, "day": "sun", "onepage": "y"},
+            {"loc_id": 74, "day": "sun", "onepage": "y"},
+        ]
+    }
+    _merge_onepage_into_report_rows(report, results, "sun")
+    assert report[0]["onepage"] == "y"
+
+
+def test_merge_skips_wrong_day():
+    report = [{"loc_id": 73, "loc_label": "A"}]
+    results = {"locations": [{"loc_id": 73, "day": "sat", "onepage": "y"}]}
+    _merge_onepage_into_report_rows(report, results, "sun")
+    assert report[0]["onepage"] == "n"
+
+
+def test_merge_empty_locations_results_defaults_n():
+    report = [{"loc_id": 1}]
+    _merge_onepage_into_report_rows(report, None, "sun")
+    assert report[0]["onepage"] == "n"
+
+
+def test_merge_matches_loc_id_string_coercion():
+    report = [{"loc_id": "73"}]
+    results = {"locations": [{"loc_id": 73, "day": "sun", "onepage": "y"}]}
+    _merge_onepage_into_report_rows(report, results, "sun")
+    assert report[0]["onepage"] == "y"


### PR DESCRIPTION
Closes #745

Locations table links when onepage=y; API merge; map popup first/last and reordered fields.

Made with [Cursor](https://cursor.com)