### PR TITLE
Export segments.csv from config package course (#758)

### DIFF
--- a/app/core/config_package/__init__.py
+++ b/app/core/config_package/__init__.py
@@ -3,12 +3,14 @@ Race configuration packages under runflow/config/{config_id}/.
 
 Issue #756: UUID config_id + manifest (config.json) + course.json workspace.
 Issue #757: load/save course.json via config package APIs.
+Issue #758: export segments.csv from course.json into config package.
 """
 
 from app.core.config_package.storage import (
     append_package_index,
     create_config_package,
     default_course_json,
+    export_config_package_segments,
     get_config_root,
     import_runner_files_from_package,
     list_config_packages,
@@ -27,6 +29,7 @@ __all__ = [
     "append_package_index",
     "create_config_package",
     "default_course_json",
+    "export_config_package_segments",
     "get_config_root",
     "import_runner_files_from_package",
     "list_config_packages",

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -13,7 +13,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from app.core.course.export import enrich_segments_event_distances
+from app.core.course.export import build_segments_csv, enrich_segments_event_distances
+from app.io.loader import load_segments
 from app.utils.constants import COURSE_EVENT_IDS
 from app.utils.run_id import generate_run_id, get_runflow_root
 
@@ -546,3 +547,67 @@ def import_runner_files_from_package(
         target_id,
     )
     return copied
+
+
+def _validate_exported_segments_file(segments_path: Path) -> None:
+    """Fail-fast checks so exported segments.csv is loadable by the pipeline."""
+    if not segments_path.is_file():
+        raise FileNotFoundError(f"segments.csv not written: {segments_path}")
+    df = load_segments(str(segments_path))
+    if df.empty:
+        raise ValueError("segments.csv must contain at least one row")
+    if "seg_id" not in df.columns:
+        raise ValueError("segments.csv missing seg_id column")
+    if df["seg_id"].duplicated().any():
+        dupes = df[df.duplicated(subset=["seg_id"], keep=False)]["seg_id"].tolist()
+        raise ValueError(f"Duplicate seg_id values: {dupes}")
+    for col in ("width_m", "schema", "direction"):
+        if col not in df.columns:
+            raise ValueError(f"segments.csv missing required column: {col}")
+    for eid in COURSE_EVENT_IDS:
+        if eid not in df.columns:
+            raise ValueError(f"segments.csv missing event column: {eid}")
+        from_col = f"{eid}_from_km"
+        to_col = f"{eid}_to_km"
+        if from_col not in df.columns or to_col not in df.columns:
+            raise ValueError(f"segments.csv missing km columns for {eid}")
+
+
+def export_config_package_segments(config_id: str) -> Dict[str, Any]:
+    """
+    Export segments.csv from package course.json into runflow/config/{config_id}/.
+
+    Backs up existing segments.csv to segments.csv.bak.{timestamp} when present.
+
+    Raises:
+        FileNotFoundError: Package or course.json missing
+        ValueError: No segments or validation failed
+    """
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    course = load_config_course(cid)
+    segments = course.get("segments") or []
+    if not segments:
+        raise ValueError("Course has no segments; add segment pins before export")
+
+    enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
+    csv_content = build_segments_csv(course, fmt="pipeline")
+
+    target = package_path / "segments.csv"
+    backup_path: Optional[Path] = None
+    if target.is_file():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        backup_path = package_path / f"segments.csv.bak.{stamp}"
+        shutil.copy2(target, backup_path)
+
+    target.write_text(csv_content, encoding="utf-8")
+    _validate_exported_segments_file(target)
+
+    logger.info("Exported segments.csv for config package %s (%s rows)", cid, len(segments))
+    return {
+        "config_id": cid,
+        "path": str(target),
+        "backup_path": str(backup_path) if backup_path else None,
+        "segment_count": len(segments),
+        "readiness": package_readiness(package_path),
+    }

--- a/app/core/course/export.py
+++ b/app/core/course/export.py
@@ -8,7 +8,7 @@ import csv
 import io
 import json
 import zipfile
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 import xml.etree.ElementTree as ET
 
 from app.utils.constants import COURSE_EVENT_IDS
@@ -36,8 +36,65 @@ def _pin_label(course: Dict[str, Any], index: int, coords_len: int, role: str) -
 
 
 def _segment_display_id(segment_index: int) -> str:
-    """Return segment ID as sequential number (1, 2, 3, ...) for pipeline compatibility."""
+    """Return segment ID as sequential number (1, 2, 3, ...) for legacy export."""
     return str(segment_index + 1)
+
+
+def _format_km_pipeline(value: float) -> str:
+    """Format km like 2026_final segments.csv (0, 0.9 — not always two decimals)."""
+    v = round(float(value), 2)
+    if v == int(v):
+        return str(int(v))
+    text = format(v, ".2f")
+    return text.rstrip("0").rstrip(".")
+
+
+def _leg_letter_from_break_id(raw: Any, leg_order: List[str]) -> str:
+    """Map segment_break_ids value to leg letter A, B, C, …"""
+    key = str(raw).strip()
+    if not key:
+        return "A"
+    if len(key) == 1 and key.isalpha():
+        return key.upper()
+    if key not in leg_order:
+        leg_order.append(key)
+    idx = leg_order.index(key)
+    if idx < 26:
+        return chr(ord("A") + idx)
+    return f"L{idx + 1}"
+
+
+def _resolve_pipeline_seg_id(
+    course: Dict[str, Any],
+    seg: Dict[str, Any],
+    segment_index: int,
+    leg_order: List[str],
+    leg_counters: Dict[str, int],
+    prev_leg: Optional[str],
+) -> tuple:
+    """
+    Resolve 2026-style seg_id (e.g. A1, B1). Returns (seg_id, leg_letter).
+    """
+    stored = (seg.get("seg_id") or "").strip()
+    if stored:
+        leg = stored[0].upper() if stored[0].isalpha() else (prev_leg or "A")
+        return stored, leg
+
+    break_ids = course.get("segment_break_ids") or {}
+    start_idx = seg.get("start_index", 0)
+    raw_leg = break_ids.get(start_idx)
+    if raw_leg is None:
+        raw_leg = break_ids.get(str(start_idx))
+
+    if raw_leg is not None and str(raw_leg).strip():
+        leg = _leg_letter_from_break_id(raw_leg, leg_order)
+    elif prev_leg:
+        leg = prev_leg
+    else:
+        leg = "A"
+
+    leg_counters[leg] = leg_counters.get(leg, 0) + 1
+    return f"{leg}{leg_counters[leg]}", leg
 
 
 def _segment_events_set(seg: Dict[str, Any], event_ids: List[str]) -> set:
@@ -102,38 +159,60 @@ def enrich_segments_event_distances(segments: List[Dict], event_ids: List[str] =
             seg[f"{eid}_to_km"] = round(float(to_km), 2)
 
 
-def build_segments_csv(course: Dict[str, Any]) -> str:
-    """Build segments.csv content from course.segments and course.events.
-    Uses sequential segment IDs (1, 2, 3, ...) for pipeline compatibility.
+def build_segments_csv(course: Dict[str, Any], fmt: str = "pipeline") -> str:
+    """
+    Build segments.csv from course.segments.
+
+    Args:
+        course: Course workspace dict (course.json).
+        fmt: ``pipeline`` (2026-style: leg seg_id, no pin columns) or ``legacy`` (pins + sequential ids).
+
     Event-specific from_km/to_km are cumulative along only segments that use that event.
     """
     segments = course.get("segments") or []
-    # Event list from constants (SSOT); course.json does not store events
     event_ids = COURSE_EVENT_IDS
     coords = (course.get("geometry") or {}).get("coordinates") or []
     coords_len = len(coords)
+    use_pipeline = fmt != "legacy"
+    km_fmt = _format_km_pipeline if use_pipeline else _format_km
 
-    # Per-segment, per-event (from_km, to_km) using event-cumulative distance
     event_distances = _event_cumulative_distances(segments, event_ids)
 
     out = io.StringIO()
-    # Header: seg_id, seg_label, pin_start_label, pin_end_label, width_m, schema, direction, then y/n, then per-event from_km/to_km/length
     event_cols = []
     for eid in event_ids:
         event_cols.extend([f"{eid}_from_km", f"{eid}_to_km"])
     length_cols = [f"{eid}_length" for eid in event_ids]
-    header = (
-        ["seg_id", "seg_label", "pin_start_label", "pin_end_label", "width_m", "schema", "direction"]
-        + event_ids
-        + event_cols
-        + length_cols
-        + ["description"]
-    )
+    if use_pipeline:
+        header = (
+            ["seg_id", "seg_label", "width_m", "schema", "direction"]
+            + event_ids
+            + event_cols
+            + length_cols
+            + ["description"]
+        )
+    else:
+        header = (
+            ["seg_id", "seg_label", "pin_start_label", "pin_end_label", "width_m", "schema", "direction"]
+            + event_ids
+            + event_cols
+            + length_cols
+            + ["description"]
+        )
     w = csv.writer(out)
     w.writerow(header)
 
+    leg_order: List[str] = []
+    leg_counters: Dict[str, int] = {}
+    prev_leg: Optional[str] = None
+
     for i, seg in enumerate(segments):
-        seg_id = _segment_display_id(i)
+        if use_pipeline:
+            seg_id, prev_leg = _resolve_pipeline_seg_id(
+                course, seg, i, leg_order, leg_counters, prev_leg
+            )
+        else:
+            seg_id = _segment_display_id(i)
         seg_label = seg.get("seg_label", "")
         start_idx = seg.get("start_index", 0)
         end_idx = seg.get("end_index", coords_len - 1 if coords_len else 0)
@@ -145,23 +224,25 @@ def build_segments_csv(course: Dict[str, Any]) -> str:
         from_km = float(seg.get("from_km") or 0)
         to_km = float(seg.get("to_km") or 0)
         seg_events = _segment_events_set(seg, event_ids)
-        # y/n per event (use lowercase for lookup)
         yn = ["y" if eid.lower() in seg_events else "n" for eid in event_ids]
-        # Event-specific from_km/to_km: use stored per-event values if present, else computed
         event_km = []
         for eid in event_ids:
             eid_lower = eid.lower()
             ev_from = seg.get(f"{eid_lower}_from_km")
             ev_to = seg.get(f"{eid_lower}_to_km")
             if ev_from is not None and ev_to is not None:
-                event_km.extend([_format_km(ev_from), _format_km(ev_to)])
+                event_km.extend([km_fmt(ev_from), km_fmt(ev_to)])
             else:
                 ev_from, ev_to = event_distances[i].get(eid_lower, (0.0, 0.0))
-                event_km.extend([_format_km(ev_from), _format_km(ev_to)])
+                event_km.extend([km_fmt(ev_from), km_fmt(ev_to)])
         seg_len = round(to_km - from_km, 2)
-        lengths = [_format_km(seg_len) if eid.lower() in seg_events else "0.00" for eid in event_ids]
+        zero_km = km_fmt(0.0) if use_pipeline else _format_km(0.0)
+        lengths = [km_fmt(seg_len) if eid.lower() in seg_events else zero_km for eid in event_ids]
         description = seg.get("description", "")
-        row = [seg_id, seg_label, pin_start, pin_end, width_m, schema, direction] + yn + event_km + lengths + [description]
+        if use_pipeline:
+            row = [seg_id, seg_label, width_m, schema, direction] + yn + event_km + lengths + [description]
+        else:
+            row = [seg_id, seg_label, pin_start, pin_end, width_m, schema, direction] + yn + event_km + lengths + [description]
         w.writerow(row)
     return out.getvalue()
 

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -3,6 +3,7 @@ API routes for Race Configuration packages (config_id).
 
 Issue #756: List, create, and resolve packages under runflow/config/{config_id}/.
 Issue #757: GET/PUT course.json workspace per config_id.
+Issue #758: Export segments.csv from course.json into config package.
 """
 
 import logging
@@ -14,6 +15,7 @@ from pydantic import BaseModel, Field
 
 from app.core.config_package import (
     create_config_package,
+    export_config_package_segments,
     import_runner_files_from_package,
     list_config_packages,
     load_config_course,
@@ -189,6 +191,28 @@ async def api_save_config_course(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to save course: {e}",
+        )
+
+
+@router.post("/api/config/packages/{config_id}/export/segments")
+async def api_export_config_package_segments(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """Export segments.csv from package course.json (2026-style pipeline format)."""
+    require_auth(request)
+    try:
+        result = export_config_package_segments(config_id)
+        return JSONResponse(content={"ok": True, **result})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to export config package segments")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to export segments: {e}",
         )
 
 

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -33,8 +33,8 @@ document.addEventListener('DOMContentLoaded', function () {
         if (btnDelete) btnDelete.style.display = 'none';
         var btnExport = document.getElementById('btn-export');
         if (btnExport) {
-            btnExport.disabled = true;
-            btnExport.title = 'Export CSV/GPX to package folder (#758)';
+            btnExport.disabled = false;
+            btnExport.title = 'Write segments.csv to this config package';
         }
     }
 
@@ -2946,8 +2946,30 @@ document.addEventListener('DOMContentLoaded', function () {
 
         var btnExport = document.getElementById('btn-export');
         if (btnExport) {
-            btnExport.addEventListener('click', function () {
+            btnExport.addEventListener('click', async function () {
                 if (!currentCourseId || !currentCourse) return;
+                if (isConfigPackageMode) {
+                    if (!currentCourse.segments || currentCourse.segments.length === 0) {
+                        alert('Add segment pins on the course line before exporting segments.csv.');
+                        return;
+                    }
+                    if (isDirty()) {
+                        alert('Save the course (Edit → Save) before exporting segments.csv.');
+                        return;
+                    }
+                    try {
+                        var url = '/api/config/packages/' + encodeURIComponent(configPackageId) + '/export/segments';
+                        var res = await fetch(url, { method: 'POST', credentials: 'same-origin' });
+                        var data = await res.json();
+                        if (!res.ok) throw new Error(data.detail || res.statusText);
+                        var msg = 'segments.csv exported to config package';
+                        if (data.backup_path) msg += ' (previous file backed up)';
+                        alert(msg);
+                    } catch (e) {
+                        alert('Export failed: ' + (e.message || String(e)));
+                    }
+                    return;
+                }
                 var url = '/api/courses/' + encodeURIComponent(currentCourseId) + '/export?to_folder=1';
                 fetch(url).then(function (r) { return r.json(); }).then(function (data) {
                     if (data.ok) alert('All map files exported to map folder.');

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -216,7 +216,7 @@
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/course_mapping.js?v=757a"></script>
+<script src="/static/js/map/course_mapping.js?v=758a"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=757b"></script>
 {% endblock %}

--- a/tests/unit/test_config_package_export_segments.py
+++ b/tests/unit/test_config_package_export_segments.py
@@ -1,0 +1,145 @@
+"""Unit tests for config package segments.csv export (Issue #758)."""
+
+import csv
+import io
+from pathlib import Path
+
+import pytest
+
+from app.core.config_package.storage import export_config_package_segments
+from app.core.course.export import build_segments_csv
+from app.io.loader import load_segments
+
+
+def test_build_segments_csv_pipeline_uses_stored_seg_id_and_2026_header():
+    course = {
+        "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1], [2, 2], [3, 3]]},
+        "segment_break_ids": {},
+        "segments": [
+            {
+                "seg_id": "A1",
+                "seg_label": "Shared start",
+                "from_km": 0,
+                "to_km": 1,
+                "events": ["full", "half"],
+                "width_m": 5,
+                "schema": "on_course_open",
+                "direction": "uni",
+            },
+            {
+                "seg_id": "B1",
+                "seg_label": "10K only",
+                "from_km": 1,
+                "to_km": 2,
+                "events": ["10k"],
+                "width_m": 1.5,
+                "schema": "on_course_narrow",
+                "direction": "bi",
+            },
+        ],
+    }
+    csv_content = build_segments_csv(course, fmt="pipeline")
+    reader = csv.DictReader(io.StringIO(csv_content))
+    rows = list(reader)
+    assert "pin_start_label" not in reader.fieldnames
+    assert rows[0]["seg_id"] == "A1"
+    assert rows[1]["seg_id"] == "B1"
+    assert rows[0]["full"] == "y" and rows[0]["half"] == "y" and rows[0]["10k"] == "n"
+    assert rows[1]["full"] == "n" and rows[1]["10k"] == "y"
+    assert float(rows[1]["10k_from_km"]) == pytest.approx(0.0)
+    assert float(rows[1]["10k_to_km"]) == pytest.approx(1.0)
+    assert float(rows[1]["full_from_km"]) == pytest.approx(0.0)
+    assert float(rows[1]["full_to_km"]) == pytest.approx(0.0)
+
+
+def test_export_config_package_segments_writes_and_validates(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    config_id = "pkg758test01"
+    package = tmp_path / config_id
+    package.mkdir()
+    (package / "config.json").write_text(
+        '{"config_id":"pkg758test01","label":"Test","legacy":false}',
+        encoding="utf-8",
+    )
+    course = {
+        "id": config_id,
+        "config_id": config_id,
+        "segments": [
+            {
+                "seg_id": "A1",
+                "seg_label": "Leg A",
+                "from_km": 0,
+                "to_km": 0.5,
+                "events": ["full"],
+                "width_m": 5,
+                "schema": "on_course_open",
+                "direction": "uni",
+            }
+        ],
+        "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
+    }
+    (package / "course.json").write_text(
+        __import__("json").dumps(course),
+        encoding="utf-8",
+    )
+
+    result = export_config_package_segments(config_id)
+    segments_path = Path(result["path"])
+    assert segments_path.is_file()
+    assert result["segment_count"] == 1
+    df = load_segments(str(segments_path))
+    assert len(df) == 1
+    assert df.iloc[0]["seg_id"] == "A1"
+
+
+def test_export_backs_up_existing_segments(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    config_id = "pkg758backup1"
+    package = tmp_path / config_id
+    package.mkdir()
+    (package / "config.json").write_text("{}", encoding="utf-8")
+    (package / "segments.csv").write_text("old,data\n1,2\n", encoding="utf-8")
+    course = {
+        "id": config_id,
+        "segments": [
+            {
+                "seg_id": "C1",
+                "seg_label": "New",
+                "from_km": 0,
+                "to_km": 1,
+                "events": ["elite"],
+                "width_m": 3,
+                "schema": "on_course_open",
+                "direction": "uni",
+            }
+        ],
+    }
+    (package / "course.json").write_text(
+        __import__("json").dumps(course),
+        encoding="utf-8",
+    )
+
+    result = export_config_package_segments(config_id)
+    assert result["backup_path"] is not None
+    assert Path(result["backup_path"]).is_file()
+    assert "old,data" in Path(result["backup_path"]).read_text()
+
+
+def test_export_rejects_empty_segments(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    config_id = "pkg758empty1"
+    package = tmp_path / config_id
+    package.mkdir()
+    (package / "course.json").write_text('{"id":"x","segments":[]}', encoding="utf-8")
+
+    with pytest.raises(ValueError, match="no segments"):
+        export_config_package_segments(config_id)

--- a/tests/unit/test_course_export.py
+++ b/tests/unit/test_course_export.py
@@ -49,7 +49,7 @@ def test_build_segments_csv_half_from_to_km():
             {"seg_label": "Station to Finish", "from_km": 8.2, "to_km": 10.08, "events": ["full", "half", "10k"], "start_index": 4, "end_index": 5},
         ],
     }
-    csv_content = build_segments_csv(course)
+    csv_content = build_segments_csv(course, fmt="legacy")
     reader = csv.DictReader(io.StringIO(csv_content))
     rows = list(reader)
     assert len(rows) == 5


### PR DESCRIPTION
## Summary
- Extend `build_segments_csv()` with **pipeline** format matching `2026_final`: leg `seg_id` (A1, B1, …), no pin columns, per-event cumulative km
- `POST /api/config/packages/{config_id}/export/segments` writes `runflow/config/{id}/segments.csv` with `.bak.{timestamp}` backup
- **Export** enabled on Race Configuration Course tab (config package mode)
- Validates exported file via `load_segments` and required columns

## Test plan
- [x] `pytest tests/unit/test_config_package_export_segments.py tests/unit/test_course_export.py`
- [ ] Manual: draw course → segment pins → Save → Export → confirm `segments.csv` in package folder

Closes #758

Made with [Cursor](https://cursor.com)