### PR TITLE
Combined run-level Locations.csv + day column in per-day report (#749)

### DIFF
--- a/app/core/v2/reports.py
+++ b/app/core/v2/reports.py
@@ -4,6 +4,8 @@ Runflow v2 Reports Module
 Generates day-partitioned reports (Density.md, Flow.csv, Locations.csv)
 organized in runflow/analysis/{run_id}/{day}/reports/ structure.
 
+Also writes a run-level ``Locations.csv`` (all days) to ``runflow/analysis/{run_id}/Locations.csv``. Issue #749.
+
 Phase 6: Reports & Artifacts (Issue #500)
 
 Issue #600: Flow.md generation deprecated (only Flow.csv is used)
@@ -16,9 +18,71 @@ import logging
 
 from app.core.v2.models import Day, Event
 from app.core.v2.timeline import DayTimeline
-from app.utils.run_id import get_runflow_root
+from app.utils.run_id import get_runflow_root, DAY_ORDER
 
 logger = logging.getLogger(__name__)
+
+
+def write_combined_locations_csv(run_dir: Path) -> Optional[Path]:
+    """
+    Issue #749: Merge ``{day}/reports/Locations.csv`` into ``run_dir/Locations.csv``.
+
+    Days follow chronological ``DAY_ORDER`` (fri→mon). Rows sort by day then ``loc_id``.
+    Per-day files missing or unreadable are skipped.
+
+    Args:
+        run_dir: Run root directory (``runflow/analysis/{run_id}``).
+
+    Returns:
+        Path to combined CSV, or None if no per-day reports existed.
+    """
+    import pandas as pd
+
+    frames: List[pd.DataFrame] = []
+    for day_code in DAY_ORDER:
+        path = run_dir / day_code / "reports" / "Locations.csv"
+        if not path.exists():
+            continue
+        try:
+            df = pd.read_csv(path)
+        except Exception as e:
+            logger.warning("Issue #749: Could not read %s: %s", path, e)
+            continue
+        if df.empty:
+            continue
+        df = _normalize_locations_report_day_column(df, day_code)
+        frames.append(df)
+
+    if not frames:
+        return None
+
+    combined = pd.concat(frames, ignore_index=True)
+    combined["_sort_day"] = combined["day"].astype(str).str.lower().map(
+        lambda d: DAY_ORDER.index(d) if d in DAY_ORDER else len(DAY_ORDER)
+    )
+    combined["_sort_loc"] = pd.to_numeric(combined["loc_id"], errors="coerce")
+    combined = combined.sort_values(
+        by=["_sort_day", "_sort_loc"], ascending=[True, True], na_position="last"
+    )
+    combined = combined.drop(columns=["_sort_day", "_sort_loc"])
+    out_path = run_dir / "Locations.csv"
+    combined.to_csv(out_path, index=False)
+    logger.info("Issue #749: Wrote combined locations report: %s (%s rows)", out_path, len(combined))
+    return out_path
+
+
+def _normalize_locations_report_day_column(df: Any, day_code: str) -> Any:
+    """Ensure ``day`` is present and placed immediately after ``loc_label``."""
+    out = df.copy()
+    if "day" in out.columns:
+        out = out.drop(columns=["day"])
+    if "loc_label" in out.columns:
+        col_list = list(out.columns)
+        pos = col_list.index("loc_label") + 1
+        out.insert(pos, "day", day_code)
+    else:
+        out["day"] = day_code
+    return out
 
 
 def get_day_output_path(
@@ -93,7 +157,9 @@ def generate_reports_per_day(
         
         Issue #682: Updated to use runflow/analysis/{run_id} structure
         }
-        Note: Issue #600 - Flow.md generation deprecated (only Flow.csv used)
+        Also writes ``runflow/analysis/{run_id}/Locations.csv`` when any per-day
+        locations report exists (Issue #749). Note: Issue #600 - Flow.md generation
+        deprecated (only Flow.csv used)
     """
     # Issue #616: File paths should be provided from analysis.json in v2 pipeline
     # These defaults should not be hit in production, but kept for backward compatibility
@@ -277,6 +343,13 @@ def generate_reports_per_day(
             f"Generated {len(day_report_paths)} reports for day {day.value} "
             f"in {reports_path}"
         )
+    
+    # Issue #749: Merge per-day Locations.csv into run-level Locations.csv
+    try:
+        from app.utils.run_id import get_run_directory
+        write_combined_locations_csv(get_run_directory(run_id))
+    except Exception as e:
+        logger.warning("Issue #749: Combined Locations.csv not written: %s", e)
     
     return report_paths_by_day
 

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -784,10 +784,12 @@ def generate_location_report(
         
         # Initialize report row
         # Issue #589: Field order matches loc_expected.csv specification
+        # Issue #749: day column after loc_label (explicit when CSV opened standalone)
         # Issue #598: Add flag fields for flag propagation
         report_row = {
             "loc_id": loc_id,
             "loc_label": loc_label,
+            "day": day or "",
             "loc_type": loc_type,
             "loc_direction": location.get("loc_direction", ""),  # Issue #589: Add this
             "lat": location.get("lat"),
@@ -1185,7 +1187,7 @@ def generate_location_report(
     # Issue #589: Reorder columns to match expected order
     # Base fields (in order from loc_expected.csv)
     base_fields = [
-        "loc_id", "loc_label", "loc_type", "loc_direction",
+        "loc_id", "loc_label", "day", "loc_type", "loc_direction",
         "lat", "lon", "zone",
         "buffer", "interval",
         "first_runner", "peak_start", "peak_end", "last_runner",

--- a/docs/dev-guides/data-sources.md
+++ b/docs/dev-guides/data-sources.md
@@ -541,7 +541,8 @@ This section maps each UI page to its API endpoints and underlying artifact sour
 - `GET /api/locations` - Locations report data
 
 **Artifact Sources:**
-- `reports/Locations.csv` → Location report data
+- `{day}/reports/Locations.csv` → Day-scoped location report (includes `day` column after `loc_label`; Issue #749)
+- `Locations.csv` (run root, next to day folders) → Combined file for all days in chronological order (Issue #749)
 - `computation/locations_results.json` → `resources_available` array
 
 **UI Elements → Data Mapping:**

--- a/tests/unit/test_combined_locations_csv.py
+++ b/tests/unit/test_combined_locations_csv.py
@@ -1,0 +1,53 @@
+"""Issue #749: run-level combined Locations.csv."""
+
+import pandas as pd
+
+from app.core.v2.reports import write_combined_locations_csv
+
+
+def test_write_combined_locations_csv_none_when_no_day_reports(tmp_path):
+    run_dir = tmp_path / "rid"
+    run_dir.mkdir()
+    assert write_combined_locations_csv(run_dir) is None
+
+
+def test_write_combined_orders_by_day_then_loc_id(tmp_path):
+    run_dir = tmp_path / "runid"
+    # Intentionally create sun before sat to prove order comes from DAY_ORDER, not disk
+    for day, loc_ids in [("sun", [10, 5]), ("sat", [3, 1])]:
+        d = run_dir / day / "reports"
+        d.mkdir(parents=True, exist_ok=True)
+        df = pd.DataFrame(
+            {
+                "loc_id": loc_ids,
+                "loc_label": [f"L{i}" for i in loc_ids],
+                "loc_type": ["course"] * len(loc_ids),
+            }
+        )
+        df.to_csv(d / "Locations.csv", index=False)
+
+    out = write_combined_locations_csv(run_dir)
+    assert out is not None
+    assert out == run_dir / "Locations.csv"
+    comb = pd.read_csv(out)
+    assert list(comb["day"]) == ["sat", "sat", "sun", "sun"]
+    assert list(comb["loc_id"]) == [1, 3, 5, 10]
+    # day column immediately after loc_label
+    assert list(comb.columns[:3]) == ["loc_id", "loc_label", "day"]
+
+
+def test_normalization_inserts_day_from_path(tmp_path):
+    run_dir = tmp_path / "runid"
+    d = run_dir / "fri" / "reports"
+    d.mkdir(parents=True, exist_ok=True)
+    pd.DataFrame(
+        {
+            "loc_id": [1],
+            "loc_label": ["A"],
+            "loc_type": ["course"],
+        }
+    ).to_csv(d / "Locations.csv", index=False)
+
+    out = write_combined_locations_csv(run_dir)
+    comb = pd.read_csv(out)
+    assert comb["day"].tolist() == ["fri"]


### PR DESCRIPTION
## Summary
Implements [issue #749](https://github.com/thomjeff/run-density/issues/749).

- **Per-day** `{day}/reports/Locations.csv`: new `day` column immediately after `loc_label`.
- **Run-level** `runflow/analysis/{run_id}/Locations.csv`: concatenation of all per-day reports that exist, days in `DAY_ORDER` (fri→sat→sun→mon), rows sorted by `loc_id` within each day.
- **When:** end of `generate_reports_per_day` (non-fatal if combine fails).
- **Docs:** `data-sources.md` artifact list.
- **Tests:** `tests/unit/test_combined_locations_csv.py`.

Closes #749

Made with [Cursor](https://cursor.com)