### PR TITLE
Waypoints and segment planner (#767)

### DIFF
--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -24,6 +24,7 @@ from app.core.locations.schema import (
     normalize_resource_registry,
 )
 from app.io.loader import load_segments
+from app.core.course.waypoints import normalize_course_waypoints
 from app.utils.constants import COURSE_EVENT_IDS
 from app.utils.run_id import generate_run_id, get_runflow_root
 
@@ -36,6 +37,8 @@ _COURSE_LIST_FIELDS = (
     "segment_breaks",
     "turnaround_indices",
     "flow_control_points",
+    "waypoints",
+    "segment_defs",
 )
 _COURSE_DICT_FIELDS = (
     "segment_break_labels",
@@ -225,6 +228,7 @@ def load_config_course(config_id: str) -> Dict[str, Any]:
     data.pop("events", None)
     resource_codes = load_package_resource_codes(config_id)
     _normalize_course_locations(data, resource_codes)
+    data = normalize_course_waypoints(data)
     return data
 
 
@@ -241,6 +245,7 @@ def save_config_course(config_id: str, course_data: Dict[str, Any]) -> Path:
     data = validate_config_course_data(course_data, cid)
     resource_codes = load_package_resource_codes(cid)
     _normalize_course_locations(data, resource_codes)
+    data = normalize_course_waypoints(dict(data))
 
     data = dict(data)
     data["id"] = cid
@@ -282,6 +287,8 @@ def default_course_json(config_id: str) -> Dict[str, Any]:
         "end_description": "",
         "turnaround_descriptions": {},
         "flow_control_points": [],
+        "waypoints": [],
+        "segment_defs": [],
     }
 
 

--- a/app/core/course/waypoints.py
+++ b/app/core/course/waypoints.py
@@ -1,0 +1,454 @@
+"""
+Waypoint-based segment definitions for draw-first course workspace (Issue #767).
+
+Waypoints are named places on the course (lat/lon). Segment definitions describe
+logical legs (from_waypoint → to_waypoint + events). A resolver projects them onto
+geometry.coordinates as start_index / end_index for export and map display.
+"""
+
+from __future__ import annotations
+
+import math
+from copy import deepcopy
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+COORD_EPS = 1e-9
+MAX_SNAP_METERS = 80.0
+
+
+def _haversine_m(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    r = 6371000.0
+    d_lat = math.radians(lat2 - lat1)
+    d_lon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_lat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(d_lon / 2) ** 2
+    )
+    return r * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _coord_near(
+    c: Sequence[float], lat: float, lon: float, eps: float = COORD_EPS
+) -> bool:
+    if not c or len(c) < 2:
+        return False
+    return abs(c[0] - lon) < eps and abs(c[1] - lat) < eps
+
+
+def _nearest_vertex_index(lat: float, lon: float, coords: Sequence[Sequence[float]]) -> int:
+    if not coords:
+        return 0
+    best_i = 0
+    best_d = float("inf")
+    for i, c in enumerate(coords):
+        d = _haversine_m(lon, lat, c[0], c[1])
+        if d < best_d:
+            best_d = d
+            best_i = i
+    return best_i
+
+
+def _cumulative_km(coords: Sequence[Sequence[float]]) -> List[float]:
+    if not coords:
+        return [0.0]
+    cum = [0.0]
+    for i in range(1, len(coords)):
+        c0, c1 = coords[i - 1], coords[i]
+        cum.append(
+            cum[-1] + _haversine_m(c0[0], c0[1], c1[0], c1[1]) / 1000.0
+        )
+    return cum
+
+
+def find_vertex_occurrence(
+    lat: float,
+    lon: float,
+    coords: Sequence[Sequence[float]],
+    *,
+    occurrence: int = 1,
+    min_index: int = 0,
+) -> int:
+    """
+    Return vertex index of the occurrence-th match at or after min_index.
+
+    Matches coordinates within COORD_EPS, then falls back to the nearest
+    vertex at or after min_index.
+    """
+    if not coords:
+        return 0
+    occ = max(1, int(occurrence))
+    start = max(0, min_index)
+
+    exact: List[int] = []
+    for i in range(start, len(coords)):
+        if _coord_near(coords[i], lat, lon):
+            exact.append(i)
+    if len(exact) >= occ:
+        return exact[occ - 1]
+
+    best_i = start
+    best_d = float("inf")
+    for i in range(start, len(coords)):
+        c = coords[i]
+        d = _haversine_m(lon, lat, c[0], c[1])
+        if d < best_d:
+            best_d = d
+            best_i = i
+    return best_i
+
+
+def _resolve_waypoint_index(
+    wp: Dict[str, Any],
+    coords: Sequence[Sequence[float]],
+    *,
+    min_index: int,
+    role: str,
+) -> int:
+    """Project waypoint onto course polyline forward from min_index."""
+    if not coords:
+        return 0
+    last = len(coords) - 1
+    kind = (wp.get("kind") or "").strip().lower()
+    if role == "from" and kind == "start":
+        return 0
+    if role == "to" and kind == "finish":
+        return last
+
+    lat, lon = _waypoint_lat_lon(wp)
+    occ = _waypoint_occurrence(wp)
+    return find_vertex_occurrence(lat, lon, coords, occurrence=occ, min_index=min_index)
+
+
+def _waypoint_lat_lon(wp: Dict[str, Any]) -> Tuple[float, float]:
+    lat = float(wp.get("lat", 0))
+    lon = float(wp.get("lon", 0))
+    return lat, lon
+
+
+def _waypoint_occurrence(wp: Dict[str, Any]) -> int:
+    raw = wp.get("path_occurrence", 1)
+    try:
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return 1
+
+
+def migrate_breaks_to_waypoints(course: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Populate waypoints and segment_defs from legacy segment_breaks + segments.
+
+    No-op if waypoints already present.
+    """
+    if course.get("waypoints"):
+        return course
+
+    geometry = course.get("geometry") or {}
+    coords = geometry.get("coordinates") or []
+    if len(coords) < 2:
+        course["waypoints"] = []
+        course["segment_defs"] = []
+        return course
+
+    labels = course.get("segment_break_labels") or {}
+    breaks = sorted(
+        int(b)
+        for b in (course.get("segment_breaks") or [])
+        if isinstance(b, (int, float)) and 0 < int(b) < len(coords)
+    )
+
+    waypoints: List[Dict[str, Any]] = []
+    c0 = coords[0]
+    waypoints.append(
+        {
+            "id": "wp-start",
+            "label": "Start",
+            "lat": c0[1],
+            "lon": c0[0],
+            "kind": "start",
+            "path_occurrence": 1,
+        }
+    )
+    for bi in breaks:
+        c = coords[bi]
+        lbl = (labels.get(bi) or labels.get(str(bi)) or "").strip() or f"Pin {bi}"
+        waypoints.append(
+            {
+                "id": f"wp-pin-{bi}",
+                "label": lbl,
+                "lat": c[1],
+                "lon": c[0],
+                "kind": "pin",
+                "path_occurrence": 1,
+                "vertex_index": bi,
+            }
+        )
+    c_last = coords[-1]
+    waypoints.append(
+        {
+            "id": "wp-finish",
+            "label": "Finish",
+            "lat": c_last[1],
+            "lon": c_last[0],
+            "kind": "finish",
+            "path_occurrence": 1,
+        }
+    )
+
+    wp_by_vertex: Dict[int, str] = {}
+    for wp in waypoints:
+        vi = wp.get("vertex_index")
+        if vi is not None:
+            wp_by_vertex[int(vi)] = wp["id"]
+    wp_by_vertex[0] = "wp-start"
+    wp_by_vertex[len(coords) - 1] = "wp-finish"
+
+    segment_defs: List[Dict[str, Any]] = []
+    existing = course.get("segments") or []
+    if existing:
+        for i, seg in enumerate(existing):
+            if not isinstance(seg, dict):
+                continue
+            start_idx = int(seg.get("start_index", 0))
+            end_idx = int(seg.get("end_index", len(coords) - 1))
+            from_id = wp_by_vertex.get(start_idx)
+            to_id = wp_by_vertex.get(end_idx)
+            if not from_id:
+                from_id = "wp-start"
+            if not to_id:
+                to_id = "wp-finish"
+            segment_defs.append(
+                {
+                    "id": f"sd-{seg.get('seg_id', i + 1)}",
+                    "from_waypoint_id": from_id,
+                    "to_waypoint_id": to_id,
+                    "events": list(seg.get("events") or []),
+                    "seg_label": (seg.get("seg_label") or "").strip()
+                    or f"Segment {i + 1}",
+                    "width_m": seg.get("width_m", 3),
+                    "schema": seg.get("schema", "on_course_open"),
+                    "direction": seg.get("direction", "uni"),
+                    "description": (seg.get("description") or "").strip(),
+                }
+            )
+    else:
+        boundaries = [0] + breaks + [len(coords) - 1]
+        for i in range(len(boundaries) - 1):
+            start_idx, end_idx = boundaries[i], boundaries[i + 1]
+            if end_idx <= start_idx:
+                continue
+            from_id = wp_by_vertex.get(start_idx, "wp-start")
+            to_id = wp_by_vertex.get(end_idx, "wp-finish")
+            segment_defs.append(
+                {
+                    "id": f"sd-{i + 1}",
+                    "from_waypoint_id": from_id,
+                    "to_waypoint_id": to_id,
+                    "events": [],
+                    "seg_label": f"Segment {i + 1}",
+                    "width_m": 3,
+                    "schema": "on_course_open",
+                    "direction": "uni",
+                    "description": "",
+                }
+            )
+
+    course["waypoints"] = waypoints
+    course["segment_defs"] = segment_defs
+    return course
+
+
+def resolve_segments_from_definitions(
+    course: Dict[str, Any],
+    event_ids: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Build course['segments'] from segment_defs + waypoints + geometry.
+
+    Updates segment_breaks cache from resolved end indices (excluding finish).
+    """
+    geometry = course.get("geometry") or {}
+    coords = geometry.get("coordinates") or []
+    if len(coords) < 2:
+        course["segments"] = []
+        return course
+
+    segment_defs = course.get("segment_defs") or []
+    if not segment_defs:
+        return course
+
+    waypoints = course.get("waypoints") or []
+    wp_by_id: Dict[str, Dict[str, Any]] = {}
+    for wp in waypoints:
+        if isinstance(wp, dict) and wp.get("id"):
+            wp_by_id[str(wp["id"])] = wp
+
+    if not wp_by_id:
+        raise ValueError("segment_defs require waypoints")
+
+    cum = _cumulative_km(coords)
+    existing = course.get("segments") or []
+    default_events = list(event_ids or [])
+    if not default_events and existing:
+        default_events = list(existing[0].get("events") or [])
+
+    resolved: List[Dict[str, Any]] = []
+    search_from = -1
+
+    for ordinal, sd in enumerate(segment_defs):
+        if not isinstance(sd, dict):
+            continue
+        from_id = str(sd.get("from_waypoint_id", "")).strip()
+        to_id = str(sd.get("to_waypoint_id", "")).strip()
+        from_wp = wp_by_id.get(from_id)
+        to_wp = wp_by_id.get(to_id)
+        if not from_wp or not to_wp:
+            raise ValueError(
+                f"segment_defs[{ordinal}]: unknown waypoint "
+                f"from={from_id!r} to={to_id!r}"
+            )
+
+        from_min = 0 if ordinal == 0 else max(0, search_from)
+        start_idx = _resolve_waypoint_index(
+            from_wp, coords, min_index=from_min, role="from"
+        )
+        if ordinal > 0 and start_idx < search_from:
+            raise ValueError(
+                f"segment_defs[{ordinal}]: from waypoint {from_id!r} is before "
+                f"the previous segment end along the course"
+            )
+        to_min = min(start_idx + 1, len(coords) - 1)
+        end_idx = _resolve_waypoint_index(
+            to_wp, coords, min_index=to_min, role="to"
+        )
+        if end_idx <= start_idx:
+            raise ValueError(
+                f"segment_defs[{ordinal}]: to waypoint {to_id!r} is before "
+                f"from waypoint {from_id!r} along the course"
+            )
+
+        prev = existing[ordinal] if ordinal < len(existing) else {}
+        if not isinstance(prev, dict):
+            prev = {}
+
+        from_km = cum[start_idx]
+        to_km = cum[end_idx]
+        events = sd.get("events")
+        if not events:
+            events = prev.get("events") or default_events
+
+        resolved.append(
+            {
+                "seg_id": str(sd.get("id", ordinal + 1)).replace("sd-", "") or str(ordinal + 1),
+                "seg_label": (sd.get("seg_label") or prev.get("seg_label") or "").strip()
+                or f"Segment {ordinal + 1}",
+                "width_m": sd.get("width_m", prev.get("width_m", 3)),
+                "direction": sd.get("direction", prev.get("direction", "uni")),
+                "schema": sd.get("schema", prev.get("schema", "on_course_open")),
+                "description": (sd.get("description") or prev.get("description") or "").strip(),
+                "events": list(events),
+                "from_km": round(from_km, 2),
+                "to_km": round(to_km, 2),
+                "start_index": start_idx,
+                "end_index": end_idx,
+                "info_icon_lat": prev.get("info_icon_lat"),
+                "info_icon_lon": prev.get("info_icon_lon"),
+            }
+        )
+        search_from = end_idx
+
+    _apply_flow_control(course, resolved, coords)
+    course["segments"] = resolved
+    _sync_segment_breaks_cache(course, resolved, coords)
+    return course
+
+
+def _apply_flow_control(
+    course: Dict[str, Any],
+    segments: List[Dict[str, Any]],
+    coords: Sequence[Sequence[float]],
+) -> None:
+    """Apply flow_control_points event overrides to resolved segments."""
+    fcp = course.get("flow_control_points") or []
+    for fc in fcp:
+        if not isinstance(fc, dict):
+            continue
+        v = fc.get("vertex_index")
+        branches = fc.get("branches") or []
+        for br in branches:
+            if not isinstance(br, dict):
+                continue
+            end_v = br.get("end_vertex_index")
+            evts = br.get("events") or []
+            for seg in segments:
+                if seg.get("start_index") == v and seg.get("end_index") == end_v:
+                    seg["events"] = list(evts)
+                    break
+
+
+def _sync_segment_breaks_cache(
+    course: Dict[str, Any],
+    segments: List[Dict[str, Any]],
+    coords: Sequence[Sequence[float]],
+) -> None:
+    """Keep segment_breaks aligned with segment end indices (excluding finish)."""
+    last = len(coords) - 1
+    breaks = sorted(
+        {
+            int(seg["end_index"])
+            for seg in segments
+            if isinstance(seg, dict)
+            and seg.get("end_index") is not None
+            and 0 < int(seg["end_index"]) < last
+        }
+    )
+    course["segment_breaks"] = breaks
+
+    labels = dict(course.get("segment_break_labels") or {})
+    ids = dict(course.get("segment_break_ids") or {})
+    wp_by_id = {
+        str(wp["id"]): wp
+        for wp in (course.get("waypoints") or [])
+        if isinstance(wp, dict) and wp.get("id")
+    }
+    for seg in segments:
+        end_idx = seg.get("end_index")
+        if end_idx is None or end_idx <= 0 or end_idx >= last:
+            continue
+        for sd in course.get("segment_defs") or []:
+            if not isinstance(sd, dict):
+                continue
+            to_wp = wp_by_id.get(str(sd.get("to_waypoint_id", "")))
+            if to_wp and find_vertex_occurrence(
+                to_wp["lat"],
+                to_wp["lon"],
+                coords,
+                occurrence=int(
+                    sd.get("to_path_occurrence") or _waypoint_occurrence(to_wp)
+                ),
+                min_index=0,
+            ) == int(end_idx):
+                lbl = (sd.get("seg_label") or to_wp.get("label") or "").strip()
+                if lbl:
+                    labels[end_idx] = lbl
+                    labels[str(end_idx)] = lbl
+                break
+    course["segment_break_labels"] = labels
+    course["segment_break_ids"] = ids
+
+
+def normalize_course_waypoints(course: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Migrate legacy breaks if needed, then resolve segments from definitions.
+    """
+    data = deepcopy(course)
+    geometry = data.get("geometry") or {}
+    coords = geometry.get("coordinates") or []
+    if len(coords) < 2:
+        return data
+
+    migrate_breaks_to_waypoints(data)
+    if data.get("segment_defs"):
+        resolve_segments_from_definitions(data)
+    return data

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -27,7 +27,10 @@ from app.core.config_package import (
     update_config_package_metadata,
 )
 from app.core.locations.suggest_events import suggest_location_events
-from app.core.config_package.storage import validate_config_id
+from app.core.config_package.storage import validate_config_course_data, validate_config_id
+from app.core.course.export import enrich_segments_event_distances
+from app.core.course.waypoints import normalize_course_waypoints
+from app.utils.constants import COURSE_EVENT_IDS
 from app.utils.auth import require_auth
 
 logger = logging.getLogger(__name__)
@@ -209,6 +212,29 @@ async def api_save_config_course(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to save course: {e}",
         )
+
+
+@router.post("/api/config/packages/{config_id}/course/preview-resolve")
+async def api_preview_resolve_config_course(
+    request: Request,
+    config_id: str,
+    body: SaveConfigCourseRequest,
+) -> JSONResponse:
+    """Resolve segment_defs + waypoints to segments without writing course.json."""
+    require_auth(request)
+    try:
+        data = validate_config_course_data(body.course, config_id)
+        normalized = normalize_course_waypoints(dict(data))
+        segments = normalized.get("segments") or []
+        if segments:
+            enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
+        return JSONResponse(
+            content={"ok": True, "config_id": config_id, "course": normalized}
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
 @router.post("/api/config/packages/{config_id}/export/segments")

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -210,8 +210,275 @@ document.addEventListener('DOMContentLoaded', function () {
             turnaround_descriptions: currentCourse.turnaround_descriptions || {},
             flow_control_points: Array.isArray(currentCourse.flow_control_points)
                 ? JSON.parse(JSON.stringify(currentCourse.flow_control_points))
+                : [],
+            waypoints: Array.isArray(currentCourse.waypoints)
+                ? JSON.parse(JSON.stringify(currentCourse.waypoints))
+                : [],
+            segment_defs: Array.isArray(currentCourse.segment_defs)
+                ? JSON.parse(JSON.stringify(currentCourse.segment_defs))
                 : []
         };
+    }
+
+    function usesSegmentPlanner() {
+        return !!(currentCourse && currentCourse.segment_defs && currentCourse.segment_defs.length);
+    }
+
+    function syncWaypointsFromSegmentPins() {
+        if (!currentCourse || !currentCourse.geometry || !currentCourse.geometry.coordinates) return;
+        var coords = currentCourse.geometry.coordinates;
+        if (coords.length < 2) return;
+        var labels = currentCourse.segment_break_labels || {};
+        var breaks = (currentCourse.segment_breaks || []).slice().sort(function (a, b) { return a - b; })
+            .filter(function (i) { return i > 0 && i < coords.length; });
+        var waypoints = [
+            {
+                id: 'wp-start',
+                label: 'Start',
+                lat: coords[0][1],
+                lon: coords[0][0],
+                kind: 'start',
+                path_occurrence: 1
+            }
+        ];
+        breaks.forEach(function (bi) {
+            var c = coords[bi];
+            waypoints.push({
+                id: 'wp-pin-' + bi,
+                label: (labels[bi] || labels['' + bi] || '').trim() || ('Pin ' + bi),
+                lat: c[1],
+                lon: c[0],
+                kind: 'pin',
+                path_occurrence: 1
+            });
+        });
+        var last = coords[coords.length - 1];
+        waypoints.push({
+            id: 'wp-finish',
+            label: 'Finish',
+            lat: last[1],
+            lon: last[0],
+            kind: 'finish',
+            path_occurrence: 1
+        });
+        currentCourse.waypoints = waypoints;
+        if (!currentCourse.segment_defs || !currentCourse.segment_defs.length) {
+            var wpAt = {};
+            waypoints.forEach(function (wp) {
+                if (wp.id.indexOf('wp-pin-') === 0) {
+                    wpAt[parseInt(wp.id.replace('wp-pin-', ''), 10)] = wp.id;
+                }
+            });
+            wpAt[0] = 'wp-start';
+            wpAt[coords.length - 1] = 'wp-finish';
+            var defs = [];
+            (currentCourse.segments || []).forEach(function (seg, i) {
+                var sid = seg.start_index != null ? seg.start_index : 0;
+                var eid = seg.end_index != null ? seg.end_index : coords.length - 1;
+                defs.push({
+                    id: 'sd-' + (seg.seg_id || (i + 1)),
+                    from_waypoint_id: wpAt[sid] || 'wp-start',
+                    to_waypoint_id: wpAt[eid] || 'wp-finish',
+                    events: (seg.events || []).slice(),
+                    seg_label: (seg.seg_label || '').trim() || ('Segment ' + (i + 1)),
+                    width_m: seg.width_m != null ? seg.width_m : 3,
+                    schema: seg.schema || 'on_course_open',
+                    direction: seg.direction || 'uni',
+                    description: (seg.description || '').trim()
+                });
+            });
+            currentCourse.segment_defs = defs;
+        }
+        setDirty();
+        renderWaypointsList();
+        renderSegmentPlannerList();
+    }
+
+    function renderWaypointsList() {
+        var card = document.getElementById('waypoints-card');
+        var wrap = document.getElementById('waypoints-table-wrap');
+        var tbody = document.getElementById('waypoints-tbody');
+        var syncBtn = document.getElementById('btn-sync-waypoints');
+        if (!card || !tbody) return;
+        var show = isConfigPackageMode() && currentCourse && currentCourse.geometry && currentCourse.geometry.coordinates && currentCourse.geometry.coordinates.length >= 2;
+        card.style.display = show ? 'block' : 'none';
+        if (!show) return;
+        if (syncBtn) syncBtn.disabled = !isEditMode;
+        var waypoints = currentCourse.waypoints || [];
+        if (!waypoints.length) {
+            if (wrap) wrap.style.display = 'none';
+            return;
+        }
+        if (wrap) wrap.style.display = 'block';
+        tbody.innerHTML = '';
+        waypoints.forEach(function (wp) {
+            var tr = document.createElement('tr');
+            tr.innerHTML = '<td>' + escapeHtml(wp.label || '') + '</td>'
+                + '<td>' + escapeHtml(wp.kind || 'pin') + '</td>'
+                + '<td>' + (wp.lat != null ? Number(wp.lat).toFixed(5) : '') + '</td>'
+                + '<td>' + (wp.lon != null ? Number(wp.lon).toFixed(5) : '') + '</td>';
+            tbody.appendChild(tr);
+        });
+    }
+
+    function renderSegmentPlannerList() {
+        var card = document.getElementById('segment-planner-card');
+        var wrap = document.getElementById('segment-planner-table-wrap');
+        var tbody = document.getElementById('segment-planner-tbody');
+        var addBtn = document.getElementById('btn-add-segment-def');
+        var updateBtn = document.getElementById('btn-update-segment-defs');
+        if (!card || !tbody) return;
+        var show = isConfigPackageMode() && currentCourse && currentCourse.geometry && currentCourse.geometry.coordinates && currentCourse.geometry.coordinates.length >= 2;
+        card.style.display = show ? 'block' : 'none';
+        if (!show) return;
+        var editable = isEditMode;
+        if (addBtn) addBtn.disabled = !editable;
+        if (updateBtn) updateBtn.disabled = !editable;
+        var waypoints = currentCourse.waypoints || [];
+        var defs = currentCourse.segment_defs || [];
+        if (!waypoints.length) {
+            if (wrap) wrap.style.display = 'none';
+            return;
+        }
+        if (wrap) wrap.style.display = 'block';
+        if (!defs.length && editable) {
+            currentCourse.segment_defs = [{
+                id: 'sd-1',
+                from_waypoint_id: waypoints[0].id,
+                to_waypoint_id: waypoints[waypoints.length - 1].id,
+                events: (EVENT_CHOICES || []).map(function (e) { return e.value || e; }),
+                seg_label: 'Segment 1'
+            }];
+            defs = currentCourse.segment_defs;
+        }
+        tbody.innerHTML = '';
+        defs.forEach(function (sd, idx) {
+            var tr = document.createElement('tr');
+            var tdFrom = document.createElement('td');
+            var selFrom = document.createElement('select');
+            selFrom.disabled = !editable;
+            waypoints.forEach(function (wp) {
+                var opt = document.createElement('option');
+                opt.value = wp.id;
+                opt.textContent = wp.label || wp.id;
+                if (wp.id === sd.from_waypoint_id) opt.selected = true;
+                selFrom.appendChild(opt);
+            });
+            selFrom.onchange = function () {
+                sd.from_waypoint_id = selFrom.value;
+                setDirty();
+            };
+            tdFrom.appendChild(selFrom);
+            var tdTo = document.createElement('td');
+            var selTo = document.createElement('select');
+            selTo.disabled = !editable;
+            waypoints.forEach(function (wp) {
+                var opt = document.createElement('option');
+                opt.value = wp.id;
+                opt.textContent = wp.label || wp.id;
+                if (wp.id === sd.to_waypoint_id) opt.selected = true;
+                selTo.appendChild(opt);
+            });
+            selTo.onchange = function () {
+                sd.to_waypoint_id = selTo.value;
+                setDirty();
+            };
+            tdTo.appendChild(selTo);
+            var tdLabel = document.createElement('td');
+            var inpLabel = document.createElement('input');
+            inpLabel.type = 'text';
+            inpLabel.value = sd.seg_label || '';
+            inpLabel.disabled = !editable;
+            inpLabel.style.width = '100%';
+            inpLabel.oninput = function () {
+                sd.seg_label = inpLabel.value;
+                setDirty();
+            };
+            tdLabel.appendChild(inpLabel);
+            var tdEv = document.createElement('td');
+            var evWrap = document.createElement('div');
+            evWrap.style.display = 'flex';
+            evWrap.style.flexWrap = 'wrap';
+            evWrap.style.gap = '0.35rem';
+            (EVENT_CHOICES || []).forEach(function (ev) {
+                var eid = ev.value || ev;
+                var lbl = document.createElement('label');
+                lbl.style.fontWeight = 'normal';
+                lbl.style.fontSize = '0.8rem';
+                var cb = document.createElement('input');
+                cb.type = 'checkbox';
+                cb.disabled = !editable;
+                cb.checked = (sd.events || []).indexOf(eid) >= 0;
+                cb.onchange = function () {
+                    if (!sd.events) sd.events = [];
+                    if (cb.checked) {
+                        if (sd.events.indexOf(eid) < 0) sd.events.push(eid);
+                    } else {
+                        sd.events = sd.events.filter(function (x) { return x !== eid; });
+                    }
+                    setDirty();
+                };
+                lbl.appendChild(cb);
+                lbl.appendChild(document.createTextNode(' ' + (ev.label || eid)));
+                evWrap.appendChild(lbl);
+            });
+            tdEv.appendChild(evWrap);
+            var tdDel = document.createElement('td');
+            if (editable) {
+                var btnDel = document.createElement('button');
+                btnDel.type = 'button';
+                btnDel.textContent = 'Remove';
+                btnDel.onclick = function () {
+                    currentCourse.segment_defs.splice(idx, 1);
+                    setDirty();
+                    renderSegmentPlannerList();
+                };
+                tdDel.appendChild(btnDel);
+            }
+            tr.appendChild(tdFrom);
+            tr.appendChild(tdTo);
+            tr.appendChild(tdLabel);
+            tr.appendChild(tdEv);
+            tr.appendChild(tdDel);
+            tbody.appendChild(tr);
+        });
+    }
+
+    function previewResolveSegmentPlanner() {
+        var pkgId = resolveConfigPackageId();
+        if (!pkgId || !currentCourse) return Promise.reject(new Error('No package loaded'));
+        var payload = buildCourseSavePayload(pkgId);
+        return fetch('/api/config/packages/' + encodeURIComponent(pkgId) + '/course/preview-resolve', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ course: payload })
+        }).then(function (res) {
+            return res.json().then(function (data) {
+                if (!res.ok) throw new Error(data.detail || res.statusText);
+                return data;
+            });
+        });
+    }
+
+    function applySegmentPlannerToCourse() {
+        return previewResolveSegmentPlanner().then(function (data) {
+            if (data && data.course) {
+                currentCourse.segments = data.course.segments || currentCourse.segments;
+                currentCourse.segment_breaks = data.course.segment_breaks || currentCourse.segment_breaks;
+                currentCourse.segment_break_labels = data.course.segment_break_labels || currentCourse.segment_break_labels;
+                currentCourse.waypoints = data.course.waypoints || currentCourse.waypoints;
+                currentCourse.segment_defs = data.course.segment_defs || currentCourse.segment_defs;
+                setDirty();
+                renderCourseLine();
+                renderSegmentPins();
+                renderSegmentsList();
+                renderWaypointsList();
+                renderSegmentPlannerList();
+            }
+        }).catch(function (e) {
+            alert('Could not update segments: ' + (e.message || String(e)));
+        });
     }
 
     function persistConfigPackageResources() {
@@ -537,6 +804,8 @@ document.addEventListener('DOMContentLoaded', function () {
         setEditMode(isEditMode);
         updateManageResourcesButton();
         updateExportButton();
+        renderWaypointsList();
+        renderSegmentPlannerList();
     }
 
     function setCourse(id, course) {
@@ -576,7 +845,11 @@ document.addEventListener('DOMContentLoaded', function () {
         renderCourseLine();
         renderSegmentPins();
         renderLocationPins();
-        syncSegmentsFromBreaks();
+        if (!usesSegmentPlanner()) {
+            syncSegmentsFromBreaks();
+        }
+        renderWaypointsList();
+        renderSegmentPlannerList();
         renderSegmentsList();
         renderLocationsList();
         renderStartFinishIcons();
@@ -3988,6 +4261,36 @@ document.addEventListener('DOMContentLoaded', function () {
 
         var btnUndo = document.getElementById('btn-undo-point');
         if (btnUndo) btnUndo.addEventListener('click', undoLastPoint);
+
+        var btnSyncWaypoints = document.getElementById('btn-sync-waypoints');
+        if (btnSyncWaypoints) {
+            btnSyncWaypoints.addEventListener('click', function () {
+                syncWaypointsFromSegmentPins();
+            });
+        }
+        var btnAddSegmentDef = document.getElementById('btn-add-segment-def');
+        if (btnAddSegmentDef) {
+            btnAddSegmentDef.addEventListener('click', function () {
+                if (!currentCourse || !currentCourse.waypoints || !currentCourse.waypoints.length) return;
+                var wps = currentCourse.waypoints;
+                if (!currentCourse.segment_defs) currentCourse.segment_defs = [];
+                currentCourse.segment_defs.push({
+                    id: 'sd-' + (currentCourse.segment_defs.length + 1),
+                    from_waypoint_id: wps[0].id,
+                    to_waypoint_id: wps[wps.length - 1].id,
+                    events: (EVENT_CHOICES || []).map(function (e) { return e.value || e; }),
+                    seg_label: 'Segment ' + (currentCourse.segment_defs.length + 1)
+                });
+                setDirty();
+                renderSegmentPlannerList();
+            });
+        }
+        var btnUpdateSegmentDefs = document.getElementById('btn-update-segment-defs');
+        if (btnUpdateSegmentDefs) {
+            btnUpdateSegmentDefs.addEventListener('click', function () {
+                applySegmentPlannerToCourse();
+            });
+        }
 
         var btnSameRouteBack = document.getElementById('btn-same-route-back');
         if (btnSameRouteBack) {

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -156,7 +156,7 @@
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/course_mapping.js?v=766m"></script>
+<script src="/static/js/map/course_mapping.js?v=767a"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=758a"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -463,6 +463,26 @@
         font-weight: normal;
         padding-left: 0.35rem;
     }
+    .course-planner-table th,
+    .course-planner-table td {
+        border: 1px solid #ecf0f1;
+        padding: 0.35rem 0.5rem;
+        text-align: left;
+        vertical-align: middle;
+    }
+    .course-planner-table th {
+        background: #f8f9fa;
+        font-weight: 600;
+    }
+    .course-planner-toolbar button.primary {
+        background: #3498db;
+        color: #fff;
+        border-color: #2980b9;
+    }
+    .course-planner-table select {
+        max-width: 100%;
+        font-size: 0.875rem;
+    }
     .location-event-flags {
         display: flex;
         flex-wrap: wrap;

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -72,9 +72,44 @@
         </div>
     </div>
 
+    <section class="course-derived-section" id="waypoints-card" style="display: none;">
+        <h4 class="course-derived-heading">Waypoints</h4>
+        <p class="course-derived-empty" style="margin-bottom: 0.5rem;">Named places on the course (Issue #767). Use the segment planner below to define legs by waypoint instead of invisible vertices.</p>
+        <div class="course-planner-toolbar" style="margin-bottom: 0.5rem;">
+            <button type="button" id="btn-sync-waypoints" disabled title="Build waypoints from Start, segment pins, and Finish">Sync from segment pins</button>
+        </div>
+        <div id="waypoints-table-wrap" style="display: none;">
+            <table id="waypoints-table" class="course-planner-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+                <thead>
+                    <tr><th>Label</th><th>Kind</th><th>Lat</th><th>Lon</th></tr>
+                </thead>
+                <tbody id="waypoints-tbody"></tbody>
+            </table>
+        </div>
+    </section>
+
+    <section class="course-derived-section" id="segment-planner-card" style="display: none;">
+        <h4 class="course-derived-heading">Segment planner</h4>
+        <p class="course-derived-empty" style="margin-bottom: 0.5rem;">Define segments by From → To waypoint and events. Click <strong>Update segments</strong> to apply to the map (save the package to persist).</p>
+        <div class="course-planner-toolbar" style="margin-bottom: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.5rem;">
+            <button type="button" id="btn-add-segment-def" disabled>Add segment</button>
+            <button type="button" id="btn-update-segment-defs" disabled class="primary">Update segments</button>
+        </div>
+        <div id="segment-planner-table-wrap" style="display: none;">
+            <div class="scrollable-table-container segments-table-scroll" style="max-height: 22vh;">
+                <table id="segment-planner-table" class="table-sticky-header course-planner-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+                    <thead>
+                        <tr><th>From</th><th>To</th><th>Label</th><th>Events</th><th></th></tr>
+                    </thead>
+                    <tbody id="segment-planner-tbody"></tbody>
+                </table>
+            </div>
+        </div>
+    </section>
+
     <section class="course-derived-section" id="segments-card" style="display: none;">
-        <h4 class="course-derived-heading">Segments</h4>
-        <p id="segments-empty" class="course-derived-empty">Add segment pins on the course line to split it into segments. Click a row to zoom the map to that leg; use From/To pin links to open a pin.</p>
+        <h4 class="course-derived-heading">Segments (resolved)</h4>
+        <p id="segments-empty" class="course-derived-empty">Add segment pins or use the segment planner above. Click a row to zoom the map to that leg; use From/To pin links to open a pin.</p>
         <div id="segments-table-wrap" style="display: none;">
             <div class="scrollable-table-container segments-table-scroll" style="max-height: 25vh;">
                 <table id="segments-table" class="table-sticky-header" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">

--- a/tests/unit/test_course_waypoints.py
+++ b/tests/unit/test_course_waypoints.py
@@ -1,0 +1,180 @@
+"""Unit tests for waypoint segment resolver (Issue #767)."""
+
+import pytest
+
+from app.core.course.waypoints import (
+    find_vertex_occurrence,
+    migrate_breaks_to_waypoints,
+    normalize_course_waypoints,
+    resolve_segments_from_definitions,
+)
+
+
+def _line_course(coords):
+    return {
+        "geometry": {"type": "LineString", "coordinates": coords},
+        "segment_breaks": [],
+        "segment_break_labels": {},
+        "segments": [],
+    }
+
+
+def test_find_vertex_occurrence_second_visit():
+    # Out-and-back: pass (0,0) twice
+    coords = [
+        [-66.0, 45.0],
+        [-66.1, 45.1],
+        [-66.2, 45.2],
+        [-66.1, 45.1],
+        [-66.0, 45.0],
+    ]
+    assert find_vertex_occurrence(45.0, -66.0, coords, occurrence=1) == 0
+    assert find_vertex_occurrence(45.0, -66.0, coords, occurrence=2) == 4
+
+
+def test_migrate_breaks_to_waypoints():
+    course = _line_course(
+        [
+            [-66.64, 45.95],
+            [-66.63, 45.96],
+            [-66.62, 45.97],
+        ]
+    )
+    course["segment_breaks"] = [1]
+    course["segment_break_labels"] = {1: "Friel"}
+    course["segments"] = [
+        {
+            "seg_id": "1",
+            "seg_label": "Start to Friel",
+            "start_index": 0,
+            "end_index": 1,
+            "events": ["full", "half"],
+            "from_km": 0,
+            "to_km": 0.5,
+        },
+        {
+            "seg_id": "2",
+            "seg_label": "Friel to Finish",
+            "start_index": 1,
+            "end_index": 2,
+            "events": ["full"],
+            "from_km": 0.5,
+            "to_km": 1.0,
+        },
+    ]
+    migrate_breaks_to_waypoints(course)
+    assert len(course["waypoints"]) == 3
+    assert course["waypoints"][0]["id"] == "wp-start"
+    assert course["waypoints"][1]["label"] == "Friel"
+    assert len(course["segment_defs"]) == 2
+    assert course["segment_defs"][0]["from_waypoint_id"] == "wp-start"
+    assert course["segment_defs"][0]["to_waypoint_id"] == "wp-pin-1"
+
+
+def test_resolve_segment_definitions():
+    coords = [
+        [-66.64, 45.95],
+        [-66.63, 45.96],
+        [-66.62, 45.97],
+        [-66.61, 45.98],
+    ]
+    course = _line_course(coords)
+    course["waypoints"] = [
+        {"id": "wp-start", "label": "Start", "lat": 45.95, "lon": -66.64},
+        {"id": "wp-mid", "label": "Mid", "lat": 45.97, "lon": -66.62},
+        {"id": "wp-finish", "label": "Finish", "lat": 45.98, "lon": -66.61},
+    ]
+    course["segment_defs"] = [
+        {
+            "id": "sd-1",
+            "from_waypoint_id": "wp-start",
+            "to_waypoint_id": "wp-mid",
+            "events": ["full"],
+            "seg_label": "Start to Mid",
+        },
+        {
+            "id": "sd-2",
+            "from_waypoint_id": "wp-mid",
+            "to_waypoint_id": "wp-finish",
+            "events": ["full", "10k"],
+            "seg_label": "Mid to Finish",
+        },
+    ]
+    resolve_segments_from_definitions(course, event_ids=["full", "half", "10k"])
+    assert len(course["segments"]) == 2
+    assert course["segments"][0]["start_index"] == 0
+    assert course["segments"][0]["end_index"] == 2
+    assert course["segments"][0]["events"] == ["full"]
+    assert course["segments"][1]["events"] == ["full", "10k"]
+    assert 2 in course["segment_breaks"]
+
+
+def test_resolve_rejects_to_before_from():
+    course = _line_course(
+        [
+            [-66.64, 45.95],
+            [-66.63, 45.96],
+            [-66.62, 45.97],
+        ]
+    )
+    course["waypoints"] = [
+        {"id": "wp-a", "label": "A", "lat": 45.97, "lon": -66.62},
+        {"id": "wp-b", "label": "B", "lat": 45.95, "lon": -66.64},
+    ]
+    course["segment_defs"] = [
+        {
+            "id": "sd-1",
+            "from_waypoint_id": "wp-a",
+            "to_waypoint_id": "wp-b",
+            "events": ["full"],
+        }
+    ]
+    with pytest.raises(ValueError, match="before"):
+        resolve_segments_from_definitions(course)
+
+
+def test_normalize_round_trip(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    from app.core.config_package.storage import (
+        create_config_package,
+        load_config_course,
+        save_config_course,
+    )
+
+    result = create_config_package("WP test", "")
+    config_id = result["config_id"]
+    course = load_config_course(config_id)
+    course["geometry"] = {
+        "type": "LineString",
+        "coordinates": [[-66.64, 45.95], [-66.63, 45.96], [-66.62, 45.97]],
+    }
+    course["segment_breaks"] = [1]
+    course["segment_break_labels"] = {"1": "Turn"}
+    course["segments"] = [
+        {
+            "seg_id": "1",
+            "seg_label": "Leg 1",
+            "start_index": 0,
+            "end_index": 1,
+            "events": ["full"],
+            "from_km": 0,
+            "to_km": 0.1,
+        },
+        {
+            "seg_id": "2",
+            "seg_label": "Leg 2",
+            "start_index": 1,
+            "end_index": 2,
+            "events": ["10k"],
+            "from_km": 0.1,
+            "to_km": 0.2,
+        },
+    ]
+    save_config_course(config_id, course)
+    reloaded = load_config_course(config_id)
+    assert reloaded.get("waypoints")
+    assert reloaded.get("segment_defs")
+    assert len(reloaded["segments"]) == 2


### PR DESCRIPTION
## Summary

Implements phases 1–3 of #767 (child of epic #755):

- **`waypoints`** and **`segment_defs`** on `course.json` with migration from legacy `segment_breaks`
- **Python resolver** projects planner rows onto geometry (`start_index` / `end_index`) for export
- **`POST .../course/preview-resolve`** to apply planner without a full save round-trip
- **UI** (config package mode): Waypoints table, Segment planner (From/To dropdowns + events), **Update segments** / **Sync from segment pins**

## Test plan

- [ ] Open a config package on `/config` → Course tab
- [ ] Draw course + segment pins → **Sync from segment pins**
- [ ] Edit segment planner rows (events, From/To) → **Update segments** → verify Segments (resolved) table and map
- [ ] Package **Save** → reload → waypoints/segment_defs persist
- [ ] `pytest tests/unit/test_course_waypoints.py`

## Notes

- Does not close #755 or #759
- Pin-first editing still works; loaded courses with `segment_defs` skip client `syncSegmentsFromBreaks` on load

Closes #767

Made with [Cursor](https://cursor.com)