### PR TITLE
Add loc_type extract + nearest-segment GPX fix (#747)

### DIFF
--- a/app/location_report.py
+++ b/app/location_report.py
@@ -369,13 +369,35 @@ def find_nearest_segment(
                 if from_km <= distance_km <= to_km:
                     # Check distance from location to segment centerline
                     seg_id = seg_row["seg_id"]
-                    
-                    # Get segment centerline
+
+                    # Issue #655 / extract+empty seg_id: generate_segment_coordinates requires
+                    # segment_label, direction, width_m (same as calculate_arrival_times_for_location).
+                    seg_label = seg_row.get("seg_label") or seg_row.get("segment_label")
+                    if not seg_label:
+                        logger.warning(
+                            "find_nearest_segment: segment %s missing seg_label/segment_label; skipping",
+                            seg_id,
+                        )
+                        continue
+                    direction = seg_row.get("direction")
+                    width_m = seg_row.get("width_m")
+                    if not direction or width_m is None or (
+                        isinstance(width_m, float) and pd.isna(width_m)
+                    ):
+                        logger.warning(
+                            "find_nearest_segment: segment %s missing direction or width_m; skipping",
+                            seg_id,
+                        )
+                        continue
+
                     segments_list = [{
                         "seg_id": seg_id,
+                        "segment_label": seg_label,
+                        "direction": direction,
+                        "width_m": width_m,
                         event_col: "y",
                         f"{event_col}_from_km": from_km,
-                        f"{event_col}_to_km": to_km
+                        f"{event_col}_to_km": to_km,
                     }]
                     seg_coords = generate_segment_coordinates(courses, segments_list)
                     

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -191,10 +191,11 @@ RUN_ID_MIN_LENGTH = 10
 LOCATION_SNAP_THRESHOLD_M = 50.0  # Maximum distance for snapping location to segment
 LOCATION_SETUP_BUFFER_MINUTES = 45  # Minutes before earliest runner start for loc_start
 
-# Course Mapping location types (Issue #732) — alphabetical for UI dropdown
+# Course Mapping location types (Issue #732 / #747) — alphabetical for UI dropdown
 LOCATION_TYPE_CHOICES = [
     "aid",
     "course",
+    "extraction",
     "official",
     "traffic",
     "water",

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -195,7 +195,7 @@ LOCATION_SETUP_BUFFER_MINUTES = 45  # Minutes before earliest runner start for l
 LOCATION_TYPE_CHOICES = [
     "aid",
     "course",
-    "extraction",
+    "extract",
     "official",
     "traffic",
     "water",

--- a/docs/dev-guides/data-sources.md
+++ b/docs/dev-guides/data-sources.md
@@ -401,6 +401,7 @@ runner_id,event,pace,distance,start_offset,day
 **Required Columns**:
 - `loc_id`: Location identifier
 - `loc_label`: Human-readable label
+- `loc_type`: Location category; allowed values are **`LOCATION_TYPE_CHOICES`** in `app/utils/constants.py` (SSOT for Course Mapping and Locations UI).
 - `seg_id`: Associated segment ID
 - `timing_source`: Source of timing data (e.g., "proxy:n")
 

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -175,7 +175,7 @@ document.addEventListener('DOMContentLoaded', function () {
     var LOCATION_PIN_COLORS = {
         aid: '#e74c3c',
         course: '#27ae60',
-        extraction: '#9c27b0',
+        extract: '#9c27b0',
         official: '#f1c40f',
         traffic: '#95a5a6',
         water: '#3498db'

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -172,7 +172,14 @@ document.addEventListener('DOMContentLoaded', function () {
 
     var LOCATION_TYPES = (window.LOCATION_TYPES_FROM_SERVER || []).slice().sort(function (a, b) { return (a.label || a.value).localeCompare(b.label || b.value); });
     var EVENT_CHOICES = window.EVENT_CHOICES_FROM_SERVER || [{ value: 'full', label: 'Full' }, { value: 'half', label: 'Half' }, { value: '10k', label: '10K' }, { value: 'elite', label: 'Elite' }, { value: 'open', label: 'Open' }];
-    var LOCATION_PIN_COLORS = { aid: '#e74c3c', course: '#27ae60', official: '#f1c40f', traffic: '#95a5a6', water: '#3498db' };
+    var LOCATION_PIN_COLORS = {
+        aid: '#e74c3c',
+        course: '#27ae60',
+        extraction: '#9c27b0',
+        official: '#f1c40f',
+        traffic: '#95a5a6',
+        water: '#3498db'
+    };
     var SEGMENT_PIN_COLOR = '#3498db';
     var ROUTE_LINE_STYLE = { color: '#2f9e44', weight: 2, opacity: 0.45, dashArray: '4 6' };
     var SEGMENT_HIT_STYLE = { color: '#2f9e44', weight: 20, opacity: 0, dashArray: '4 6' };

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -12,7 +12,9 @@ const locationTypeColors = {
     'course': '#4CAF50',   // Green
     'aid': '#F44336',      // Red
     'water': '#2196F3',    // Blue
-    'marshal': '#FF9800'   // Orange
+    'marshal': '#FF9800',  // Orange (legacy)
+    'official': '#FFC107', // Amber
+    'extraction': '#9C27B0' // Purple — remote trail extraction / stretcher access (Issue #747)
 };
 
 /**

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -14,7 +14,7 @@ const locationTypeColors = {
     'water': '#2196F3',    // Blue
     'marshal': '#FF9800',  // Orange (legacy)
     'official': '#FFC107', // Amber
-    'extraction': '#9C27B0' // Purple — remote trail extraction / stretcher access (Issue #747)
+    'extract': '#9C27B0' // Purple — remote trail extract / stretcher access (Issue #747)
 };
 
 /**

--- a/frontend/templates/pages/course_mapping.html
+++ b/frontend/templates/pages/course_mapping.html
@@ -317,7 +317,7 @@
 
 <div class="card" id="locations-card" style="margin-top: 1rem; display: none;">
     <h3 style="margin-bottom: 0.5rem;">Locations</h3>
-    <p id="locations-empty" style="color: #95a5a6; font-size: 0.875rem;">Add location pins on the map (types are selected per pin; includes extraction for remote trail stretcher access).</p>
+    <p id="locations-empty" style="color: #95a5a6; font-size: 0.875rem;">Add location pins on the map (types are selected per pin; includes extract for remote trail stretcher access).</p>
     <div id="locations-table-wrap" style="display: none;">
         <table id="locations-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
             <thead>

--- a/frontend/templates/pages/course_mapping.html
+++ b/frontend/templates/pages/course_mapping.html
@@ -317,7 +317,7 @@
 
 <div class="card" id="locations-card" style="margin-top: 1rem; display: none;">
     <h3 style="margin-bottom: 0.5rem;">Locations</h3>
-    <p id="locations-empty" style="color: #95a5a6; font-size: 0.875rem;">Add location pins on the map (aid, course, official, traffic, water).</p>
+    <p id="locations-empty" style="color: #95a5a6; font-size: 0.875rem;">Add location pins on the map (types are selected per pin; includes extraction for remote trail stretcher access).</p>
     <div id="locations-table-wrap" style="display: none;">
         <table id="locations-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
             <thead>

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -194,7 +194,7 @@
             </tr>
             <tr>
                 <td><strong>Type</strong></td>
-                <td>The location type: <em>traffic</em> (traffic control), <em>course</em> (on-course), <em>water</em> (water stop), <em>aid</em> (aid station), <em>official</em> (official point), <em>extraction</em> (remote trail extraction / stretcher-mule access), or <em>marshal</em> (legacy marshal point).</td>
+                <td>The location type: <em>traffic</em> (traffic control), <em>course</em> (on-course), <em>water</em> (water stop), <em>aid</em> (aid station), <em>official</em> (official point), <em>extract</em> (remote trail extract / stretcher-mule access), or <em>marshal</em> (legacy marshal point).</td>
             </tr>
             <tr>
                 <td><strong>Zone</strong></td>
@@ -224,7 +224,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-05-03T747Z"></script>
+<script src="/static/js/map/locations.js?v=2026-05-03T747Z-extract"></script>
 
 <!-- Table interaction script -->
 <script>
@@ -870,7 +870,7 @@
             'water': '#2196F3',    // Blue
             'marshal': '#FF9800',  // Orange (legacy)
             'official': '#FFC107', // Amber
-            'extraction': '#9C27B0' // Purple (Issue #747)
+            'extract': '#9C27B0' // Purple (Issue #747)
         };
         return locationTypeColors[locType?.toLowerCase()] || '#999999';
     }

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -194,7 +194,7 @@
             </tr>
             <tr>
                 <td><strong>Type</strong></td>
-                <td>The location type: <em>traffic</em> (traffic control point), <em>course</em> (on-course location), <em>water</em> (water stop), <em>aid</em> (aid station), or <em>marshal</em> (marshal point).</td>
+                <td>The location type: <em>traffic</em> (traffic control), <em>course</em> (on-course), <em>water</em> (water stop), <em>aid</em> (aid station), <em>official</em> (official point), <em>extraction</em> (remote trail extraction / stretcher-mule access), or <em>marshal</em> (legacy marshal point).</td>
             </tr>
             <tr>
                 <td><strong>Zone</strong></td>
@@ -224,7 +224,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-05-03T745Z3"></script>
+<script src="/static/js/map/locations.js?v=2026-05-03T747Z"></script>
 
 <!-- Table interaction script -->
 <script>
@@ -868,7 +868,9 @@
             'course': '#4CAF50',   // Green
             'aid': '#F44336',      // Red
             'water': '#2196F3',    // Blue
-            'marshal': '#FF9800'   // Orange
+            'marshal': '#FF9800',  // Orange (legacy)
+            'official': '#FFC107', // Amber
+            'extraction': '#9C27B0' // Purple (Issue #747)
         };
         return locationTypeColors[locType?.toLowerCase()] || '#999999';
     }

--- a/tests/unit/test_location_type_choices.py
+++ b/tests/unit/test_location_type_choices.py
@@ -1,10 +1,10 @@
-"""Issue #747: LOCATION_TYPE_CHOICES includes extraction and stays sorted."""
+"""Issue #747: LOCATION_TYPE_CHOICES includes extract and stays sorted."""
 
 from app.utils.constants import LOCATION_TYPE_CHOICES
 
 
-def test_extraction_in_location_type_choices():
-    assert "extraction" in LOCATION_TYPE_CHOICES
+def test_extract_in_location_type_choices():
+    assert "extract" in LOCATION_TYPE_CHOICES
 
 
 def test_location_type_choices_sorted():

--- a/tests/unit/test_location_type_choices.py
+++ b/tests/unit/test_location_type_choices.py
@@ -1,0 +1,11 @@
+"""Issue #747: LOCATION_TYPE_CHOICES includes extraction and stays sorted."""
+
+from app.utils.constants import LOCATION_TYPE_CHOICES
+
+
+def test_extraction_in_location_type_choices():
+    assert "extraction" in LOCATION_TYPE_CHOICES
+
+
+def test_location_type_choices_sorted():
+    assert LOCATION_TYPE_CHOICES == sorted(LOCATION_TYPE_CHOICES)


### PR DESCRIPTION
## Summary
- Add `extract` location type for remote trail extraction points (colors, constants, docs).
- Rename slug from `extraction` to `extract`.
- **Fix:** `find_nearest_segment` now passes `segment_label`, `direction`, and `width_m` to `generate_segment_coordinates`, matching Issue #655 requirements. Rows with empty `seg_id` (including `extract`) no longer crash Sunday/locations report generation.

Closes #747

Made with [Cursor](https://cursor.com)