### PR TITLE
Course mapping UX, map styling, and locations export

### DIFF
--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -13,7 +13,11 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from app.core.course.export import build_segments_csv, enrich_segments_event_distances
+from app.core.course.export import (
+    build_locations_csv,
+    build_segments_csv,
+    enrich_segments_event_distances,
+)
 from app.io.loader import load_segments
 from app.utils.constants import COURSE_EVENT_IDS
 from app.utils.run_id import generate_run_id, get_runflow_root
@@ -168,6 +172,21 @@ def validate_config_course_data(course_data: Any, config_id: str) -> Dict[str, A
     return course_data
 
 
+def _normalize_course_locations(course_data: Dict[str, Any]) -> None:
+    """Migrate deprecated loc_description to notes; drop loc_direction if present."""
+    locations = course_data.get("locations")
+    if not isinstance(locations, list):
+        return
+    for loc in locations:
+        if not isinstance(loc, dict):
+            continue
+        if loc.get("loc_description") and not loc.get("notes"):
+            loc["notes"] = str(loc.pop("loc_description")).strip()
+        elif "loc_description" in loc:
+            loc.pop("loc_description", None)
+        loc.pop("loc_direction", None)
+
+
 def load_config_course(config_id: str) -> Dict[str, Any]:
     """
     Load course.json from runflow/config/{config_id}/.
@@ -187,6 +206,7 @@ def load_config_course(config_id: str) -> Dict[str, Any]:
     if not isinstance(data, dict):
         raise ValueError(f"Invalid {COURSE_WORKSPACE_NAME} in package {config_id}")
     data.pop("events", None)
+    _normalize_course_locations(data)
     return data
 
 
@@ -201,6 +221,7 @@ def save_config_course(config_id: str, course_data: Dict[str, Any]) -> Path:
     cid = validate_config_id(config_id)
     package_path = resolve_config_package_path(cid)
     data = validate_config_course_data(course_data, cid)
+    _normalize_course_locations(data)
 
     data = dict(data)
     data["id"] = cid
@@ -603,11 +624,30 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
     target.write_text(csv_content, encoding="utf-8")
     _validate_exported_segments_file(target)
 
-    logger.info("Exported segments.csv for config package %s (%s rows)", cid, len(segments))
+    locations_target = package_path / "locations.csv"
+    locations_backup_path: Optional[Path] = None
+    locations = course.get("locations") or []
+    locations_csv = build_locations_csv(course)
+    if locations_target.is_file():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        locations_backup_path = package_path / f"locations.csv.bak.{stamp}"
+        shutil.copy2(locations_target, locations_backup_path)
+    locations_target.write_text(locations_csv, encoding="utf-8")
+
+    logger.info(
+        "Exported segments.csv (%s rows) and locations.csv (%s rows) for config package %s",
+        len(segments),
+        len(locations),
+        cid,
+    )
     return {
         "config_id": cid,
         "path": str(target),
         "backup_path": str(backup_path) if backup_path else None,
+        "segments_backup_path": str(backup_path) if backup_path else None,
         "segment_count": len(segments),
+        "locations_path": str(locations_target),
+        "locations_backup_path": str(locations_backup_path) if locations_backup_path else None,
+        "location_count": len(locations),
         "readiness": package_readiness(package_path),
     }

--- a/app/core/course/export.py
+++ b/app/core/course/export.py
@@ -268,19 +268,21 @@ def build_flow_csv(course: Dict[str, Any]) -> str:
 
 
 def build_locations_csv(course: Dict[str, Any]) -> str:
-    """Build locations.csv from course.locations (minimal columns)."""
+    """Build locations.csv from course.locations (minimal columns; notes for loc sheets)."""
     locations = course.get("locations") or []
     out = io.StringIO()
     w = csv.writer(out)
-    w.writerow(["loc_id", "loc_label", "loc_type", "loc_description", "lat", "lon"])
+    w.writerow(["loc_id", "loc_label", "loc_type", "lat", "lon", "notes"])
     for i, loc in enumerate(locations):
         loc_id = loc.get("id", i + 1)
         loc_label = loc.get("loc_label", "")
         loc_type = loc.get("loc_type", "course")
-        loc_description = loc.get("loc_description", "")
         lat = loc.get("lat", "")
         lon = loc.get("lon", "")
-        w.writerow([loc_id, loc_label, loc_type, loc_description, lat, lon])
+        notes = loc.get("notes", "")
+        if not notes and loc.get("loc_description"):
+            notes = loc.get("loc_description", "")
+        w.writerow([loc_id, loc_label, loc_type, lat, lon, notes])
     return out.getvalue()
 
 

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -199,7 +199,7 @@ async def api_export_config_package_segments(
     request: Request,
     config_id: str,
 ) -> JSONResponse:
-    """Export segments.csv from package course.json (2026-style pipeline format)."""
+    """Export segments.csv and locations.csv from package course.json."""
     require_auth(request)
     try:
         result = export_config_package_segments(config_id)

--- a/frontend/static/js/map/base_map.js
+++ b/frontend/static/js/map/base_map.js
@@ -46,8 +46,8 @@ function initMap(containerId, options) {
     // Store reference to prevent double initialization
     window.existingMap = map;
     
-    // Primary tile layer - Carto Light (minimal, grayscale-friendly styling)
-    const cartoLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/light_all/{z}/{x}/{y}{r}.png', {
+    // Primary tile layer - Carto Voyager (richer street detail, similar to route-planning maps)
+    const cartoLayer = L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
         attribution: '© OpenStreetMap contributors, © CARTO',
         maxZoom: 19
     });

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -225,6 +225,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         if (currentCourse && !Array.isArray(currentCourse.segment_breaks)) currentCourse.segment_breaks = [];
         if (currentCourse && !Array.isArray(currentCourse.locations)) currentCourse.locations = [];
+        if (currentCourse) normalizeCourseLocations(currentCourse);
         if (currentCourse && !Array.isArray(currentCourse.flow_control_points)) currentCourse.flow_control_points = [];
         if (currentCourse && typeof currentCourse.segment_break_labels !== 'object') currentCourse.segment_break_labels = {};
         if (currentCourse && typeof currentCourse.segment_break_descriptions !== 'object') currentCourse.segment_break_descriptions = {};
@@ -252,6 +253,23 @@ document.addEventListener('DOMContentLoaded', function () {
         fitMapToCourse();
     }
 
+    /** Drop deprecated loc_description; migrate into notes for one-pager export. */
+    function normalizeCourseLocations(course) {
+        if (!course || !Array.isArray(course.locations)) return;
+        course.locations.forEach(function (loc) {
+            if (loc.loc_description && !loc.notes) {
+                loc.notes = String(loc.loc_description).trim();
+            }
+            if (loc.loc_description != null) delete loc.loc_description;
+        });
+    }
+
+    function truncateNotesPreview(notes, maxLen) {
+        var s = (notes || '').trim();
+        if (!s) return '—';
+        return s.length <= maxLen ? s : s.slice(0, maxLen) + '…';
+    }
+
     var LOCATION_TYPES = (window.LOCATION_TYPES_FROM_SERVER || []).slice().sort(function (a, b) { return (a.label || a.value).localeCompare(b.label || b.value); });
     var EVENT_CHOICES = window.EVENT_CHOICES_FROM_SERVER || [{ value: 'full', label: 'Full' }, { value: 'half', label: 'Half' }, { value: '10k', label: '10K' }, { value: 'elite', label: 'Elite' }, { value: 'open', label: 'Open' }];
     var LOCATION_PIN_COLORS = {
@@ -262,9 +280,12 @@ document.addEventListener('DOMContentLoaded', function () {
         traffic: '#95a5a6',
         water: '#3498db'
     };
-    var SEGMENT_PIN_COLOR = '#3498db';
-    var ROUTE_LINE_STYLE = { color: '#2f9e44', weight: 2, opacity: 0.45, dashArray: '4 6' };
-    var SEGMENT_HIT_STYLE = { color: '#2f9e44', weight: 20, opacity: 0, dashArray: '4 6' };
+    var ROUTE_COLOR = '#2563eb';
+    var ROUTE_LINE_CASING_STYLE = { color: '#ffffff', weight: 7, opacity: 0.9, lineCap: 'round', lineJoin: 'round' };
+    var ROUTE_LINE_STYLE = { color: ROUTE_COLOR, weight: 5, opacity: 0.92, lineCap: 'round', lineJoin: 'round' };
+    var SEGMENT_HIT_STYLE = { color: ROUTE_COLOR, weight: 22, opacity: 0, lineCap: 'round', lineJoin: 'round' };
+    var START_MARKER = { bg: '#22c55e', border: '#15803d' };
+    var FINISH_MARKER = { bg: '#ef4444', border: '#b91c1c' };
     var SCHEMA_OPTIONS = [{ value: 'on_course_open', label: 'on_course_open' }, { value: 'on_course_narrow', label: 'on_course_narrow' }];
     var DIRECTION_OPTIONS = [{ value: 'uni', label: 'uni' }, { value: 'bi', label: 'bi' }];
 
@@ -974,7 +995,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (samePoint && last) {
             var sfIcon = L.divIcon({
                 className: 'start-finish-icon',
-                html: '<div style="width:20px;height:20px;background:#27ae60;color:#fff;border:2px solid #1e8449;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:bold;">S/F</div>',
+                html: '<div style="width:20px;height:20px;background:' + START_MARKER.bg + ';color:#fff;border:3px solid ' + FINISH_MARKER.border + ';border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:10px;font-weight:bold;">S/F</div>',
                 iconSize: [20, 20],
                 iconAnchor: [10, 10]
             });
@@ -982,7 +1003,7 @@ document.addEventListener('DOMContentLoaded', function () {
         } else {
             var startIcon = L.divIcon({
                 className: 'start-finish-icon',
-                html: '<div style="width:20px;height:20px;background:#27ae60;color:#fff;border:2px solid #1e8449;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:bold;">S</div>',
+                html: '<div style="width:20px;height:20px;background:' + START_MARKER.bg + ';color:#fff;border:2px solid ' + START_MARKER.border + ';border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:bold;">S</div>',
                 iconSize: [20, 20],
                 iconAnchor: [10, 10]
             });
@@ -990,7 +1011,7 @@ document.addEventListener('DOMContentLoaded', function () {
             if (coords.length >= 2) {
                 var finishIcon = L.divIcon({
                     className: 'start-finish-icon',
-                    html: '<div style="width:20px;height:20px;background:#27ae60;color:#fff;border:2px solid #1e8449;border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:bold;">F</div>',
+                    html: '<div style="width:20px;height:20px;background:' + FINISH_MARKER.bg + ';color:#fff;border:2px solid ' + FINISH_MARKER.border + ';border-radius:50%;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:bold;">F</div>',
                     iconSize: [20, 20],
                     iconAnchor: [10, 10]
                 });
@@ -1041,6 +1062,9 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             latlngChunks.forEach(function (latlngs) {
             if (latlngs.length < 2) return;
+            var casing = L.polyline(latlngs, ROUTE_LINE_CASING_STYLE);
+            casing._segmentIndex = segIdx;
+            segmentLinesLayer.addLayer(casing);
             var line = L.polyline(latlngs, ROUTE_LINE_STYLE);
             line._segmentIndex = segIdx;
             var openPopup = function (e) {
@@ -1496,16 +1520,6 @@ document.addEventListener('DOMContentLoaded', function () {
         inputLon.style.width = '100%';
         inputLon.style.boxSizing = 'border-box';
         content.appendChild(inputLon);
-        var lblDesc = document.createElement('label');
-        lblDesc.textContent = 'Description (optional)';
-        content.appendChild(lblDesc);
-        var inputDesc = document.createElement('textarea');
-        inputDesc.rows = 2;
-        inputDesc.value = locEl.loc_description || '';
-        inputDesc.style.display = 'block';
-        inputDesc.style.width = '100%';
-        inputDesc.style.boxSizing = 'border-box';
-        content.appendChild(inputDesc);
         var btnSave = document.createElement('button');
         btnSave.type = 'button';
         btnSave.textContent = 'Save';
@@ -1524,7 +1538,6 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             locEl.lat = newLat;
             locEl.lon = newLon;
-            locEl.loc_description = (inputDesc.value || '').trim();
             window.courseMappingMap.closePopup();
             setDirty();
             if (onSave) onSave();
@@ -1717,8 +1730,8 @@ document.addEventListener('DOMContentLoaded', function () {
             var c = coords[idx];
             var label = getSegmentBreakLabel(idx);
             var squareIcon = L.divIcon({
-                className: 'segment-pin-square',
-                html: '<div style="width:12px;height:12px;background:' + SEGMENT_PIN_COLOR + ';border:2px solid #2980b9;border-radius:0;"></div>',
+                className: 'segment-pin-circle',
+                html: '<div style="width:12px;height:12px;background:#fff;border:2px solid ' + ROUTE_COLOR + ';border-radius:50%;"></div>',
                 iconSize: [12, 12],
                 iconAnchor: [6, 6]
             });
@@ -2109,9 +2122,8 @@ document.addEventListener('DOMContentLoaded', function () {
             var tipHtml = buildPopupRowsHtml([
                 { label: 'ID', value: locId },
                 { label: 'Label', value: loc.loc_label || getLocationTypeLabel(loc.loc_type) || 'Location' },
-                { label: 'Type', value: getLocationTypeLabel(loc.loc_type) },
-                { label: 'Description', value: loc.loc_description || '' }
-            ]) + (isEditMode ? '<div class="popup-row" style="font-size:0.75rem;color:#7f8c8d;">(drag to move)</div>' : '');
+                { label: 'Type', value: getLocationTypeLabel(loc.loc_type) }
+            ]) + (isEditMode ? '<div class="popup-row" style="font-size:0.75rem;color:#7f8c8d;">(drag to move; edit details in Locations table)</div>' : '');
             m.bindTooltip(tipHtml, { permanent: false, direction: 'top', offset: [0, -10], className: 'course-map-tooltip' });
             m.on('dragend', function () {
                 var ll = m.getLatLng();
@@ -2130,13 +2142,13 @@ document.addEventListener('DOMContentLoaded', function () {
             var locId = locEl.id != null ? String(locEl.id) : (idx + 1);
             var name = locEl.loc_label || getLocationTypeLabel(locEl.loc_type) || 'Location';
             var typeLabel = getLocationTypeLabel(locEl.loc_type);
-            var desc = locEl.loc_description || '';
+            var notesPreview = truncateNotesPreview(locEl.notes, 120);
                 var content = document.createElement('div');
                 content.innerHTML = buildPopupRowsHtml([
                     { label: 'ID', value: locId },
                     { label: 'Label', value: name },
                     { label: 'Type', value: typeLabel },
-                    { label: 'Description', value: desc }
+                    { label: 'Notes', value: notesPreview }
                 ]);
                 content.classList.add('course-map-popup-wrap');
                 if (isEditMode) {
@@ -2195,18 +2207,18 @@ document.addEventListener('DOMContentLoaded', function () {
                     input.style.marginBottom = '8px';
                     input.style.boxSizing = 'border-box';
                     editContent.appendChild(input);
-                    var lblDesc = document.createElement('label');
-                    lblDesc.textContent = 'Description (optional)';
-                    editContent.appendChild(lblDesc);
-                    var inputDesc = document.createElement('textarea');
-                    inputDesc.rows = 2;
-                    inputDesc.placeholder = 'Description';
-                    inputDesc.value = locEl.loc_description || '';
-                    inputDesc.style.display = 'block';
-                    inputDesc.style.width = '100%';
-                    inputDesc.style.marginBottom = '8px';
-                    inputDesc.style.boxSizing = 'border-box';
-                    editContent.appendChild(inputDesc);
+                    var lblNotes = document.createElement('label');
+                    lblNotes.textContent = 'Notes (optional, for loc sheets)';
+                    editContent.appendChild(lblNotes);
+                    var inputNotes = document.createElement('textarea');
+                    inputNotes.rows = 3;
+                    inputNotes.placeholder = 'Operational notes for resources at this location';
+                    inputNotes.value = locEl.notes || '';
+                    inputNotes.style.display = 'block';
+                    inputNotes.style.width = '100%';
+                    inputNotes.style.marginBottom = '8px';
+                    inputNotes.style.boxSizing = 'border-box';
+                    editContent.appendChild(inputNotes);
                     var btnSave = document.createElement('button');
                     btnSave.type = 'button';
                     btnSave.textContent = 'Save';
@@ -2220,7 +2232,8 @@ document.addEventListener('DOMContentLoaded', function () {
                     btnSave.onclick = function () {
                         locEl.loc_type = sel.value || 'course';
                         locEl.loc_label = (input.value && input.value.trim()) ? input.value.trim() : '';
-                        locEl.loc_description = (inputDesc.value && inputDesc.value.trim()) ? inputDesc.value.trim() : '';
+                        locEl.notes = (inputNotes.value && inputNotes.value.trim()) ? inputNotes.value.trim() : '';
+                        if (locEl.loc_description != null) delete locEl.loc_description;
                         window.courseMappingMap.closePopup();
                         renderLocationPins();
                         renderLocationsList();
@@ -2268,12 +2281,11 @@ document.addEventListener('DOMContentLoaded', function () {
             var tr = document.createElement('tr');
             var typeLabel = getLocationTypeLabel(loc.loc_type);
             var locId = loc.id != null ? String(loc.id) : String(i + 1);
-            var desc = (loc.loc_description || '').trim();
             tr.innerHTML =
-                '<td>' + escapeHtml(typeLabel) + '</td>' +
                 '<td>' + escapeHtml(locId) + '</td>' +
+                '<td>' + escapeHtml(typeLabel) + '</td>' +
                 '<td>' + escapeHtml(loc.loc_label || '') + '</td>' +
-                '<td>' + escapeHtml(desc || '—') + '</td>' +
+                '<td>' + escapeHtml(truncateNotesPreview(loc.notes, 80)) + '</td>' +
                 '<td>' + (isNaN(lat) ? '' : lat.toFixed(5)) + '</td>' +
                 '<td>' + (isNaN(lon) ? '' : lon.toFixed(5)) + '</td>' +
                 '<td><button type="button" class="btn-remove-loc" data-index="' + i + '">Remove</button></td>';
@@ -3016,17 +3028,6 @@ document.addEventListener('DOMContentLoaded', function () {
                 input.style.marginBottom = '8px';
                 input.style.boxSizing = 'border-box';
                 content.appendChild(input);
-                var lblDesc = document.createElement('label');
-                lblDesc.textContent = 'Description (optional)';
-                content.appendChild(lblDesc);
-                var inputDesc = document.createElement('textarea');
-                inputDesc.rows = 2;
-                inputDesc.placeholder = 'Description';
-                inputDesc.style.display = 'block';
-                inputDesc.style.width = '100%';
-                inputDesc.style.marginBottom = '8px';
-                inputDesc.style.boxSizing = 'border-box';
-                content.appendChild(inputDesc);
                 var btnAdd = document.createElement('button');
                 btnAdd.type = 'button';
                 btnAdd.textContent = 'Add';
@@ -3040,12 +3041,11 @@ document.addEventListener('DOMContentLoaded', function () {
                 btnAdd.onclick = function () {
                     var locType = sel.value || 'course';
                     var locLabel = (input.value && input.value.trim()) ? input.value.trim() : '';
-                    var locDesc = (inputDesc.value && inputDesc.value.trim()) ? inputDesc.value.trim() : '';
                     currentCourse.locations.push({
                         id: nextLocationId(),
                         loc_type: locType,
                         loc_label: locLabel,
-                        loc_description: locDesc,
+                        notes: '',
                         lat: e.latlng.lat,
                         lon: e.latlng.lng
                     });
@@ -3159,8 +3159,10 @@ document.addEventListener('DOMContentLoaded', function () {
                         var res = await fetch(url, { method: 'POST', credentials: 'same-origin' });
                         var data = await res.json();
                         if (!res.ok) throw new Error(data.detail || res.statusText);
-                        var msg = 'segments.csv exported to config package';
-                        if (data.backup_path) msg += ' (previous file backed up)';
+                        var msg = 'Exported to config package: segments.csv';
+                        if (data.location_count != null) msg += ', locations.csv (' + data.location_count + ' rows)';
+                        if (data.segments_backup_path) msg += ' (segments.csv backed up)';
+                        if (data.locations_backup_path) msg += ' (locations.csv backed up)';
                         alert(msg);
                     } catch (e) {
                         alert('Export failed: ' + (e.message || String(e)));

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -11,18 +11,29 @@ document.addEventListener('DOMContentLoaded', function () {
     const loadingEl = container.querySelector('.map-loading');
     const toggleEl = document.getElementById('basemap-toggle');
 
-    function getConfigPackageId() {
+    function resolveConfigPackageId() {
         var root = document.getElementById('course-mapping-root');
         if (root && root.dataset && root.dataset.configId) {
             return String(root.dataset.configId).trim();
         }
         var params = new URLSearchParams(window.location.search);
         var fromUrl = params.get('config_id');
-        return fromUrl ? fromUrl.trim() : null;
+        if (fromUrl) return fromUrl.trim();
+        if (currentCourse && currentCourse.config_id) {
+            return String(currentCourse.config_id).trim();
+        }
+        if (window.location.pathname.indexOf('/config') === 0) {
+            var cid = params.get('config_id');
+            if (cid) return cid.trim();
+        }
+        return null;
     }
 
-    var configPackageId = getConfigPackageId();
-    var isConfigPackageMode = !!configPackageId;
+    function isConfigPackageMode() {
+        return !!resolveConfigPackageId();
+    }
+
+    var POPUP_MAX_WIDTH = 375;
 
     function applyConfigPackageUIMode() {
         var listCard = document.getElementById('course-list-card');
@@ -39,17 +50,18 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     function loadConfigPackageCourse() {
-        if (!configPackageId) return;
+        var pkgId = resolveConfigPackageId();
+        if (!pkgId) return;
         fetch(
-            '/api/config/packages/' + encodeURIComponent(configPackageId) + '/course',
+            '/api/config/packages/' + encodeURIComponent(pkgId) + '/course',
             { credentials: 'same-origin' }
         )
             .then(function (res) {
                 if (res.status === 404) {
                     var c = blankCourse();
-                    c.id = configPackageId;
-                    c.config_id = configPackageId;
-                    setCourse(configPackageId, c);
+                    c.id = pkgId;
+                    c.config_id = pkgId;
+                    setCourse(pkgId, c);
                     clearDirty();
                     return null;
                 }
@@ -63,9 +75,9 @@ document.addEventListener('DOMContentLoaded', function () {
             .then(function (data) {
                 if (!data) return;
                 if (data.ok && data.course) {
-                    setCourse(configPackageId, data.course);
+                    setCourse(pkgId, data.course);
                     clearDirty();
-                    console.log('Loaded config package course:', configPackageId);
+                    console.log('Loaded config package course:', pkgId);
                 }
             })
             .catch(function (e) {
@@ -185,7 +197,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
         if (idEl) {
             idEl.textContent = currentCourseId
-                ? (isConfigPackageMode
+                ? (isConfigPackageMode()
                     ? 'Config package: ' + currentCourseId
                     : 'Course: ' + currentCourseId)
                 : '';
@@ -342,9 +354,15 @@ document.addEventListener('DOMContentLoaded', function () {
         // When a pin is removed (one fewer segment), remaining segments keep their ordinal mapping.
         var existingArr = (currentCourse.segments || []).slice();
         function prevAt(ordinal) {
-            if (ordinal < 0 || existingArr.length === 0) return null;
-            var s = existingArr[Math.min(ordinal, existingArr.length - 1)];
+            if (ordinal < 0 || ordinal >= existingArr.length) return null;
+            var s = existingArr[ordinal];
             return s ? { seg_label: s.seg_label, events: s.events, width_m: s.width_m, schema: s.schema, direction: s.direction, description: s.description, info_icon_lat: s.info_icon_lat, info_icon_lon: s.info_icon_lon } : null;
+        }
+        function segmentLabelFromPinRange(startIdx, endIdx, coordsLen, ordinal) {
+            var startLbl = getPinLabelForIndex(startIdx, coordsLen);
+            var endLbl = getPinLabelForIndex(endIdx, coordsLen);
+            if (startLbl && endLbl && startLbl !== endLbl) return startLbl + ' to ' + endLbl;
+            return endLbl || startLbl || ('Segment ' + (ordinal + 1));
         }
         var segs = [];
         var startIdx = 0;
@@ -359,12 +377,12 @@ document.addEventListener('DOMContentLoaded', function () {
             }
             var ordinal = segs.length;
             var prev = prevAt(ordinal);
-            var pinLabel = (currentCourse.segment_break_labels && (currentCourse.segment_break_labels[endIdx] || currentCourse.segment_break_labels['' + endIdx] || '').trim()) || '';
-            var isLastSegment = (b >= breaks.length && endIdx === coords.length - 1);
-            var defaultLabel = pinLabel || (isLastSegment ? 'Finish' : ('Segment ' + (ordinal + 1)));
+            var defaultLabel = segmentLabelFromPinRange(startIdx, endIdx, coords.length, ordinal);
+            var inheritedLabel = (prev && prev.seg_label) ? prev.seg_label : '';
+            var useInherited = inheritedLabel && inheritedLabel !== 'Finish' && !/^Segment \d+$/.test(inheritedLabel);
             segs.push({
                 seg_id: String(segs.length + 1),
-                seg_label: (prev && prev.seg_label) ? prev.seg_label : defaultLabel,
+                seg_label: useInherited ? inheritedLabel : defaultLabel,
                 width_m: (prev && prev.width_m != null) ? prev.width_m : 3,
                 direction: (prev && prev.direction) ? prev.direction : 'uni',
                 schema: (prev && prev.schema) ? prev.schema : 'on_course_open',
@@ -780,7 +798,7 @@ document.addEventListener('DOMContentLoaded', function () {
         btnSave.type = 'button';
         btnSave.textContent = 'Save';
         content.appendChild(btnSave);
-        var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
         btnSave.onclick = function () {
             s.seg_label = (inputLabel.value && inputLabel.value.trim()) ? inputLabel.value.trim() : segId;
             s.width_m = parseFloat(inputWidth.value);
@@ -896,7 +914,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         openSegmentAnnotationPopup(m._segmentIndex, e.latlng);
                     };
                 }
-                var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(info).setLatLng(e.latlng).openOn(window.courseMappingMap);
+                var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(info).setLatLng(e.latlng).openOn(window.courseMappingMap);
             });
             segmentInfoIconsLayer.addLayer(m);
         });
@@ -1058,7 +1076,7 @@ document.addEventListener('DOMContentLoaded', function () {
                             { label: 'Events', value: (s.events || []).join(', ') || '(none)' },
                             { label: 'From–To (km)', value: (s.from_km != null ? s.from_km : '') + ' – ' + (s.to_km != null ? s.to_km : '') }
                         ]);
-                        L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(viewInfo).setLatLng(latlng).openOn(window.courseMappingMap);
+                        L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(viewInfo).setLatLng(latlng).openOn(window.courseMappingMap);
                     }
                 }
             };
@@ -1214,7 +1232,7 @@ document.addEventListener('DOMContentLoaded', function () {
             updateCourseUI();
             window.courseMappingMap.closePopup();
         };
-        var pop = L.popup({ maxWidth: 340, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
     }
 
     /** Open the segment-pin popup (Edit, Delete, Extend from here) at a pin by index. Used when clicking From/To in Segments table. */
@@ -1242,10 +1260,23 @@ document.addEventListener('DOMContentLoaded', function () {
         if (isEditMode) {
             var btnWrap = document.createElement('div');
             btnWrap.style.marginTop = '0.5rem';
+            var pinTitle = isStart ? 'Start' : (isFinish ? 'Finish' : label);
+            addEditLatLonButton(btnWrap, pinIndex, latlng, pinTitle, desc, function (d) {
+                if (isStart) currentCourse.start_description = d;
+                else if (isFinish) currentCourse.end_description = d;
+                else {
+                    if (!currentCourse.segment_break_descriptions) currentCourse.segment_break_descriptions = {};
+                    currentCourse.segment_break_descriptions[pinIndex] = d;
+                }
+            }, function () {
+                renderSegmentPins();
+                renderSegmentsList();
+                updateCourseUI();
+            });
             if (!isStart && !isFinish) {
                 var btnEdit = document.createElement('button');
                 btnEdit.type = 'button';
-                btnEdit.textContent = 'Edit';
+                btnEdit.textContent = 'Edit label';
                 btnEdit.style.marginRight = '6px';
                 btnEdit.style.marginTop = '6px';
                 var btnDel = document.createElement('button');
@@ -1331,21 +1362,9 @@ document.addEventListener('DOMContentLoaded', function () {
                     updateExtendHint();
                 };
             }
-            if (isStart || isFinish) {
-                var btnEditPoint = document.createElement('button');
-                btnEditPoint.type = 'button';
-                btnEditPoint.textContent = 'Edit position';
-                btnEditPoint.style.marginRight = '6px';
-                btnWrap.insertBefore(btnEditPoint, btnExtend);
-                btnEditPoint.onclick = function () {
-                    window.courseMappingMap.closePopup();
-                    var lastIdx = coordsLen - 1;
-                    openPointEditTile(isStart ? 'start' : 'finish', isStart ? 0 : lastIdx, latlng, function () {}, (isStart && lastIdx > 0 && coords[0][0] === coords[lastIdx][0] && coords[0][1] === coords[lastIdx][1]) ? lastIdx : null);
-                };
-            }
             content.appendChild(btnWrap);
         }
-        var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
     }
 
     function nextSegmentPinId() {
@@ -1367,11 +1386,157 @@ document.addEventListener('DOMContentLoaded', function () {
         return max + 1;
     }
 
+    function openCoordinateEditTile(coordIndex, latlng, title, descValue, onDescSave, onSave) {
+        var content = document.createElement('div');
+        content.className = 'course-map-popup-form';
+        content.innerHTML = '<strong>' + escapeHtml(title || 'Edit position') + '</strong><br/>';
+        var lblLat = document.createElement('label');
+        lblLat.textContent = 'Latitude';
+        content.appendChild(lblLat);
+        var inputLat = document.createElement('input');
+        inputLat.type = 'text';
+        inputLat.value = String(latlng.lat);
+        inputLat.style.display = 'block';
+        inputLat.style.width = '100%';
+        inputLat.style.boxSizing = 'border-box';
+        content.appendChild(inputLat);
+        var lblLon = document.createElement('label');
+        lblLon.textContent = 'Longitude';
+        content.appendChild(lblLon);
+        var inputLon = document.createElement('input');
+        inputLon.type = 'text';
+        inputLon.value = String(latlng.lng);
+        inputLon.style.display = 'block';
+        inputLon.style.width = '100%';
+        inputLon.style.boxSizing = 'border-box';
+        content.appendChild(inputLon);
+        var inputDesc = null;
+        if (descValue !== undefined) {
+            var lblDesc = document.createElement('label');
+            lblDesc.textContent = 'Description (optional)';
+            content.appendChild(lblDesc);
+            inputDesc = document.createElement('textarea');
+            inputDesc.rows = 2;
+            inputDesc.placeholder = 'Optional description';
+            inputDesc.value = descValue || '';
+            inputDesc.style.display = 'block';
+            inputDesc.style.width = '100%';
+            inputDesc.style.boxSizing = 'border-box';
+            content.appendChild(inputDesc);
+        }
+        var btnSave = document.createElement('button');
+        btnSave.type = 'button';
+        btnSave.textContent = 'Save';
+        var btnCancel = document.createElement('button');
+        btnCancel.type = 'button';
+        btnCancel.textContent = 'Cancel';
+        content.appendChild(btnSave);
+        content.appendChild(btnCancel);
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        btnSave.onclick = function () {
+            var newLat = parseFloat(inputLat.value);
+            var newLon = parseFloat(inputLon.value);
+            if (isNaN(newLat) || isNaN(newLon)) {
+                alert('Enter valid latitude and longitude.');
+                return;
+            }
+            var coords = currentCourse.geometry.coordinates;
+            if (coordIndex >= 0 && coordIndex < coords.length) {
+                coords[coordIndex] = [newLon, newLat];
+            }
+            if (inputDesc && onDescSave) onDescSave((inputDesc.value || '').trim());
+            window.courseMappingMap.closePopup();
+            setDirty();
+            syncSegmentsFromBreaks();
+            renderCourseLine();
+            renderSegmentPins();
+            renderStartFinishIcons();
+            renderUturnIcons();
+            renderSegmentsList();
+            renderLocationPins();
+            updateCourseUI();
+            if (onSave) onSave();
+        };
+        btnCancel.onclick = function () { window.courseMappingMap.closePopup(); };
+    }
+
+    function addEditLatLonButton(btnWrap, coordIndex, latlng, title, descValue, onDescSave, onAfterSave) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = 'Edit lat/lon';
+        btn.title = 'Edit latitude and longitude for this point';
+        btn.onclick = function () {
+            window.courseMappingMap.closePopup();
+            openCoordinateEditTile(coordIndex, latlng, title, descValue, onDescSave, onAfterSave);
+        };
+        btnWrap.appendChild(btn);
+    }
+
+    function openLocationLatLonEdit(locEl, latlng, onSave) {
+        var content = document.createElement('div');
+        content.className = 'course-map-popup-form';
+        content.innerHTML = '<strong>' + escapeHtml(locEl.loc_label || 'Location') + '</strong><br/>';
+        var lblLat = document.createElement('label');
+        lblLat.textContent = 'Latitude';
+        content.appendChild(lblLat);
+        var inputLat = document.createElement('input');
+        inputLat.type = 'text';
+        inputLat.value = String(typeof locEl.lat === 'number' ? locEl.lat : parseFloat(locEl.lat));
+        inputLat.style.display = 'block';
+        inputLat.style.width = '100%';
+        inputLat.style.boxSizing = 'border-box';
+        content.appendChild(inputLat);
+        var lblLon = document.createElement('label');
+        lblLon.textContent = 'Longitude';
+        content.appendChild(lblLon);
+        var inputLon = document.createElement('input');
+        inputLon.type = 'text';
+        inputLon.value = String(typeof locEl.lon === 'number' ? locEl.lon : parseFloat(locEl.lon));
+        inputLon.style.display = 'block';
+        inputLon.style.width = '100%';
+        inputLon.style.boxSizing = 'border-box';
+        content.appendChild(inputLon);
+        var lblDesc = document.createElement('label');
+        lblDesc.textContent = 'Description (optional)';
+        content.appendChild(lblDesc);
+        var inputDesc = document.createElement('textarea');
+        inputDesc.rows = 2;
+        inputDesc.value = locEl.loc_description || '';
+        inputDesc.style.display = 'block';
+        inputDesc.style.width = '100%';
+        inputDesc.style.boxSizing = 'border-box';
+        content.appendChild(inputDesc);
+        var btnSave = document.createElement('button');
+        btnSave.type = 'button';
+        btnSave.textContent = 'Save';
+        var btnCancel = document.createElement('button');
+        btnCancel.type = 'button';
+        btnCancel.textContent = 'Cancel';
+        content.appendChild(btnSave);
+        content.appendChild(btnCancel);
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        btnSave.onclick = function () {
+            var newLat = parseFloat(inputLat.value);
+            var newLon = parseFloat(inputLon.value);
+            if (isNaN(newLat) || isNaN(newLon)) {
+                alert('Enter valid latitude and longitude.');
+                return;
+            }
+            locEl.lat = newLat;
+            locEl.lon = newLon;
+            locEl.loc_description = (inputDesc.value || '').trim();
+            window.courseMappingMap.closePopup();
+            setDirty();
+            if (onSave) onSave();
+        };
+        btnCancel.onclick = function () { window.courseMappingMap.closePopup(); };
+    }
+
     function openSegmentPinFormTile(idx, latlng, onSave) {
         var label = getSegmentBreakLabel(idx);
         var desc = getSegmentBreakDescription(idx);
         var content = document.createElement('div');
-        content.style.minWidth = '220px';
+        content.className = 'course-map-popup-form';
         var lblLabel = document.createElement('label');
         lblLabel.textContent = 'Label';
         content.appendChild(lblLabel);
@@ -1405,12 +1570,14 @@ document.addEventListener('DOMContentLoaded', function () {
         btnCancel.textContent = 'Cancel';
         content.appendChild(btnSave);
         content.appendChild(btnCancel);
-        var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
         btnSave.onclick = function () {
             if (!currentCourse.segment_break_labels) currentCourse.segment_break_labels = {};
             if (!currentCourse.segment_break_descriptions) currentCourse.segment_break_descriptions = {};
             currentCourse.segment_break_labels[idx] = (inputLabel.value && inputLabel.value.trim()) ? inputLabel.value.trim() : '';
             currentCourse.segment_break_descriptions[idx] = (inputDesc.value && inputDesc.value.trim()) ? inputDesc.value.trim() : '';
+            syncSegmentsFromBreaks();
+            renderSegmentsList();
             window.courseMappingMap.closePopup();
             setDirty();
             if (onSave) onSave();
@@ -1497,7 +1664,8 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (onSave) onSave();
             };
         }
-        var pop = L.popup({ maxWidth: 320, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
+        content.className = 'course-map-popup-form';
+        var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(latlng).openOn(window.courseMappingMap);
         btnSave.onclick = function () {
             var newLat = parseFloat(inputLat.value);
             var newLon = parseFloat(inputLon.value);
@@ -1590,9 +1758,17 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (isEditMode) {
                     var btnWrap = document.createElement('div');
                     btnWrap.style.marginTop = '0.5rem';
+                    addEditLatLonButton(btnWrap, i, e.latlng, label, desc, function (d) {
+                        if (!currentCourse.segment_break_descriptions) currentCourse.segment_break_descriptions = {};
+                        currentCourse.segment_break_descriptions[i] = d;
+                    }, function () {
+                        renderSegmentPins();
+                        renderSegmentsList();
+                        updateCourseUI();
+                    });
                     var btnEdit = document.createElement('button');
                     btnEdit.type = 'button';
-                    btnEdit.textContent = 'Edit';
+                    btnEdit.textContent = 'Edit label';
                     btnEdit.style.marginRight = '6px';
                     btnEdit.style.marginTop = '6px';
                     var btnDel = document.createElement('button');
@@ -1689,7 +1865,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         };
                     }
                 }
-                var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(content).setLatLng(e.latlng).openOn(window.courseMappingMap);
+                var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(e.latlng).openOn(window.courseMappingMap);
             });
             segmentPinsLayer.addLayer(m);
         });
@@ -1966,9 +2142,21 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (isEditMode) {
                     var btnWrap = document.createElement('div');
                     btnWrap.style.marginTop = '0.5rem';
+                    var btnLatLon = document.createElement('button');
+                    btnLatLon.type = 'button';
+                    btnLatLon.textContent = 'Edit lat/lon';
+                    btnLatLon.onclick = function () {
+                        window.courseMappingMap.closePopup();
+                        openLocationLatLonEdit(locEl, e.latlng, function () {
+                            renderLocationPins();
+                            renderLocationsList();
+                            updateCourseUI();
+                        });
+                    };
+                    btnWrap.appendChild(btnLatLon);
                     var btnEdit = document.createElement('button');
                     btnEdit.type = 'button';
-                    btnEdit.textContent = 'Edit';
+                    btnEdit.textContent = 'Edit details';
                     btnEdit.style.marginRight = '6px';
                     var btnDel = document.createElement('button');
                     btnDel.type = 'button';
@@ -1979,7 +2167,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     btnEdit.onclick = function () {
                         window.courseMappingMap.closePopup();
                         var editContent = document.createElement('div');
-                    editContent.style.minWidth = '180px';
+                    editContent.className = 'course-map-popup-form';
                     var lblType = document.createElement('label');
                     lblType.textContent = 'Type';
                     editContent.appendChild(lblType);
@@ -2028,7 +2216,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     btnCancel.textContent = 'Cancel';
                     editContent.appendChild(btnSave);
                     editContent.appendChild(btnCancel);
-                    var editPop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(editContent).setLatLng(e.latlng).openOn(window.courseMappingMap);
+                    var editPop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(editContent).setLatLng(e.latlng).openOn(window.courseMappingMap);
                     btnSave.onclick = function () {
                         locEl.loc_type = sel.value || 'course';
                         locEl.loc_label = (input.value && input.value.trim()) ? input.value.trim() : '';
@@ -2051,7 +2239,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     updateCourseUI();
                 };
                 }
-                var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(content).setLatLng(e.latlng).openOn(window.courseMappingMap);
+                var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(e.latlng).openOn(window.courseMappingMap);
             });
             locationsLayer.addLayer(m);
         });
@@ -2079,7 +2267,16 @@ document.addEventListener('DOMContentLoaded', function () {
             var lon = typeof loc.lon === 'number' ? loc.lon : parseFloat(loc.lon);
             var tr = document.createElement('tr');
             var typeLabel = getLocationTypeLabel(loc.loc_type);
-            tr.innerHTML = '<td>' + typeLabel + '</td><td>' + (loc.loc_label || '') + '</td><td>' + (isNaN(lat) ? '' : lat.toFixed(5)) + '</td><td>' + (isNaN(lon) ? '' : lon.toFixed(5)) + '</td><td><button type="button" class="btn-remove-loc" data-index="' + i + '" style="font-size: 0.75rem;">Remove</button></td>';
+            var locId = loc.id != null ? String(loc.id) : String(i + 1);
+            var desc = (loc.loc_description || '').trim();
+            tr.innerHTML =
+                '<td>' + escapeHtml(typeLabel) + '</td>' +
+                '<td>' + escapeHtml(locId) + '</td>' +
+                '<td>' + escapeHtml(loc.loc_label || '') + '</td>' +
+                '<td>' + escapeHtml(desc || '—') + '</td>' +
+                '<td>' + (isNaN(lat) ? '' : lat.toFixed(5)) + '</td>' +
+                '<td>' + (isNaN(lon) ? '' : lon.toFixed(5)) + '</td>' +
+                '<td><button type="button" class="btn-remove-loc" data-index="' + i + '">Remove</button></td>';
             tbody.appendChild(tr);
         });
         tbody.querySelectorAll('.btn-remove-loc').forEach(function (btn) {
@@ -2400,10 +2597,10 @@ document.addEventListener('DOMContentLoaded', function () {
                 currentCourse.description = d;
                 try {
                     var courseIdToSave = currentCourseId;
-                    if (isConfigPackageMode) {
-                        courseIdToSave = configPackageId;
-                        currentCourse.id = configPackageId;
-                        currentCourse.config_id = configPackageId;
+                    if (isConfigPackageMode()) {
+                        courseIdToSave = resolveConfigPackageId();
+                        currentCourse.id = courseIdToSave;
+                        currentCourse.config_id = courseIdToSave;
                     } else if (!courseIdToSave) {
                         var createRes = await fetch('/api/courses', { method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({}) });
                         var createData = await createRes.json();
@@ -2415,7 +2612,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     // Build payload with explicit geometry and turnaround_indices to ensure Same Route Back is persisted (Issue #732)
                     var toSave = JSON.parse(JSON.stringify({
                         id: courseIdToSave,
-                        config_id: isConfigPackageMode ? configPackageId : currentCourse.config_id,
+                        config_id: isConfigPackageMode() ? resolveConfigPackageId() : currentCourse.config_id,
                         name: currentCourse.name,
                         description: currentCourse.description,
                         segments: currentCourse.segments || [],
@@ -2431,8 +2628,8 @@ document.addEventListener('DOMContentLoaded', function () {
                         turnaround_descriptions: currentCourse.turnaround_descriptions || {},
                         flow_control_points: Array.isArray(currentCourse.flow_control_points) ? JSON.parse(JSON.stringify(currentCourse.flow_control_points)) : []
                     }));
-                    var saveUrl = isConfigPackageMode
-                        ? '/api/config/packages/' + encodeURIComponent(configPackageId) + '/course'
+                    var saveUrl = isConfigPackageMode()
+                        ? '/api/config/packages/' + encodeURIComponent(resolveConfigPackageId()) + '/course'
                         : '/api/courses/' + encodeURIComponent(courseIdToSave);
                     const res = await fetch(saveUrl, {
                         method: 'PUT',
@@ -2443,10 +2640,10 @@ document.addEventListener('DOMContentLoaded', function () {
                     const data = await res.json();
                     if (!res.ok) throw new Error(data.detail || res.statusText);
                     if (data.ok && data.course) {
-                        var savedId = isConfigPackageMode ? configPackageId : data.course.id;
+                        var savedId = isConfigPackageMode() ? resolveConfigPackageId() : data.course.id;
                         setCourse(savedId, data.course);
                         clearDirty();
-                        if (!isConfigPackageMode) loadCourseList();
+                        if (!isConfigPackageMode()) loadCourseList();
                         console.log('Saved course:', savedId, data.course.name || '(no name)');
                     }
                 } catch (e) {
@@ -2839,7 +3036,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 btnCancel.textContent = 'Cancel';
                 content.appendChild(btnAdd);
                 content.appendChild(btnCancel);
-                var pop = L.popup({ maxWidth: 300, className: 'location-popup' }).setContent(content).setLatLng(e.latlng).openOn(window.courseMappingMap);
+                var pop = L.popup({ maxWidth: POPUP_MAX_WIDTH, className: 'location-popup' }).setContent(content).setLatLng(e.latlng).openOn(window.courseMappingMap);
                 btnAdd.onclick = function () {
                     var locType = sel.value || 'course';
                     var locLabel = (input.value && input.value.trim()) ? input.value.trim() : '';
@@ -2948,7 +3145,7 @@ document.addEventListener('DOMContentLoaded', function () {
         if (btnExport) {
             btnExport.addEventListener('click', async function () {
                 if (!currentCourseId || !currentCourse) return;
-                if (isConfigPackageMode) {
+                if (isConfigPackageMode()) {
                     if (!currentCourse.segments || currentCourse.segments.length === 0) {
                         alert('Add segment pins on the course line before exporting segments.csv.');
                         return;
@@ -2958,7 +3155,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         return;
                     }
                     try {
-                        var url = '/api/config/packages/' + encodeURIComponent(configPackageId) + '/export/segments';
+                        var url = '/api/config/packages/' + encodeURIComponent(resolveConfigPackageId()) + '/export/segments';
                         var res = await fetch(url, { method: 'POST', credentials: 'same-origin' });
                         var data = await res.json();
                         if (!res.ok) throw new Error(data.detail || res.statusText);
@@ -2978,7 +3175,7 @@ document.addEventListener('DOMContentLoaded', function () {
             });
         }
 
-        if (isConfigPackageMode) {
+        if (isConfigPackageMode()) {
             applyConfigPackageUIMode();
             loadConfigPackageCourse();
         } else {

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -412,10 +412,11 @@ async function addSegmentsOverlay(map) {
     const overlayLayer = L.geoJSON(geojson, {
         pane: paneName,
         style: {
-            color: '#2f9e44',
-            weight: 2,
-            opacity: 0.45,
-            dashArray: '4 6'
+            color: '#2563eb',
+            weight: 5,
+            opacity: 0.92,
+            lineCap: 'round',
+            lineJoin: 'round'
         }
     });
     

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -216,7 +216,7 @@
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/course_mapping.js?v=758b"></script>
+<script src="/static/js/map/course_mapping.js?v=759d"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=757b"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -216,7 +216,7 @@
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/course_mapping.js?v=758a"></script>
+<script src="/static/js/map/course_mapping.js?v=758b"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=757b"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -156,24 +156,55 @@
     .turnaround-marker > div { cursor: move; }
     .uturn-icon { background: transparent !important; border: none !important; }
     /* Course map popups: match Locations UI (shared styles in common.css for tooltips) */
+    .leaflet-popup-content {
+        font-size: 1.09rem;
+        line-height: 1.45;
+        min-width: 250px;
+    }
     .course-map-popup, .leaflet-popup-content .course-map-popup {
         font-family: Arial, sans-serif;
-        font-size: 0.875rem;
-        line-height: 1.4;
-        min-width: 200px;
-        max-width: 280px;
+        font-size: 1.09rem;
+        line-height: 1.45;
+        min-width: 250px;
+        max-width: 350px;
     }
-    .course-map-popup .popup-row { margin-bottom: 0.5rem; }
+    .course-map-popup .popup-row { margin-bottom: 0.65rem; }
     .course-map-popup .popup-row:last-child { margin-bottom: 0; }
-    .course-map-popup .popup-label { font-weight: 600; color: #2c3e50; font-size: 0.875rem; }
-    .course-map-popup .popup-value { color: #34495e; font-size: 0.875rem; }
-    .course-map-popup .popup-heading { margin: 0 0 0.5rem 0; font-size: 1rem; color: #2c3e50; font-weight: 600; }
-    .course-map-popup-wrap { font-size: 0.875rem; }
+    .course-map-popup .popup-label { font-weight: 600; color: #2c3e50; font-size: 1.09rem; }
+    .course-map-popup .popup-value { color: #34495e; font-size: 1.09rem; }
+    .course-map-popup .popup-heading { margin: 0 0 0.65rem 0; font-size: 1.25rem; color: #2c3e50; font-weight: 600; }
+    .course-map-popup-wrap, .course-map-popup-form {
+        font-size: 1.09rem;
+        min-width: 275px;
+    }
+    .course-map-popup-wrap label, .course-map-popup-form label {
+        display: block;
+        font-weight: 600;
+        margin-top: 0.35rem;
+        font-size: 1.09rem;
+    }
     .course-map-popup input, .course-map-popup select, .course-map-popup textarea,
     .course-map-popup-wrap input, .course-map-popup-wrap select, .course-map-popup-wrap textarea,
+    .course-map-popup-form input, .course-map-popup-form select, .course-map-popup-form textarea,
     .leaflet-popup-content input, .leaflet-popup-content select, .leaflet-popup-content textarea {
-        margin: 5px !important;
-        font-size: 0.875rem;
+        margin: 6px 0 10px 0 !important;
+        font-size: 1.09rem !important;
+        padding: 0.45rem 0.55rem !important;
+    }
+    .course-map-popup-wrap button, .course-map-popup-form button,
+    .leaflet-popup-content .course-map-popup-wrap button,
+    .leaflet-popup-content .course-map-popup-form button {
+        padding: 0.44rem 0.75rem;
+        font-size: 1.09rem;
+        border: 1px solid #bdc3c7;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+        margin-right: 0.35rem;
+        margin-top: 0.35rem;
+    }
+    .course-map-popup-wrap button:hover, .course-map-popup-form button:hover {
+        background: #ecf0f1;
     }
     #course-list-table tbody tr.course-row { cursor: pointer; }
     #course-list-table tbody tr.course-row.selected { background: #e3f2fd; }
@@ -185,7 +216,7 @@
     #btn-delete-course { background: #e8e8e8 !important; color: #c0392b !important; border-color: #bdc3c7 !important; }
     #btn-delete-course:hover:not(:disabled) { background: #ddd !important; }
     /* Edit toolbar: same look as Street/Satellite buttons */
-    #course-edit-toolbar button { padding: 0.35rem 0.6rem; border: 1px solid #ccc; border-radius: 4px; background: #fff; cursor: pointer; font-size: 0.875rem; color: #000; }
+    #course-edit-toolbar button { padding: 0.44rem 0.75rem; border: 1px solid #ccc; border-radius: 4px; background: #fff; cursor: pointer; font-size: 1.09rem; color: #000; }
     #course-edit-toolbar button:hover:not(:disabled) { background: #ecf0f1; }
     #course-edit-toolbar button:disabled { opacity: 0.6; cursor: not-allowed; }
     #course-edit-toolbar button.active { background: #3498db; color: #fff; border-color: #2980b9; }

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -85,7 +85,7 @@
     <div id="locations-table-wrap" style="display: none;">
         <table id="locations-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
             <thead>
-                <tr><th>Type</th><th>ID</th><th>Label</th><th>Description</th><th>Lat</th><th>Lon</th><th></th></tr>
+                <tr><th>ID</th><th>Type</th><th>Label</th><th>Notes</th><th>Lat</th><th>Lon</th><th></th></tr>
             </thead>
             <tbody id="locations-tbody"></tbody>
         </table>

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -85,7 +85,7 @@
     <div id="locations-table-wrap" style="display: none;">
         <table id="locations-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
             <thead>
-                <tr><th>Type</th><th>Label</th><th>Lat</th><th>Lon</th><th></th></tr>
+                <tr><th>Type</th><th>ID</th><th>Label</th><th>Description</th><th>Lat</th><th>Lon</th><th></th></tr>
             </thead>
             <tbody id="locations-tbody"></tbody>
         </table>

--- a/tests/unit/test_config_package_export_segments.py
+++ b/tests/unit/test_config_package_export_segments.py
@@ -79,6 +79,16 @@ def test_export_config_package_segments_writes_and_validates(tmp_path, monkeypat
                 "direction": "uni",
             }
         ],
+        "locations": [
+            {
+                "id": 1,
+                "loc_label": "Aid 1",
+                "loc_type": "aid",
+                "notes": "North side",
+                "lat": 45.95,
+                "lon": -66.64,
+            }
+        ],
         "geometry": {"type": "LineString", "coordinates": [[0, 0], [1, 1]]},
     }
     (package / "course.json").write_text(
@@ -93,6 +103,14 @@ def test_export_config_package_segments_writes_and_validates(tmp_path, monkeypat
     df = load_segments(str(segments_path))
     assert len(df) == 1
     assert df.iloc[0]["seg_id"] == "A1"
+    locations_path = Path(result["locations_path"])
+    assert locations_path.is_file()
+    assert result["location_count"] == 1
+    loc_lines = locations_path.read_text(encoding="utf-8").strip().splitlines()
+    assert loc_lines[0].startswith("loc_id,")
+    assert "notes" in loc_lines[0]
+    assert "Aid 1" in loc_lines[1]
+    assert "North side" in loc_lines[1]
 
 
 def test_export_backs_up_existing_segments(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Improves Race Configuration course map UX: larger popups, segment label fix, lat/lon editing, locations table with ID first column
- Visual refresh (On The Go Map–style): solid blue route with white casing, Carto Voyager basemap, green start / red finish markers
- Config package **Export** writes `segments.csv` and `locations.csv` (`notes` column; migrates deprecated `loc_description`)
- Removes `loc_description` from UI/storage; normalizes locations on load/save; does not collect `loc_direction`
- Fixes `SEGMENT_PIN_COLOR` regression that broke pins and tables after styling change

## Test plan
- [x] `pytest tests/unit/test_config_package_export_segments.py` (in dev container)
- [ ] Open `/config?tab=course`, verify map styling, segments/locations tables, pins
- [ ] Save course, Export — confirm `segments.csv` and `locations.csv` in package folder
- [ ] Restart app container after deploy if export API changes do not appear (`docker compose restart app`)


Made with [Cursor](https://cursor.com)