### PR TITLE
Phase 1: Segment library, legs, and event recipes (#769)

### DIFF
--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -1,0 +1,321 @@
+"""
+Config package segment library + event recipes (#755 / #769).
+
+GPX chunks live under runflow/config/{config_id}/segment_library/.
+Manifest (chunks metadata + recipes) is segment_library/manifest.json.
+Apply recipes rebuilds course.json segments[] for export.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+from app.core.config_package.storage import (
+    export_config_package_segments,
+    load_config_course,
+    resolve_config_package_path,
+    save_config_course,
+    validate_config_id,
+)
+from app.core.course.segment_library import (
+    build_course_segments_from_library,
+    export_library_to_course,
+    load_chunk_library,
+    load_manifest,
+    validate_recipe_stitch,
+)
+from app.utils.constants import COURSE_EVENT_IDS
+
+logger = logging.getLogger(__name__)
+
+SEGMENT_LIBRARY_DIRNAME = "segment_library"
+MANIFEST_NAME = "manifest.json"
+
+# Sun events for Phase 1 recipe UI
+RECIPE_EVENT_IDS = ("full", "half", "10k")
+
+REFERENCE_LIBRARY_DIR = (
+    Path(__file__).resolve().parents[2] / "cursor" / "plotaroute"
+)
+
+
+def package_segment_library_dir(package_path: Path) -> Path:
+    return package_path / SEGMENT_LIBRARY_DIRNAME
+
+
+def _manifest_path(package_path: Path) -> Path:
+    return package_segment_library_dir(package_path) / MANIFEST_NAME
+
+
+def _default_manifest() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "label": "",
+        "chunks": [],
+        "recipes": {eid: [] for eid in RECIPE_EVENT_IDS},
+        "flow_overrides": [],
+    }
+
+
+def load_package_segment_manifest(config_id: str) -> Dict[str, Any]:
+    """Load segment_library/manifest.json or empty defaults."""
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    path = _manifest_path(package_path)
+    if not path.is_file():
+        return _default_manifest()
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError("segment library manifest must be a JSON object")
+    if "recipes" not in data:
+        data["recipes"] = {eid: [] for eid in RECIPE_EVENT_IDS}
+    if "chunks" not in data:
+        data["chunks"] = []
+    return data
+
+
+def save_package_segment_manifest(config_id: str, manifest: Dict[str, Any]) -> Path:
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    path = _manifest_path(package_path)
+    out = dict(manifest)
+    if "recipes" not in out:
+        out["recipes"] = {eid: [] for eid in RECIPE_EVENT_IDS}
+    if "chunks" not in out:
+        out["chunks"] = []
+    path.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    logger.info("Saved segment library manifest: %s", path)
+    return path
+
+
+def seed_reference_segment_library(config_id: str) -> Dict[str, Any]:
+    """Copy cursor/plotaroute reference library into the config package."""
+    if not REFERENCE_LIBRARY_DIR.is_dir():
+        raise FileNotFoundError(f"Reference library not found: {REFERENCE_LIBRARY_DIR}")
+    ref_manifest = REFERENCE_LIBRARY_DIR / MANIFEST_NAME
+    if not ref_manifest.is_file():
+        raise FileNotFoundError(f"Reference manifest missing: {ref_manifest}")
+
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    if lib_dir.exists():
+        shutil.rmtree(lib_dir)
+    shutil.copytree(REFERENCE_LIBRARY_DIR, lib_dir, ignore=shutil.ignore_patterns("generated_segments.csv", "README.md"))
+    manifest = load_manifest(lib_dir / MANIFEST_NAME)
+    manifest["label"] = manifest.get("label") or "Reference (PlotARoute)"
+    save_package_segment_manifest(cid, manifest)
+    return get_package_segment_library_state(cid)
+
+
+def recipes_from_order_grid(
+    chunks: Sequence[Dict[str, Any]],
+    order_by_event: Dict[str, Dict[str, Optional[int]]],
+    event_ids: Sequence[str] = RECIPE_EVENT_IDS,
+) -> Dict[str, List[str]]:
+    """
+    Convert UI order grid to recipe lists.
+
+    order_by_event[event][chunk_id] = 1-based order or None if unused.
+    """
+    recipes: Dict[str, List[str]] = {}
+    chunk_ids = [str(c.get("id", "")).strip() for c in chunks if c.get("id")]
+    for eid in event_ids:
+        key = eid if eid in order_by_event else eid.lower()
+        orders = order_by_event.get(key) or order_by_event.get(eid) or {}
+        pairs: List[tuple] = []
+        for cid in chunk_ids:
+            raw = orders.get(cid)
+            if raw is None or raw == "":
+                continue
+            try:
+                n = int(raw)
+            except (TypeError, ValueError):
+                continue
+            if n > 0:
+                pairs.append((n, cid))
+        pairs.sort(key=lambda x: x[0])
+        recipes[eid] = [cid for _, cid in pairs]
+    return recipes
+
+
+def order_grid_from_recipes(
+    chunks: Sequence[Dict[str, Any]],
+    recipes: Dict[str, Any],
+    event_ids: Sequence[str] = RECIPE_EVENT_IDS,
+) -> Dict[str, Dict[str, Optional[int]]]:
+    """Inverse of recipes_from_order_grid for UI."""
+    chunk_ids = [str(c.get("id", "")).strip() for c in chunks if c.get("id")]
+    grid: Dict[str, Dict[str, Optional[int]]] = {}
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        row: Dict[str, Optional[int]] = {cid: None for cid in chunk_ids}
+        for i, cid in enumerate(seq, start=1):
+            if cid in row:
+                row[cid] = i
+        grid[eid] = row
+    return grid
+
+
+def get_package_segment_library_state(config_id: str) -> Dict[str, Any]:
+    """Full library state for API: chunks, recipes, lengths, warnings."""
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    manifest = load_package_segment_manifest(cid)
+    chunks_meta = manifest.get("chunks") or []
+
+    if not lib_dir.is_dir() or not chunks_meta:
+        return {
+            "config_id": cid,
+            "library_dir": str(lib_dir),
+            "has_library": False,
+            "manifest": manifest,
+            "chunks": [],
+            "recipes": manifest.get("recipes") or {},
+            "order_grid": order_grid_from_recipes([], manifest.get("recipes") or {}),
+            "recipe_lengths_km": {eid: 0.0 for eid in RECIPE_EVENT_IDS},
+            "stitch_warnings": [],
+        }
+
+    manifest_path = _manifest_path(package_path)
+    chunks_by_id = load_chunk_library(lib_dir, manifest)
+    chunk_rows: List[Dict[str, Any]] = []
+    for entry in chunks_meta:
+        if not isinstance(entry, dict):
+            continue
+        cid_chunk = str(entry.get("id", "")).strip()
+        loaded = chunks_by_id.get(cid_chunk) or {}
+        chunk_rows.append(
+            {
+                "id": cid_chunk,
+                "file": entry.get("file") or loaded.get("file"),
+                "seg_id": entry.get("seg_id") or cid_chunk,
+                "seg_label": entry.get("seg_label") or loaded.get("name") or cid_chunk,
+                "length_km": loaded.get("length_km", 0),
+                "width_m": entry.get("width_m", 3),
+                "schema": entry.get("schema", "on_course_open"),
+                "direction": entry.get("direction", "uni"),
+                "description": (entry.get("description") or "").strip(),
+            }
+        )
+
+    recipes = manifest.get("recipes") or {}
+    stitch_warnings: List[str] = []
+    recipe_lengths: Dict[str, float] = {}
+    for eid in RECIPE_EVENT_IDS:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        stitch_warnings.extend(validate_recipe_stitch(lib_dir, seq, chunks_by_id))
+        recipe_lengths[eid] = round(
+            sum(float(chunks_by_id[c]["length_km"]) for c in seq if c in chunks_by_id),
+            2,
+        )
+
+    return {
+        "config_id": cid,
+        "library_dir": str(lib_dir),
+        "has_library": bool(chunk_rows),
+        "manifest": manifest,
+        "chunks": chunk_rows,
+        "recipes": recipes,
+        "order_grid": order_grid_from_recipes(chunk_rows, recipes),
+        "recipe_lengths_km": recipe_lengths,
+        "stitch_warnings": stitch_warnings,
+    }
+
+
+def save_package_recipes(
+    config_id: str,
+    recipes: Dict[str, List[str]],
+    *,
+    order_by_event: Optional[Dict[str, Dict[str, Optional[int]]]] = None,
+) -> Dict[str, Any]:
+    """Persist recipe lists to package manifest."""
+    manifest = load_package_segment_manifest(config_id)
+    if order_by_event is not None:
+        recipes = recipes_from_order_grid(manifest.get("chunks") or [], order_by_event)
+    normalized: Dict[str, List[str]] = {}
+    for eid in RECIPE_EVENT_IDS:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        normalized[eid] = [str(x).strip() for x in seq if str(x).strip()]
+    manifest["recipes"] = normalized
+    save_package_segment_manifest(config_id, manifest)
+    return get_package_segment_library_state(config_id)
+
+
+def apply_package_recipes(
+    config_id: str,
+    *,
+    export_csv: bool = True,
+) -> Dict[str, Any]:
+    """
+    Rebuild course.json segments from package segment library recipes.
+
+    Optionally writes segments.csv via export_config_package_segments.
+    """
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    manifest_path = _manifest_path(package_path)
+    if not manifest_path.is_file():
+        raise ValueError("No segment library; import or seed GPX chunks first")
+
+    bundle = export_library_to_course(lib_dir, manifest_path, event_ids=RECIPE_EVENT_IDS)
+    segments = bundle["segments"]
+    if not segments:
+        raise ValueError("Recipes produced no segments; check chunk GPX and recipe order")
+
+    course = load_config_course(cid)
+    course["segments"] = segments
+    course["segment_library_applied"] = True
+    save_config_course(cid, course)
+
+    export_result: Optional[Dict[str, Any]] = None
+    if export_csv:
+        export_result = export_config_package_segments(cid)
+
+    state = get_package_segment_library_state(cid)
+    return {
+        "config_id": cid,
+        "segment_count": len(segments),
+        "recipe_lengths_km": bundle["recipe_lengths_km"],
+        "stitch_warnings": bundle["stitch_warnings"],
+        "segments_csv_path": export_result.get("path") if export_result else None,
+        "library": state,
+    }
+
+
+def import_gpx_files_to_library(
+    config_id: str,
+    uploads: Sequence[tuple],
+) -> Dict[str, Any]:
+    """
+    Save uploaded GPX files into segment_library/.
+
+    uploads: sequence of (filename, bytes).
+    Filenames should match manifest chunk file names when updating an existing library.
+    """
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    saved: List[str] = []
+    for name, data in uploads:
+        safe = Path(name).name
+        if not safe.lower().endswith(".gpx"):
+            continue
+        dest = lib_dir / safe
+        dest.write_bytes(data)
+        saved.append(safe)
+    if not saved:
+        raise ValueError("No .gpx files uploaded")
+    return get_package_segment_library_state(config_id)

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -14,6 +14,8 @@ import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
 
+import yaml
+
 from app.core.config_package.storage import (
     export_config_package_segments,
     load_config_course,
@@ -26,6 +28,7 @@ from app.core.course.segment_library import (
     export_library_to_course,
     load_chunk_library,
     load_manifest,
+    parse_chunk_gpx,
     validate_recipe_stitch,
 )
 from app.utils.constants import COURSE_EVENT_IDS
@@ -33,14 +36,30 @@ from app.utils.constants import COURSE_EVENT_IDS
 logger = logging.getLogger(__name__)
 
 SEGMENT_LIBRARY_DIRNAME = "segment_library"
-MANIFEST_NAME = "manifest.json"
+MANIFEST_YAML = "manifest.yaml"
+MANIFEST_JSON = "manifest.json"
 
 # Sun events for Phase 1 recipe UI
 RECIPE_EVENT_IDS = ("full", "half", "10k")
 
-REFERENCE_LIBRARY_DIR = (
-    Path(__file__).resolve().parents[2] / "cursor" / "plotaroute"
-)
+def _repo_root() -> Path:
+    """Project root (/app in Docker, repo root on host)."""
+    return Path(__file__).resolve().parents[3]
+
+
+def _reference_library_dir() -> Path:
+    """Built-in PlotARoute reference chunks (image or repo cursor/plotaroute)."""
+    candidates = [
+        _repo_root() / "cursor" / "plotaroute",
+        Path("/app/cursor/plotaroute"),
+    ]
+    for path in candidates:
+        if (path / MANIFEST_YAML).is_file() or (path / MANIFEST_JSON).is_file():
+            return path
+    return candidates[0]
+
+
+REFERENCE_LIBRARY_DIR = _reference_library_dir()
 
 
 def package_segment_library_dir(package_path: Path) -> Path:
@@ -48,7 +67,33 @@ def package_segment_library_dir(package_path: Path) -> Path:
 
 
 def _manifest_path(package_path: Path) -> Path:
-    return package_segment_library_dir(package_path) / MANIFEST_NAME
+    """Resolved manifest file in package (yaml preferred, matches reference library)."""
+    lib_dir = package_segment_library_dir(package_path)
+    for name in (MANIFEST_YAML, MANIFEST_JSON):
+        path = lib_dir / name
+        if path.is_file():
+            return path
+    return lib_dir / MANIFEST_YAML
+
+
+def _read_manifest_file(path: Path) -> Dict[str, Any]:
+    if path.suffix.lower() in (".yaml", ".yml"):
+        return load_manifest(path)
+    data = json.loads(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid manifest: {path}")
+    return data
+
+
+def _write_manifest_file(path: Path, manifest: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.suffix.lower() in (".yaml", ".yml"):
+        path.write_text(
+            yaml.safe_dump(manifest, sort_keys=False, allow_unicode=True),
+            encoding="utf-8",
+        )
+    else:
+        path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
 
 
 def _default_manifest() -> Dict[str, Any]:
@@ -62,15 +107,15 @@ def _default_manifest() -> Dict[str, Any]:
 
 
 def load_package_segment_manifest(config_id: str) -> Dict[str, Any]:
-    """Load segment_library/manifest.json or empty defaults."""
+    """Load segment_library manifest or empty defaults."""
     cid = validate_config_id(config_id)
     package_path = resolve_config_package_path(cid)
     path = _manifest_path(package_path)
     if not path.is_file():
         return _default_manifest()
-    data = json.loads(path.read_text(encoding="utf-8"))
+    data = _read_manifest_file(path)
     if not isinstance(data, dict):
-        raise ValueError("segment library manifest must be a JSON object")
+        raise ValueError("segment library manifest must be an object")
     if "recipes" not in data:
         data["recipes"] = {eid: [] for eid in RECIPE_EVENT_IDS}
     if "chunks" not in data:
@@ -83,32 +128,104 @@ def save_package_segment_manifest(config_id: str, manifest: Dict[str, Any]) -> P
     package_path = resolve_config_package_path(cid)
     lib_dir = package_segment_library_dir(package_path)
     lib_dir.mkdir(parents=True, exist_ok=True)
-    path = _manifest_path(package_path)
+    path = package_segment_library_dir(package_path) / MANIFEST_YAML
     out = dict(manifest)
     if "recipes" not in out:
         out["recipes"] = {eid: [] for eid in RECIPE_EVENT_IDS}
     if "chunks" not in out:
         out["chunks"] = []
-    path.write_text(json.dumps(out, indent=2), encoding="utf-8")
+    _write_manifest_file(path, out)
     logger.info("Saved segment library manifest: %s", path)
     return path
 
 
+def _chunk_id_from_filename(filename: str) -> str:
+    """Derive chunk id from PlotARoute-style names (e.g. 01_start_friel.gpx -> 01)."""
+    stem = Path(filename).stem
+    if stem.startswith("00_"):
+        return ""
+    prefix = stem.split("_", 1)[0]
+    if prefix.isdigit():
+        return prefix
+    return stem[:24]
+
+
+def sync_manifest_chunks_from_gpx(
+    lib_dir: Path,
+    manifest: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """
+    Ensure manifest lists every chunk GPX in lib_dir (except 00_* combined routes).
+
+    New files get default metadata; existing entries keep seg_id, width, recipes, etc.
+    """
+    manifest = dict(manifest or _default_manifest())
+    existing_by_file = {
+        str(c.get("file", "")): c
+        for c in (manifest.get("chunks") or [])
+        if isinstance(c, dict) and c.get("file")
+    }
+    chunks: List[Dict[str, Any]] = []
+    for gpx_path in sorted(lib_dir.glob("*.gpx")):
+        name = gpx_path.name
+        if name.startswith("00_"):
+            continue
+        cid = _chunk_id_from_filename(name)
+        if not cid:
+            continue
+        prior = existing_by_file.get(name) or {}
+        if prior.get("id"):
+            cid = str(prior["id"])
+        try:
+            parsed = parse_chunk_gpx(gpx_path)
+        except ValueError:
+            continue
+        label = (
+            (prior.get("seg_label") or "").strip()
+            or (parsed.get("name") or "").strip()
+            or gpx_path.stem.replace("_", " ").title()
+        )
+        chunks.append(
+            {
+                "id": cid,
+                "file": name,
+                "seg_id": (prior.get("seg_id") or cid).strip(),
+                "seg_label": label,
+                "width_m": prior.get("width_m", 3),
+                "schema": prior.get("schema", "on_course_open"),
+                "direction": prior.get("direction", "uni"),
+                "description": (prior.get("description") or "").strip(),
+            }
+        )
+    manifest["chunks"] = chunks
+    return manifest
+
+
 def seed_reference_segment_library(config_id: str) -> Dict[str, Any]:
     """Copy cursor/plotaroute reference library into the config package."""
-    if not REFERENCE_LIBRARY_DIR.is_dir():
-        raise FileNotFoundError(f"Reference library not found: {REFERENCE_LIBRARY_DIR}")
-    ref_manifest = REFERENCE_LIBRARY_DIR / MANIFEST_NAME
+    ref_dir = _reference_library_dir()
+    if not ref_dir.is_dir():
+        raise FileNotFoundError(
+            f"Reference library not found at {ref_dir}. "
+            "Rebuild the dev container or mount cursor/plotaroute."
+        )
+    ref_manifest = ref_dir / MANIFEST_YAML
     if not ref_manifest.is_file():
-        raise FileNotFoundError(f"Reference manifest missing: {ref_manifest}")
+        ref_manifest = ref_dir / MANIFEST_JSON
+    if not ref_manifest.is_file():
+        raise FileNotFoundError(f"Reference manifest missing under {ref_dir}")
 
     cid = validate_config_id(config_id)
     package_path = resolve_config_package_path(cid)
     lib_dir = package_segment_library_dir(package_path)
     if lib_dir.exists():
         shutil.rmtree(lib_dir)
-    shutil.copytree(REFERENCE_LIBRARY_DIR, lib_dir, ignore=shutil.ignore_patterns("generated_segments.csv", "README.md"))
-    manifest = load_manifest(lib_dir / MANIFEST_NAME)
+    shutil.copytree(
+        ref_dir,
+        lib_dir,
+        ignore=shutil.ignore_patterns("generated_segments.csv", "README.md"),
+    )
+    manifest = _read_manifest_file(_manifest_path(package_path))
     manifest["label"] = manifest.get("label") or "Reference (PlotARoute)"
     save_package_segment_manifest(cid, manifest)
     return get_package_segment_library_state(cid)
@@ -318,4 +435,7 @@ def import_gpx_files_to_library(
         saved.append(safe)
     if not saved:
         raise ValueError("No .gpx files uploaded")
+    manifest = load_package_segment_manifest(config_id)
+    manifest = sync_manifest_chunks_from_gpx(lib_dir, manifest)
+    save_package_segment_manifest(config_id, manifest)
     return get_package_segment_library_state(config_id)

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -189,7 +189,6 @@ def sync_manifest_chunks_from_gpx(
             {
                 "id": cid,
                 "file": name,
-                "seg_id": (prior.get("seg_id") or cid).strip(),
                 "seg_label": label,
                 "width_m": prior.get("width_m", 3),
                 "schema": prior.get("schema", "on_course_open"),
@@ -314,8 +313,7 @@ def get_package_segment_library_state(config_id: str) -> Dict[str, Any]:
             {
                 "id": cid_chunk,
                 "file": entry.get("file") or loaded.get("file"),
-                "seg_id": entry.get("seg_id") or cid_chunk,
-                "seg_label": entry.get("seg_label") or loaded.get("name") or cid_chunk,
+                "leg_label": entry.get("seg_label") or loaded.get("name") or cid_chunk,
                 "length_km": loaded.get("length_km", 0),
                 "width_m": entry.get("width_m", 3),
                 "schema": entry.get("schema", "on_course_open"),

--- a/app/core/course/__init__.py
+++ b/app/core/course/__init__.py
@@ -4,6 +4,10 @@ Course Mapping storage and helpers.
 Issue #732: Course map saved under {data_dir}/courses/{id}.
 """
 
+from app.core.course.segment_library import (
+    export_library_to_course,
+    write_package_exports,
+)
 from app.core.course.storage import (
     create_course_directory,
     list_courses,
@@ -13,7 +17,9 @@ from app.core.course.storage import (
 
 __all__ = [
     "create_course_directory",
+    "export_library_to_course",
     "list_courses",
     "load_course",
     "save_course",
+    "write_package_exports",
 ]

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -195,6 +195,7 @@ def build_course_segments_from_library(
 
     segments: List[Dict[str, Any]] = []
     chunk_order = manifest.get("chunks") or []
+    segment_index = 0
     for entry in chunk_order:
         if not isinstance(entry, dict):
             continue
@@ -202,10 +203,11 @@ def build_course_segments_from_library(
         ch = chunks_by_id.get(cid)
         if not ch:
             continue
+        segment_index += 1
         length_km = float(ch["length_km"])
         events = _events_for_chunk(cid, recipes, event_ids)
         seg: Dict[str, Any] = {
-            "seg_id": (entry.get("seg_id") or cid).strip(),
+            "seg_id": f"S{segment_index}",
             "seg_label": (entry.get("seg_label") or ch.get("name") or cid).strip(),
             "width_m": entry.get("width_m", 3),
             "schema": entry.get("schema", "on_course_open"),

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -1,0 +1,395 @@
+"""
+Segment library + event recipes (PlotARoute / 2027 planning).
+
+A segment library is a set of reusable GPX chunks. Event recipes list chunk ids in order.
+From that we build:
+  - per-event combined GPX
+  - multi-event segments.csv (one row per chunk, 2026-style)
+  - flow.csv rows for event pairs on shared chunks (#759 baseline)
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import math
+from itertools import combinations
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import yaml
+
+from app.core.course.export import build_segments_csv, enrich_segments_event_distances
+from app.core.gpx.processor import parse_gpx_file
+from app.utils.constants import COURSE_EVENT_IDS
+
+GPX_NS = "http://www.topografix.com/GPX/1/1"
+EARTH_R = 6371000.0
+STITCH_TOLERANCE_M = 80.0
+
+
+def _haversine_m(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    d_lat = math.radians(lat2 - lat1)
+    d_lon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_lat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(d_lon / 2) ** 2
+    )
+    return EARTH_R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def load_manifest(path: Path) -> Dict[str, Any]:
+    """Load YAML manifest with chunks and recipes."""
+    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid manifest: {path}")
+    if "chunks" not in data or "recipes" not in data:
+        raise ValueError("manifest must include chunks and recipes")
+    return data
+
+
+def parse_chunk_gpx(path: Path) -> Dict[str, Any]:
+    """Parse a PlotARoute chunk GPX into coordinates and length."""
+    course = parse_gpx_file(str(path))
+    coords = [[p.lon, p.lat] for p in course.points]
+    if len(coords) < 2:
+        raise ValueError(f"Chunk GPX needs at least 2 points: {path}")
+    return {
+        "name": course.name,
+        "coordinates": coords,
+        "length_km": round(course.total_distance_km, 2),
+        "start": coords[0],
+        "end": coords[-1],
+        "point_count": len(coords),
+    }
+
+
+def validate_recipe_stitch(
+    library_dir: Path,
+    chunk_ids: Sequence[str],
+    chunks_by_id: Dict[str, Dict[str, Any]],
+    *,
+    tolerance_m: float = STITCH_TOLERANCE_M,
+) -> List[str]:
+    """Return human-readable warnings for endpoint gaps between consecutive chunks."""
+    warnings: List[str] = []
+    for i in range(len(chunk_ids) - 1):
+        a_id, b_id = chunk_ids[i], chunk_ids[i + 1]
+        a = chunks_by_id.get(a_id)
+        b = chunks_by_id.get(b_id)
+        if not a or not b:
+            warnings.append(f"Unknown chunk in recipe: {a_id} or {b_id}")
+            continue
+        gap = _haversine_m(a["end"][0], a["end"][1], b["start"][0], b["start"][1])
+        if gap > tolerance_m:
+            warnings.append(
+                f"Stitch gap {gap:.0f}m between {a_id} ({a.get('file', '')}) "
+                f"and {b_id} ({b.get('file', '')})"
+            )
+    return warnings
+
+
+def load_chunk_library(library_dir: Path, manifest: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
+    """Load all chunks from manifest into memory."""
+    out: Dict[str, Dict[str, Any]] = {}
+    for entry in manifest.get("chunks") or []:
+        if not isinstance(entry, dict):
+            continue
+        cid = str(entry.get("id", "")).strip()
+        file_name = entry.get("file")
+        if not cid or not file_name:
+            continue
+        gpx_path = library_dir / str(file_name)
+        parsed = parse_chunk_gpx(gpx_path)
+        out[cid] = {**entry, **parsed, "file": str(file_name)}
+    return out
+
+
+def concat_recipe_coordinates(
+    chunk_ids: Sequence[str],
+    chunks_by_id: Dict[str, Dict[str, Any]],
+) -> List[List[float]]:
+    """Concatenate chunk LineStrings; drop duplicate join vertex."""
+    coords: List[List[float]] = []
+    for cid in chunk_ids:
+        chunk = chunks_by_id.get(cid)
+        if not chunk:
+            raise ValueError(f"Unknown chunk id: {cid}")
+        part = chunk["coordinates"]
+        if not coords:
+            coords.extend(part)
+        else:
+            coords.extend(part[1:])
+    return coords
+
+
+def build_event_gpx_content(
+    event_id: str,
+    manifest: Dict[str, Any],
+    chunks_by_id: Dict[str, Dict[str, Any]],
+    *,
+    course_name: str = "",
+) -> str:
+    """Build GPX 1.1 XML for one event recipe."""
+    import xml.etree.ElementTree as ET
+
+    recipes = manifest.get("recipes") or {}
+    chunk_ids = recipes.get(event_id) or recipes.get(event_id.lower())
+    if not chunk_ids:
+        raise ValueError(f"No recipe for event: {event_id}")
+
+    coords = concat_recipe_coordinates(chunk_ids, chunks_by_id)
+    root = ET.Element("gpx", version="1.1", creator="run-density segment_library")
+    root.set("xmlns", GPX_NS)
+    trk = ET.SubElement(root, "trk")
+    name_el = ET.SubElement(trk, "name")
+    name_el.text = course_name or f"{event_id} course"
+    trkseg = ET.SubElement(trk, "trkseg")
+    for lon, lat in coords:
+        ET.SubElement(trkseg, "trkpt", lat=str(lat), lon=str(lon))
+    return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
+
+
+def _events_for_chunk(
+    chunk_id: str,
+    recipes: Dict[str, Any],
+    event_ids: Sequence[str],
+) -> List[str]:
+    out: List[str] = []
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        if chunk_id in seq:
+            out.append(eid.lower())
+    return out
+
+
+def build_course_segments_from_library(
+    manifest: Dict[str, Any],
+    chunks_by_id: Dict[str, Dict[str, Any]],
+    event_ids: Optional[Sequence[str]] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Build course['segments'] list: one dict per library chunk (multi-event row).
+
+    Each segment has geometry length (chunk length) and per-event from/to km from
+    cumulative distance along each event's recipe (2026 segments.csv model).
+    """
+    event_ids = list(event_ids or COURSE_EVENT_IDS)
+    recipes = manifest.get("recipes") or {}
+
+    # Per-event cumulative at each chunk end (only chunks in that recipe)
+    event_cum_at_chunk: Dict[str, Dict[str, float]] = {e: {} for e in event_ids}
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        cum = 0.0
+        for cid in seq:
+            ch = chunks_by_id.get(cid)
+            if not ch:
+                continue
+            cum += float(ch["length_km"])
+            event_cum_at_chunk[eid.lower()][cid] = round(cum, 2)
+
+    segments: List[Dict[str, Any]] = []
+    chunk_order = manifest.get("chunks") or []
+    for entry in chunk_order:
+        if not isinstance(entry, dict):
+            continue
+        cid = str(entry.get("id", "")).strip()
+        ch = chunks_by_id.get(cid)
+        if not ch:
+            continue
+        length_km = float(ch["length_km"])
+        events = _events_for_chunk(cid, recipes, event_ids)
+        seg: Dict[str, Any] = {
+            "seg_id": (entry.get("seg_id") or cid).strip(),
+            "seg_label": (entry.get("seg_label") or ch.get("name") or cid).strip(),
+            "width_m": entry.get("width_m", 3),
+            "schema": entry.get("schema", "on_course_open"),
+            "direction": entry.get("direction", "uni"),
+            "description": (entry.get("description") or "").strip(),
+            "events": events,
+            "chunk_id": cid,
+            "length_km": length_km,
+            "from_km": 0.0,
+            "to_km": length_km,
+        }
+        for eid in event_ids:
+            el = eid.lower()
+            if el not in events:
+                seg[f"{el}_from_km"] = 0.0
+                seg[f"{el}_to_km"] = 0.0
+                continue
+            to_km = event_cum_at_chunk[el].get(cid, 0.0)
+            from_km = round(to_km - length_km, 2)
+            seg[f"{el}_from_km"] = max(0.0, from_km)
+            seg[f"{el}_to_km"] = to_km
+        segments.append(seg)
+
+    enrich_segments_event_distances(segments, event_ids)
+    return segments
+
+
+def build_flow_csv_from_segments(
+    segments: Sequence[Dict[str, Any]],
+    event_ids: Optional[Sequence[str]] = None,
+    *,
+    overrides: Optional[Sequence[Dict[str, Any]]] = None,
+    include_same_event_pairs: bool = True,
+) -> str:
+    """
+    Generate 2026-style flow.csv from multi-event segment rows.
+
+    For each segment used by 2+ events, emit one row per event pair (A,B) with
+    from_km_a/to_km_a and from_km_b/to_km_b from segment per-event columns.
+    """
+    event_ids = [e.lower() for e in (event_ids or COURSE_EVENT_IDS)]
+    override_index = {
+        (str(o.get("seg_id", "")), str(o.get("event_a", "")), str(o.get("event_b", ""))): o
+        for o in (overrides or [])
+        if isinstance(o, dict)
+    }
+
+    out = io.StringIO()
+    w = csv.writer(out)
+    w.writerow(
+        [
+            "seg_id",
+            "seg_label",
+            "event_a",
+            "event_b",
+            "from_km_a",
+            "to_km_a",
+            "from_km_b",
+            "to_km_b",
+            "flow_type",
+            "direction",
+            "notes",
+        ]
+    )
+
+    for seg in segments:
+        seg_id = str(seg.get("seg_id", "")).strip()
+        seg_label = str(seg.get("seg_label", "")).strip()
+        direction = seg.get("direction", "uni")
+        active = []
+        for eid in event_ids:
+            if eid in (seg.get("events") or []):
+                active.append(eid)
+            elif str(seg.get(eid, "n")).lower() == "y":
+                active.append(eid)
+        if len(active) < 2 and not include_same_event_pairs:
+            continue
+        pairs: List[Tuple[str, str]] = []
+        if include_same_event_pairs:
+            pairs = [(a, b) for a, b in combinations(active, 2)]
+            for e in active:
+                pairs.append((e, e))
+        else:
+            pairs = [(a, b) for a, b in combinations(active, 2)]
+        for event_a, event_b in pairs:
+            from_a = float(seg.get(f"{event_a}_from_km") or 0)
+            to_a = float(seg.get(f"{event_a}_to_km") or 0)
+            from_b = float(seg.get(f"{event_b}_from_km") or 0)
+            to_b = float(seg.get(f"{event_b}_to_km") or 0)
+            if to_a <= from_a and to_b <= from_b:
+                continue
+            key = (seg_id, event_a, event_b)
+            ov = override_index.get(key, {})
+            flow_type = ov.get("flow_type") or seg.get("flow_type") or "overtake"
+            notes = ov.get("notes") or seg.get("flow_notes") or ""
+            w.writerow(
+                [
+                    seg_id,
+                    seg_label,
+                    event_a,
+                    event_b,
+                    from_a,
+                    to_a,
+                    from_b,
+                    to_b,
+                    flow_type,
+                    direction,
+                    notes,
+                ]
+            )
+    return out.getvalue()
+
+
+def export_library_to_course(
+    library_dir: Path,
+    manifest_path: Optional[Path] = None,
+    *,
+    event_ids: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Load library + manifest and return export bundle (segments, flow csv, validation).
+    """
+    manifest_path = manifest_path or (library_dir / "manifest.yaml")
+    manifest = load_manifest(manifest_path)
+    chunks_by_id = load_chunk_library(library_dir, manifest)
+    event_ids = list(event_ids or COURSE_EVENT_IDS)
+
+    stitch_warnings: List[str] = []
+    recipes = manifest.get("recipes") or {}
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        stitch_warnings.extend(
+            validate_recipe_stitch(library_dir, seq, chunks_by_id)
+        )
+
+    segments = build_course_segments_from_library(manifest, chunks_by_id, event_ids)
+    course = {"segments": segments, "name": manifest.get("label", "")}
+    segments_csv = build_segments_csv(course, fmt="pipeline")
+    flow_csv = build_flow_csv_from_segments(
+        segments,
+        event_ids,
+        overrides=manifest.get("flow_overrides"),
+    )
+
+    recipe_lengths: Dict[str, float] = {}
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        recipe_lengths[eid] = round(
+            sum(float(chunks_by_id[c]["length_km"]) for c in seq if c in chunks_by_id),
+            2,
+        )
+
+    return {
+        "manifest": manifest,
+        "segments": segments,
+        "segments_csv": segments_csv,
+        "flow_csv": flow_csv,
+        "stitch_warnings": stitch_warnings,
+        "recipe_lengths_km": recipe_lengths,
+    }
+
+
+def write_package_exports(
+    package_dir: Path,
+    library_dir: Path,
+    manifest_path: Optional[Path] = None,
+    *,
+    write_event_gpx: bool = True,
+) -> Dict[str, Any]:
+    """Write segments.csv, flow.csv, and optional per-event GPX into a config package."""
+    bundle = export_library_to_course(library_dir, manifest_path)
+    package_dir.mkdir(parents=True, exist_ok=True)
+    (package_dir / "segments.csv").write_text(bundle["segments_csv"], encoding="utf-8")
+    (package_dir / "flow.csv").write_text(bundle["flow_csv"], encoding="utf-8")
+
+    manifest = bundle["manifest"]
+    chunks_by_id = load_chunk_library(
+        library_dir, manifest
+    )
+    if write_event_gpx:
+        for eid in (manifest.get("recipes") or {}).keys():
+            gpx = build_event_gpx_content(eid, manifest, chunks_by_id)
+            (package_dir / f"{eid.lower()}.gpx").write_text(gpx, encoding="utf-8")
+
+    return bundle

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -9,7 +9,7 @@ Issue #758: Export segments.csv from course.json into config package.
 import logging
 from typing import Any, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query, Request, status
+from fastapi import APIRouter, File, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -26,8 +26,15 @@ from app.core.config_package import (
     save_config_package_resources,
     update_config_package_metadata,
 )
-from app.core.locations.suggest_events import suggest_location_events
+from app.core.config_package.segment_recipes import (
+    apply_package_recipes,
+    get_package_segment_library_state,
+    import_gpx_files_to_library,
+    save_package_recipes,
+    seed_reference_segment_library,
+)
 from app.core.config_package.storage import validate_config_id
+from app.core.locations.suggest_events import suggest_location_events
 from app.utils.auth import require_auth
 
 logger = logging.getLogger(__name__)
@@ -66,6 +73,17 @@ class SavePackageResourcesRequest(BaseModel):
 class SuggestLocationEventsRequest(BaseModel):
     location_index: Optional[int] = Field(None, ge=0)
     location: Optional[Dict[str, Any]] = None
+
+
+class SaveSegmentRecipesRequest(BaseModel):
+    order_by_event: Dict[str, Dict[str, Optional[int]]] = Field(
+        default_factory=dict,
+        description="Per event, chunk id -> 1-based order (omit or null if unused)",
+    )
+    export_csv: bool = Field(
+        True,
+        description="After save, apply recipes to course.json and write segments.csv",
+    )
 
 
 @router.get("/api/config/packages")
@@ -208,6 +226,113 @@ async def api_save_config_course(
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to save course: {e}",
+        )
+
+
+@router.get("/api/config/packages/{config_id}/segment-library")
+async def api_get_segment_library(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """Load segment library chunks, recipes, and per-event km totals."""
+    require_auth(request)
+    try:
+        state = get_package_segment_library_state(config_id)
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/config/packages/{config_id}/segment-library/seed-reference")
+async def api_seed_reference_segment_library(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """Copy built-in PlotARoute reference library into the package (dev / bootstrap)."""
+    require_auth(request)
+    try:
+        state = seed_reference_segment_library(config_id)
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/config/packages/{config_id}/segment-library/upload")
+async def api_upload_segment_library_gpx(
+    request: Request,
+    config_id: str,
+    files: List[UploadFile] = File(...),
+) -> JSONResponse:
+    """Upload GPX chunk files into the package segment_library folder."""
+    require_auth(request)
+    try:
+        uploads = []
+        for uf in files:
+            data = await uf.read()
+            uploads.append((uf.filename or "chunk.gpx", data))
+        state = import_gpx_files_to_library(config_id, uploads)
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.put("/api/config/packages/{config_id}/segment-library/recipes")
+async def api_save_segment_recipes(
+    request: Request,
+    config_id: str,
+    body: SaveSegmentRecipesRequest,
+) -> JSONResponse:
+    """Save recipe order grid; optionally apply to course and export segments.csv."""
+    require_auth(request)
+    try:
+        state = save_package_recipes(config_id, {}, order_by_event=body.order_by_event)
+        result: Dict[str, Any] = {"ok": True, "library": state}
+        if body.export_csv:
+            apply_result = apply_package_recipes(config_id, export_csv=True)
+            result["apply"] = apply_result
+            course = load_config_course(config_id)
+            result["course"] = course
+        return JSONResponse(content=result)
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to save segment recipes")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to save recipes: {e}",
+        )
+
+
+@router.post("/api/config/packages/{config_id}/segment-library/apply")
+async def api_apply_segment_recipes(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """Apply saved recipes to course.json and export segments.csv."""
+    require_auth(request)
+    try:
+        result = apply_package_recipes(config_id, export_csv=True)
+        course = load_config_course(config_id)
+        return JSONResponse(
+            content={"ok": True, **result, "course": course}
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to apply segment recipes")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to apply recipes: {e}",
         )
 
 

--- a/cursor/plotaroute/00_10k.gpx
+++ b/cursor/plotaroute/00_10k.gpx
@@ -1,0 +1,762 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.954489" lon="-66.641395">
+<time>2026-02-10T00:00:00Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Saint John Street</cmt>
+<desc>Start on Rue Saint John Street</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954492" lon="-66.6414">
+<time>2026-02-10T00:00:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-10T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rang Churchill Row</cmt>
+<desc>Turn right onto Rang Churchill Row</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-10T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956374" lon="-66.639758">
+<time>2026-02-10T00:01:29Z</time>
+<name>At roundab</name>
+<cmt>At roundabout, take exit 2 onto Rue Saint John Street</cmt>
+<desc>At roundabout, take exit 2 onto Rue Saint John Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-10T00:01:35Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-10T00:01:35Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-10T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Brunswick Street</cmt>
+<desc>Turn right onto Rue Brunswick Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-10T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-10T00:03:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue King Street</cmt>
+<desc>Turn right onto Rue King Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-10T00:03:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-10T00:04:28Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-10T00:04:29Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Queen Street</cmt>
+<desc>Turn left onto Rue Queen Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.96099" lon="-66.638372">
+<time>2026-02-10T00:05:33Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.961255" lon="-66.638537">
+<time>2026-02-10T00:05:45Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</cmt>
+<desc>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.964051" lon="-66.641227">
+<time>2026-02-10T00:08:24Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966872" lon="-66.643476">
+<time>2026-02-10T00:10:42Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Westmorland Street Bridge</cmt>
+<desc>Turn slight right onto Westmorland Street Bridge</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971269" lon="-66.641336">
+<time>2026-02-10T00:13:48Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971842" lon="-66.640842">
+<time>2026-02-10T00:14:15Z</time>
+<name>Keep left</name>
+<cmt>Keep left</cmt>
+<desc>Keep left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973279" lon="-66.639509">
+<time>2026-02-10T00:15:25Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Rue Union Street</cmt>
+<desc>Turn slight right onto Rue Union Street</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973069" lon="-66.638821">
+<time>2026-02-10T00:15:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Friel Street</cmt>
+<desc>Turn right onto Rue Friel Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973747" lon="-66.638243">
+<time>2026-02-10T00:16:18Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Northside Trail</cmt>
+<desc>Turn left onto Northside Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973749" lon="-66.63825">
+<time>2026-02-10T00:16:18Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Friel Street</cmt>
+<desc>Start on Rue Friel Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.980194" lon="-66.656652">
+<time>2026-02-10T00:25:53Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959573" lon="-66.61926">
+<time>2026-02-10T00:48:54Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Sentier Nashwaak Trail</cmt>
+<desc>Turn right onto Sentier Nashwaak Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9539395" lon="-66.6399014">
+<time>2026-02-10T01:00:10Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>00_10k</name>
+<trkseg>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.954492" lon="-66.6414">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639772">
+<ele>13</ele>
+<time>2026-02-10T00:01:28Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639771">
+<ele>13</ele>
+<time>2026-02-10T00:01:28Z</time></trkpt>
+<trkpt lat="45.956374" lon="-66.639758">
+<ele>13</ele>
+<time>2026-02-10T00:01:29Z</time></trkpt>
+<trkpt lat="45.956371" lon="-66.639719">
+<ele>13</ele>
+<time>2026-02-10T00:01:30Z</time></trkpt>
+<trkpt lat="45.956394" lon="-66.639674">
+<ele>13</ele>
+<time>2026-02-10T00:01:31Z</time></trkpt>
+<trkpt lat="45.956428" lon="-66.639667">
+<ele>13</ele>
+<time>2026-02-10T00:01:33Z</time></trkpt>
+<trkpt lat="45.956454" lon="-66.639689">
+<ele>13</ele>
+<time>2026-02-10T00:01:34Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-10T00:02:16Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-10T00:02:16Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-10T00:03:45Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-10T00:04:29Z</time></trkpt>
+<trkpt lat="45.960461" lon="-66.637131">
+<ele>8</ele>
+<time>2026-02-10T00:04:52Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.96099" lon="-66.638372">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.961139" lon="-66.638502">
+<ele>9</ele>
+<time>2026-02-10T00:05:40Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-10T00:05:43Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-10T00:05:43Z</time></trkpt>
+<trkpt lat="45.961255" lon="-66.638537">
+<ele>9</ele>
+<time>2026-02-10T00:05:45Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-10T00:06:08Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-10T00:06:08Z</time></trkpt>
+<trkpt lat="45.961916" lon="-66.638033">
+<ele>8</ele>
+<time>2026-02-10T00:06:15Z</time></trkpt>
+<trkpt lat="45.962057" lon="-66.638009">
+<ele>8</ele>
+<time>2026-02-10T00:06:21Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-10T00:06:30Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-10T00:06:30Z</time></trkpt>
+<trkpt lat="45.962472" lon="-66.638212">
+<ele>7</ele>
+<time>2026-02-10T00:06:38Z</time></trkpt>
+<trkpt lat="45.96257" lon="-66.638353">
+<ele>7</ele>
+<time>2026-02-10T00:06:44Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-10T00:07:04Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-10T00:07:04Z</time></trkpt>
+<trkpt lat="45.964051" lon="-66.641227">
+<ele>8</ele>
+<time>2026-02-10T00:08:24Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-10T00:08:30Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-10T00:08:30Z</time></trkpt>
+<trkpt lat="45.964399" lon="-66.641753">
+<ele>8</ele>
+<time>2026-02-10T00:08:44Z</time></trkpt>
+<trkpt lat="45.965254" lon="-66.642927">
+<ele>7</ele>
+<time>2026-02-10T00:09:31Z</time></trkpt>
+<trkpt lat="45.965528" lon="-66.643281">
+<ele>6</ele>
+<time>2026-02-10T00:09:46Z</time></trkpt>
+<trkpt lat="45.965639" lon="-66.643394">
+<ele>6</ele>
+<time>2026-02-10T00:09:51Z</time></trkpt>
+<trkpt lat="45.965748" lon="-66.643484">
+<ele>4</ele>
+<time>2026-02-10T00:09:56Z</time></trkpt>
+<trkpt lat="45.965873" lon="-66.643545">
+<ele>3</ele>
+<time>2026-02-10T00:10:02Z</time></trkpt>
+<trkpt lat="45.966106" lon="-66.643575">
+<ele>3</ele>
+<time>2026-02-10T00:10:11Z</time></trkpt>
+<trkpt lat="45.966613" lon="-66.643482">
+<ele>3</ele>
+<time>2026-02-10T00:10:32Z</time></trkpt>
+<trkpt lat="45.966872" lon="-66.643476">
+<ele>3</ele>
+<time>2026-02-10T00:10:42Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-10T00:10:43Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-10T00:10:43Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-10T00:11:54Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-10T00:11:54Z</time></trkpt>
+<trkpt lat="45.971269" lon="-66.641336">
+<ele>6</ele>
+<time>2026-02-10T00:13:48Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-10T00:14:02Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-10T00:14:02Z</time></trkpt>
+<trkpt lat="45.971679" lon="-66.640971">
+<ele>7</ele>
+<time>2026-02-10T00:14:07Z</time></trkpt>
+<trkpt lat="45.971842" lon="-66.640842">
+<ele>8</ele>
+<time>2026-02-10T00:14:15Z</time></trkpt>
+<trkpt lat="45.97315" lon="-66.639854">
+<ele>10</ele>
+<time>2026-02-10T00:15:14Z</time></trkpt>
+<trkpt lat="45.97324" lon="-66.639695">
+<ele>10</ele>
+<time>2026-02-10T00:15:20Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-10T00:15:22Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-10T00:15:22Z</time></trkpt>
+<trkpt lat="45.973279" lon="-66.639509">
+<ele>10</ele>
+<time>2026-02-10T00:15:25Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-10T00:15:46Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-10T00:15:46Z</time></trkpt>
+<trkpt lat="45.973069" lon="-66.638821">
+<ele>10</ele>
+<time>2026-02-10T00:15:47Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-02-10T00:17:11Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-02-10T00:17:19Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-02-10T00:17:56Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-02-10T00:17:56Z</time></trkpt>
+<trkpt lat="45.975824" lon="-66.644429">
+<ele>15</ele>
+<time>2026-02-10T00:19:29Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-02-10T00:20:37Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-02-10T00:20:37Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-02-10T00:23:51Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-02-10T00:23:51Z</time></trkpt>
+<trkpt lat="45.978997" lon="-66.653873">
+<ele>18</ele>
+<time>2026-02-10T00:24:22Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-02-10T00:24:29Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-02-10T00:24:29Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-02-10T00:24:47Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-02-10T00:24:47Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.979219" lon="-66.654489">
+<ele>18</ele>
+<time>2026-02-10T00:27:05Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-02-10T00:27:54Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-02-10T00:27:54Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-02-10T00:31:08Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-02-10T00:31:08Z</time></trkpt>
+<trkpt lat="45.975454" lon="-66.64332">
+<ele>15</ele>
+<time>2026-02-10T00:32:50Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-02-10T00:33:48Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-02-10T00:33:48Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-02-10T00:34:27Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-02-10T00:34:34Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T00:35:27Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T00:35:27Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:35:28Z</time></trkpt>
+<trkpt lat="45.9737509" lon="-66.6382492">
+<ele>11</ele>
+<time>2026-02-10T00:35:28Z</time></trkpt>
+<trkpt lat="45.9735813" lon="-66.6377503">
+<ele>11</ele>
+<time>2026-02-10T00:35:43Z</time></trkpt>
+<trkpt lat="45.9729717" lon="-66.6359103">
+<ele>10</ele>
+<time>2026-02-10T00:36:40Z</time></trkpt>
+<trkpt lat="45.9727555" lon="-66.6352236">
+<ele>12</ele>
+<time>2026-02-10T00:37:01Z</time></trkpt>
+<trkpt lat="45.9725244" lon="-66.6346014">
+<ele>15</ele>
+<time>2026-02-10T00:37:21Z</time></trkpt>
+<trkpt lat="45.9723976" lon="-66.6342688">
+<ele>16</ele>
+<time>2026-02-10T00:37:31Z</time></trkpt>
+<trkpt lat="45.9722634" lon="-66.6339362">
+<ele>16</ele>
+<time>2026-02-10T00:37:42Z</time></trkpt>
+<trkpt lat="45.9720919" lon="-66.6335714">
+<ele>16</ele>
+<time>2026-02-10T00:37:54Z</time></trkpt>
+<trkpt lat="45.9719129" lon="-66.6331744">
+<ele>15</ele>
+<time>2026-02-10T00:38:07Z</time></trkpt>
+<trkpt lat="45.9716818" lon="-66.6327238">
+<ele>14</ele>
+<time>2026-02-10T00:38:23Z</time></trkpt>
+<trkpt lat="45.9714208" lon="-66.6323483">
+<ele>14</ele>
+<time>2026-02-10T00:38:38Z</time></trkpt>
+<trkpt lat="45.9712354" lon="-66.6320807">
+<ele>14</ele>
+<time>2026-02-10T00:38:48Z</time></trkpt>
+<trkpt lat="45.9710181" lon="-66.6317689">
+<ele>14</ele>
+<time>2026-02-10T00:39:00Z</time></trkpt>
+<trkpt lat="45.9707571" lon="-66.6315114">
+<ele>13</ele>
+<time>2026-02-10T00:39:13Z</time></trkpt>
+<trkpt lat="45.9705632" lon="-66.6312754">
+<ele>13</ele>
+<time>2026-02-10T00:39:23Z</time></trkpt>
+<trkpt lat="45.9702724" lon="-66.6308463">
+<ele>12</ele>
+<time>2026-02-10T00:39:40Z</time></trkpt>
+<trkpt lat="45.9700785" lon="-66.6305244">
+<ele>12</ele>
+<time>2026-02-10T00:39:52Z</time></trkpt>
+<trkpt lat="45.9697877" lon="-66.6301167">
+<ele>11</ele>
+<time>2026-02-10T00:40:08Z</time></trkpt>
+<trkpt lat="45.9692881" lon="-66.629473">
+<ele>10</ele>
+<time>2026-02-10T00:40:35Z</time></trkpt>
+<trkpt lat="45.9685574" lon="-66.6285373">
+<ele>11</ele>
+<time>2026-02-10T00:41:14Z</time></trkpt>
+<trkpt lat="45.9675431" lon="-66.6272092">
+<ele>12</ele>
+<time>2026-02-10T00:42:09Z</time></trkpt>
+<trkpt lat="45.9664096" lon="-66.6257286">
+<ele>12</ele>
+<time>2026-02-10T00:43:11Z</time></trkpt>
+<trkpt lat="45.9658727" lon="-66.6250634">
+<ele>13</ele>
+<time>2026-02-10T00:43:39Z</time></trkpt>
+<trkpt lat="45.9653954" lon="-66.6243339">
+<ele>14</ele>
+<time>2026-02-10T00:44:07Z</time></trkpt>
+<trkpt lat="45.9644259" lon="-66.6230249">
+<ele>13</ele>
+<time>2026-02-10T00:45:00Z</time></trkpt>
+<trkpt lat="45.9632327" lon="-66.6214371">
+<ele>12</ele>
+<time>2026-02-10T00:46:05Z</time></trkpt>
+<trkpt lat="45.9626062" lon="-66.6206002">
+<ele>12</ele>
+<time>2026-02-10T00:46:40Z</time></trkpt>
+<trkpt lat="45.9619201" lon="-66.6197419">
+<ele>14</ele>
+<time>2026-02-10T00:47:16Z</time></trkpt>
+<trkpt lat="45.9613682" lon="-66.6193771">
+<ele>13</ele>
+<time>2026-02-10T00:47:40Z</time></trkpt>
+<trkpt lat="45.9609058" lon="-66.6192484">
+<ele>12</ele>
+<time>2026-02-10T00:47:59Z</time></trkpt>
+<trkpt lat="45.9603837" lon="-66.6192484">
+<ele>11</ele>
+<time>2026-02-10T00:48:20Z</time></trkpt>
+<trkpt lat="45.9598915" lon="-66.6194201">
+<ele>10</ele>
+<time>2026-02-10T00:48:40Z</time></trkpt>
+<trkpt lat="45.9595782" lon="-66.6192698">
+<ele>10</ele>
+<time>2026-02-10T00:48:54Z</time></trkpt>
+<trkpt lat="45.95958" lon="-66.619267">
+<ele>10</ele>
+<time>2026-02-10T00:48:54Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-02-10T00:48:54Z</time></trkpt>
+<trkpt lat="45.95957" lon="-66.619267">
+<ele>10</ele>
+<time>2026-02-10T00:48:54Z</time></trkpt>
+<trkpt lat="45.9595734" lon="-66.6192701">
+<ele>10</ele>
+<time>2026-02-10T00:48:54Z</time></trkpt>
+<trkpt lat="45.9592053" lon="-66.6199726">
+<ele>9</ele>
+<time>2026-02-10T00:49:19Z</time></trkpt>
+<trkpt lat="45.9589182" lon="-66.6204447">
+<ele>10</ele>
+<time>2026-02-10T00:49:36Z</time></trkpt>
+<trkpt lat="45.9588771" lon="-66.6204983">
+<ele>10</ele>
+<time>2026-02-10T00:49:39Z</time></trkpt>
+<trkpt lat="45.95881" lon="-66.6206163">
+<ele>10</ele>
+<time>2026-02-10T00:49:43Z</time></trkpt>
+<trkpt lat="45.958728" lon="-66.6208094">
+<ele>9</ele>
+<time>2026-02-10T00:49:49Z</time></trkpt>
+<trkpt lat="45.9585042" lon="-66.6213566">
+<ele>10</ele>
+<time>2026-02-10T00:50:07Z</time></trkpt>
+<trkpt lat="45.9584446" lon="-66.6215658">
+<ele>10</ele>
+<time>2026-02-10T00:50:13Z</time></trkpt>
+<trkpt lat="45.9583401" lon="-66.6220111">
+<ele>10</ele>
+<time>2026-02-10T00:50:26Z</time></trkpt>
+<trkpt lat="45.9580642" lon="-66.6235507">
+<ele>7</ele>
+<time>2026-02-10T00:51:11Z</time></trkpt>
+<trkpt lat="45.957806" lon="-66.6251547">
+<ele>3</ele>
+<time>2026-02-10T00:51:56Z</time></trkpt>
+<trkpt lat="45.9573966" lon="-66.6274559">
+<ele>2</ele>
+<time>2026-02-10T00:53:03Z</time></trkpt>
+<trkpt lat="45.9564308" lon="-66.6329193">
+<ele>8</ele>
+<time>2026-02-10T00:55:40Z</time></trkpt>
+<trkpt lat="45.9562927" lon="-66.6336787">
+<ele>8</ele>
+<time>2026-02-10T00:56:02Z</time></trkpt>
+<trkpt lat="45.9561622" lon="-66.6343224">
+<ele>9</ele>
+<time>2026-02-10T00:56:20Z</time></trkpt>
+<trkpt lat="45.9560914" lon="-66.6345102">
+<ele>9</ele>
+<time>2026-02-10T00:56:26Z</time></trkpt>
+<trkpt lat="45.9559981" lon="-66.6347516">
+<ele>10</ele>
+<time>2026-02-10T00:56:34Z</time></trkpt>
+<trkpt lat="45.9558788" lon="-66.6349822">
+<ele>10</ele>
+<time>2026-02-10T00:56:42Z</time></trkpt>
+<trkpt lat="45.9558042" lon="-66.63517">
+<ele>10</ele>
+<time>2026-02-10T00:56:48Z</time></trkpt>
+<trkpt lat="45.9557557" lon="-66.635288">
+<ele>10</ele>
+<time>2026-02-10T00:56:52Z</time></trkpt>
+<trkpt lat="45.9556662" lon="-66.635406">
+<ele>10</ele>
+<time>2026-02-10T00:56:57Z</time></trkpt>
+<trkpt lat="45.9553716" lon="-66.6357011">
+<ele>10</ele>
+<time>2026-02-10T00:57:11Z</time></trkpt>
+<trkpt lat="45.9550956" lon="-66.6359586">
+<ele>10</ele>
+<time>2026-02-10T00:57:24Z</time></trkpt>
+<trkpt lat="45.9547711" lon="-66.6362321">
+<ele>10</ele>
+<time>2026-02-10T00:57:39Z</time></trkpt>
+<trkpt lat="45.9530784" lon="-66.6376535">
+<ele>8</ele>
+<time>2026-02-10T00:58:58Z</time></trkpt>
+<trkpt lat="45.9530928" lon="-66.6378307">
+<ele>8</ele>
+<time>2026-02-10T00:59:03Z</time></trkpt>
+<trkpt lat="45.9536224" lon="-66.6391021">
+<ele>9</ele>
+<time>2026-02-10T00:59:44Z</time></trkpt>
+<trkpt lat="45.9539395" lon="-66.6399014">
+<ele>9</ele>
+<time>2026-02-10T01:00:10Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/00_full.gpx
+++ b/cursor/plotaroute/00_full.gpx
@@ -1,0 +1,2653 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.954489" lon="-66.641395">
+<time>2026-02-10T00:00:00Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Saint John Street</cmt>
+<desc>Start on Rue Saint John Street</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954492" lon="-66.6414">
+<time>2026-02-10T00:00:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-10T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rang Churchill Row</cmt>
+<desc>Turn right onto Rang Churchill Row</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-10T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956374" lon="-66.639758">
+<time>2026-02-10T00:01:29Z</time>
+<name>At roundab</name>
+<cmt>At roundabout, take exit 2 onto Rue Saint John Street</cmt>
+<desc>At roundabout, take exit 2 onto Rue Saint John Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-10T00:01:35Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-10T00:01:35Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-10T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Brunswick Street</cmt>
+<desc>Turn right onto Rue Brunswick Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-10T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-10T00:03:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue King Street</cmt>
+<desc>Turn right onto Rue King Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-10T00:03:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-10T00:04:28Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-10T00:04:29Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Queen Street</cmt>
+<desc>Turn left onto Rue Queen Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.96099" lon="-66.638372">
+<time>2026-02-10T00:05:33Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.961255" lon="-66.638537">
+<time>2026-02-10T00:05:45Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</cmt>
+<desc>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.964051" lon="-66.641227">
+<time>2026-02-10T00:08:24Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966872" lon="-66.643476">
+<time>2026-02-10T00:10:42Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Westmorland Street Bridge</cmt>
+<desc>Turn slight right onto Westmorland Street Bridge</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971269" lon="-66.641336">
+<time>2026-02-10T00:13:48Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971842" lon="-66.640842">
+<time>2026-02-10T00:14:15Z</time>
+<name>Keep left</name>
+<cmt>Keep left</cmt>
+<desc>Keep left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973279" lon="-66.639509">
+<time>2026-02-10T00:15:25Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Rue Union Street</cmt>
+<desc>Turn slight right onto Rue Union Street</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973069" lon="-66.638821">
+<time>2026-02-10T00:15:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Friel Street</cmt>
+<desc>Turn right onto Rue Friel Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973747" lon="-66.638243">
+<time>2026-02-10T00:16:18Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Northside Trail</cmt>
+<desc>Turn left onto Northside Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973749" lon="-66.63825">
+<time>2026-02-10T00:16:18Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Friel Street</cmt>
+<desc>Start on Rue Friel Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.977804" lon="-66.723732">
+<time>2026-02-10T00:59:20Z</time>
+<name>Make a U-t</name>
+<cmt>Make a U-turn onto Northside Trail</cmt>
+<desc>Make a U-turn onto Northside Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978723" lon="-66.69264">
+<time>2026-02-10T01:13:49Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Northside Trail</cmt>
+<desc>Keep left onto Northside Trail</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978782" lon="-66.692065">
+<time>2026-02-10T01:14:09Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Northside Trail</cmt>
+<desc>Keep left onto Northside Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.980194" lon="-66.656652">
+<time>2026-02-10T01:32:47Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-02-10T02:05:54Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9536" lon="-66.639076">
+<time>2026-02-10T02:06:39Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Church Street</cmt>
+<desc>Turn right onto Rue Church Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9536" lon="-66.639076">
+<time>2026-02-10T02:06:40Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Aberdeen Street</cmt>
+<desc>Turn right onto Rue Aberdeen Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954559" lon="-66.641341">
+<time>2026-02-10T02:07:54Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953262" lon="-66.642474">
+<time>2026-02-10T02:08:55Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Avenue McLeod Avenue</cmt>
+<desc>Turn left onto Avenue McLeod Avenue</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.952078" lon="-66.640406">
+<time>2026-02-10T02:10:11Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.952065" lon="-66.640308">
+<time>2026-02-10T02:10:14Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951885" lon="-66.640411">
+<time>2026-02-10T02:10:22Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951918" lon="-66.640503">
+<time>2026-02-10T02:10:25Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Avenue McLeod Avenue</cmt>
+<desc>Turn left onto Avenue McLeod Avenue</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95163" lon="-66.640884">
+<time>2026-02-10T02:10:41Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951567" lon="-66.640825">
+<time>2026-02-10T02:10:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951476" lon="-66.641114">
+<time>2026-02-10T02:10:52Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950944" lon="-66.64109">
+<time>2026-02-10T02:11:14Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right onto Crosstown Trail</cmt>
+<desc>Turn sharp right onto Crosstown Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95021" lon="-66.640061">
+<time>2026-02-10T02:12:06Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Crosstown Trail</cmt>
+<desc>Turn left onto Crosstown Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95024" lon="-66.639638">
+<time>2026-02-10T02:12:18Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Lincoln Trail</cmt>
+<desc>Turn right onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951746" lon="-66.638803">
+<time>2026-02-10T02:13:25Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951746" lon="-66.638803">
+<time>2026-02-10T02:13:25Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Lincoln Trail</cmt>
+<desc>Turn right onto Lincoln Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958962" lon="-66.62037">
+<time>2026-02-10T02:23:52Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958961" lon="-66.620292">
+<time>2026-02-10T02:23:54Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Gibson Trail</cmt>
+<desc>Turn slight right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95894" lon="-66.620251">
+<time>2026-02-10T02:23:55Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958898" lon="-66.620214">
+<time>2026-02-10T02:23:57Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Gibson Trail</cmt>
+<desc>Turn sharp left onto Gibson Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958909" lon="-66.620208">
+<time>2026-02-10T02:23:58Z</time>
+<name>Start on G</name>
+<cmt>Start on Gibson Trail</cmt>
+<desc>Start on Gibson Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-02-10T02:27:41Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-02-10T02:27:42Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Sentier Gibson Trail</cmt>
+<desc>Turn left onto Sentier Gibson Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950003" lon="-66.614738">
+<time>2026-02-10T02:30:31Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Gibson Trail</cmt>
+<desc>Keep left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.949942" lon="-66.614185">
+<time>2026-02-10T02:30:48Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Gibson Trail</cmt>
+<desc>Turn left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-02-10T02:31:50Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-02-10T02:31:51Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-02-10T02:32:43Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-02-10T02:32:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.976297" lon="-66.589324">
+<time>2026-02-10T02:55:46Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue McGloin Street</cmt>
+<desc>Turn left onto Rue McGloin Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978815" lon="-66.589547">
+<time>2026-02-10T02:57:29Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978811" lon="-66.589684">
+<time>2026-02-10T02:57:33Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-02-10T02:58:36Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="46.003025" lon="-66.57611">
+<time>2026-02-10T03:19:03Z</time>
+<name>Make a U-t</name>
+<cmt>Make a U-turn onto Nashwaak Trail</cmt>
+<desc>Make a U-turn onto Nashwaak Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-02-10T03:39:29Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.97879" lon="-66.591898">
+<time>2026-02-10T03:39:29Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-02-10T03:39:29Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.975623" lon="-66.592254">
+<time>2026-02-10T03:41:40Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966115" lon="-66.603295">
+<time>2026-02-10T03:50:42Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-02-10T04:09:38Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953944" lon="-66.639888">
+<time>2026-02-10T04:10:50Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953933" lon="-66.639899">
+<time>2026-02-10T04:10:51Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>00_full</name>
+<trkseg>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.954492" lon="-66.6414">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639772">
+<ele>13</ele>
+<time>2026-02-10T00:01:28Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639771">
+<ele>13</ele>
+<time>2026-02-10T00:01:28Z</time></trkpt>
+<trkpt lat="45.956374" lon="-66.639758">
+<ele>13</ele>
+<time>2026-02-10T00:01:29Z</time></trkpt>
+<trkpt lat="45.956371" lon="-66.639719">
+<ele>13</ele>
+<time>2026-02-10T00:01:30Z</time></trkpt>
+<trkpt lat="45.956394" lon="-66.639674">
+<ele>13</ele>
+<time>2026-02-10T00:01:31Z</time></trkpt>
+<trkpt lat="45.956428" lon="-66.639667">
+<ele>13</ele>
+<time>2026-02-10T00:01:33Z</time></trkpt>
+<trkpt lat="45.956454" lon="-66.639689">
+<ele>13</ele>
+<time>2026-02-10T00:01:34Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-10T00:02:16Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-10T00:02:16Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-10T00:03:45Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-10T00:04:29Z</time></trkpt>
+<trkpt lat="45.960461" lon="-66.637131">
+<ele>8</ele>
+<time>2026-02-10T00:04:52Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.96099" lon="-66.638372">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.961139" lon="-66.638502">
+<ele>9</ele>
+<time>2026-02-10T00:05:40Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-10T00:05:43Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-10T00:05:43Z</time></trkpt>
+<trkpt lat="45.961255" lon="-66.638537">
+<ele>9</ele>
+<time>2026-02-10T00:05:45Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-10T00:06:08Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-10T00:06:08Z</time></trkpt>
+<trkpt lat="45.961916" lon="-66.638033">
+<ele>8</ele>
+<time>2026-02-10T00:06:15Z</time></trkpt>
+<trkpt lat="45.962057" lon="-66.638009">
+<ele>8</ele>
+<time>2026-02-10T00:06:21Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-10T00:06:30Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-10T00:06:30Z</time></trkpt>
+<trkpt lat="45.962472" lon="-66.638212">
+<ele>7</ele>
+<time>2026-02-10T00:06:38Z</time></trkpt>
+<trkpt lat="45.96257" lon="-66.638353">
+<ele>7</ele>
+<time>2026-02-10T00:06:44Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-10T00:07:04Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-10T00:07:04Z</time></trkpt>
+<trkpt lat="45.964051" lon="-66.641227">
+<ele>8</ele>
+<time>2026-02-10T00:08:24Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-10T00:08:30Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-10T00:08:30Z</time></trkpt>
+<trkpt lat="45.964399" lon="-66.641753">
+<ele>8</ele>
+<time>2026-02-10T00:08:44Z</time></trkpt>
+<trkpt lat="45.965254" lon="-66.642927">
+<ele>7</ele>
+<time>2026-02-10T00:09:31Z</time></trkpt>
+<trkpt lat="45.965528" lon="-66.643281">
+<ele>6</ele>
+<time>2026-02-10T00:09:46Z</time></trkpt>
+<trkpt lat="45.965639" lon="-66.643394">
+<ele>6</ele>
+<time>2026-02-10T00:09:51Z</time></trkpt>
+<trkpt lat="45.965748" lon="-66.643484">
+<ele>4</ele>
+<time>2026-02-10T00:09:56Z</time></trkpt>
+<trkpt lat="45.965873" lon="-66.643545">
+<ele>3</ele>
+<time>2026-02-10T00:10:02Z</time></trkpt>
+<trkpt lat="45.966106" lon="-66.643575">
+<ele>3</ele>
+<time>2026-02-10T00:10:11Z</time></trkpt>
+<trkpt lat="45.966613" lon="-66.643482">
+<ele>3</ele>
+<time>2026-02-10T00:10:32Z</time></trkpt>
+<trkpt lat="45.966872" lon="-66.643476">
+<ele>3</ele>
+<time>2026-02-10T00:10:42Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-10T00:10:43Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-10T00:10:43Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-10T00:11:54Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-10T00:11:54Z</time></trkpt>
+<trkpt lat="45.971269" lon="-66.641336">
+<ele>6</ele>
+<time>2026-02-10T00:13:48Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-10T00:14:02Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-10T00:14:02Z</time></trkpt>
+<trkpt lat="45.971679" lon="-66.640971">
+<ele>7</ele>
+<time>2026-02-10T00:14:07Z</time></trkpt>
+<trkpt lat="45.971842" lon="-66.640842">
+<ele>8</ele>
+<time>2026-02-10T00:14:15Z</time></trkpt>
+<trkpt lat="45.97315" lon="-66.639854">
+<ele>10</ele>
+<time>2026-02-10T00:15:14Z</time></trkpt>
+<trkpt lat="45.97324" lon="-66.639695">
+<ele>10</ele>
+<time>2026-02-10T00:15:20Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-10T00:15:22Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-10T00:15:22Z</time></trkpt>
+<trkpt lat="45.973279" lon="-66.639509">
+<ele>10</ele>
+<time>2026-02-10T00:15:25Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-10T00:15:46Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-10T00:15:46Z</time></trkpt>
+<trkpt lat="45.973069" lon="-66.638821">
+<ele>10</ele>
+<time>2026-02-10T00:15:47Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-02-10T00:17:11Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-02-10T00:17:19Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-02-10T00:17:56Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-02-10T00:17:56Z</time></trkpt>
+<trkpt lat="45.975824" lon="-66.644429">
+<ele>15</ele>
+<time>2026-02-10T00:19:29Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-02-10T00:20:37Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-02-10T00:20:37Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-02-10T00:23:51Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-02-10T00:23:51Z</time></trkpt>
+<trkpt lat="45.978997" lon="-66.653873">
+<ele>18</ele>
+<time>2026-02-10T00:24:22Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-02-10T00:24:29Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-02-10T00:24:29Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-02-10T00:24:47Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-02-10T00:24:47Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-02-10T00:25:53Z</time></trkpt>
+<trkpt lat="45.980604" lon="-66.657551">
+<ele>11</ele>
+<time>2026-02-10T00:26:24Z</time></trkpt>
+<trkpt lat="45.980697" lon="-66.657702">
+<ele>12</ele>
+<time>2026-02-10T00:26:29Z</time></trkpt>
+<trkpt lat="45.98074" lon="-66.657895">
+<ele>12</ele>
+<time>2026-02-10T00:26:35Z</time></trkpt>
+<trkpt lat="45.98101" lon="-66.658415">
+<ele>13</ele>
+<time>2026-02-10T00:26:53Z</time></trkpt>
+<trkpt lat="45.982123" lon="-66.660807">
+<ele>18</ele>
+<time>2026-02-10T00:28:13Z</time></trkpt>
+<trkpt lat="45.982332" lon="-66.661179">
+<ele>18</ele>
+<time>2026-02-10T00:28:26Z</time></trkpt>
+<trkpt lat="45.982542" lon="-66.661474">
+<ele>18</ele>
+<time>2026-02-10T00:28:38Z</time></trkpt>
+<trkpt lat="45.982829" lon="-66.661806">
+<ele>17</ele>
+<time>2026-02-10T00:28:53Z</time></trkpt>
+<trkpt lat="45.98328" lon="-66.662203">
+<ele>16</ele>
+<time>2026-02-10T00:29:14Z</time></trkpt>
+<trkpt lat="45.9835" lon="-66.66236">
+<ele>16</ele>
+<time>2026-02-10T00:29:24Z</time></trkpt>
+<trkpt lat="45.984143" lon="-66.662745">
+<ele>16</ele>
+<time>2026-02-10T00:29:52Z</time></trkpt>
+<trkpt lat="45.984298" lon="-66.66288">
+<ele>15</ele>
+<time>2026-02-10T00:29:59Z</time></trkpt>
+<trkpt lat="45.98464" lon="-66.663258">
+<ele>14</ele>
+<time>2026-02-10T00:30:16Z</time></trkpt>
+<trkpt lat="45.984913" lon="-66.663744">
+<ele>12</ele>
+<time>2026-02-10T00:30:34Z</time></trkpt>
+<trkpt lat="45.985021" lon="-66.664005">
+<ele>12</ele>
+<time>2026-02-10T00:30:42Z</time></trkpt>
+<trkpt lat="45.98514" lon="-66.664376">
+<ele>12</ele>
+<time>2026-02-10T00:30:54Z</time></trkpt>
+<trkpt lat="45.985171" lon="-66.664557">
+<ele>11</ele>
+<time>2026-02-10T00:30:59Z</time></trkpt>
+<trkpt lat="45.985256" lon="-66.665378">
+<ele>9</ele>
+<time>2026-02-10T00:31:22Z</time></trkpt>
+<trkpt lat="45.985234" lon="-66.665874">
+<ele>7</ele>
+<time>2026-02-10T00:31:36Z</time></trkpt>
+<trkpt lat="45.985204" lon="-66.666054">
+<ele>8</ele>
+<time>2026-02-10T00:31:41Z</time></trkpt>
+<trkpt lat="45.981326" lon="-66.681447">
+<ele>12</ele>
+<time>2026-02-10T00:39:17Z</time></trkpt>
+<trkpt lat="45.979288" lon="-66.689529">
+<ele>17</ele>
+<time>2026-02-10T00:43:16Z</time></trkpt>
+<trkpt lat="45.979041" lon="-66.690623">
+<ele>16</ele>
+<time>2026-02-10T00:43:48Z</time></trkpt>
+<trkpt lat="45.978782" lon="-66.692065">
+<ele>10</ele>
+<time>2026-02-10T00:44:30Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.692608">
+<ele>10</ele>
+<time>2026-02-10T00:44:45Z</time></trkpt>
+<trkpt lat="45.978733" lon="-66.692631">
+<ele>10</ele>
+<time>2026-02-10T00:44:50Z</time></trkpt>
+<trkpt lat="45.978695" lon="-66.6927">
+<ele>10</ele>
+<time>2026-02-10T00:44:52Z</time></trkpt>
+<trkpt lat="45.978543" lon="-66.693878">
+<ele>11</ele>
+<time>2026-02-10T00:45:26Z</time></trkpt>
+<trkpt lat="45.978489" lon="-66.694513">
+<ele>12</ele>
+<time>2026-02-10T00:45:44Z</time></trkpt>
+<trkpt lat="45.978412" lon="-66.69597">
+<ele>12</ele>
+<time>2026-02-10T00:46:24Z</time></trkpt>
+<trkpt lat="45.978396" lon="-66.696948">
+<ele>13</ele>
+<time>2026-02-10T00:46:52Z</time></trkpt>
+<trkpt lat="45.978403" lon="-66.699644">
+<ele>13</ele>
+<time>2026-02-10T00:48:07Z</time></trkpt>
+<trkpt lat="45.978433" lon="-66.700431">
+<ele>13</ele>
+<time>2026-02-10T00:48:29Z</time></trkpt>
+<trkpt lat="45.978423" lon="-66.701015">
+<ele>13</ele>
+<time>2026-02-10T00:48:45Z</time></trkpt>
+<trkpt lat="45.978021" lon="-66.707083">
+<ele>21</ele>
+<time>2026-02-10T00:51:35Z</time></trkpt>
+<trkpt lat="45.977706" lon="-66.71324">
+<ele>14</ele>
+<time>2026-02-10T00:54:27Z</time></trkpt>
+<trkpt lat="45.977504" lon="-66.716414">
+<ele>17</ele>
+<time>2026-02-10T00:55:55Z</time></trkpt>
+<trkpt lat="45.977494" lon="-66.717682">
+<ele>16</ele>
+<time>2026-02-10T00:56:31Z</time></trkpt>
+<trkpt lat="45.977569" lon="-66.719148">
+<ele>15</ele>
+<time>2026-02-10T00:57:12Z</time></trkpt>
+<trkpt lat="45.977804" lon="-66.723732">
+<ele>17</ele>
+<time>2026-02-10T00:59:20Z</time></trkpt>
+<trkpt lat="45.977569" lon="-66.719148">
+<ele>15</ele>
+<time>2026-02-10T01:01:28Z</time></trkpt>
+<trkpt lat="45.977494" lon="-66.717682">
+<ele>16</ele>
+<time>2026-02-10T01:02:08Z</time></trkpt>
+<trkpt lat="45.977504" lon="-66.716414">
+<ele>17</ele>
+<time>2026-02-10T01:02:44Z</time></trkpt>
+<trkpt lat="45.977706" lon="-66.71324">
+<ele>14</ele>
+<time>2026-02-10T01:04:13Z</time></trkpt>
+<trkpt lat="45.978021" lon="-66.707083">
+<ele>21</ele>
+<time>2026-02-10T01:07:05Z</time></trkpt>
+<trkpt lat="45.978423" lon="-66.701015">
+<ele>13</ele>
+<time>2026-02-10T01:09:54Z</time></trkpt>
+<trkpt lat="45.978433" lon="-66.700431">
+<ele>13</ele>
+<time>2026-02-10T01:10:11Z</time></trkpt>
+<trkpt lat="45.978403" lon="-66.699644">
+<ele>13</ele>
+<time>2026-02-10T01:10:32Z</time></trkpt>
+<trkpt lat="45.978396" lon="-66.696948">
+<ele>13</ele>
+<time>2026-02-10T01:11:48Z</time></trkpt>
+<trkpt lat="45.978412" lon="-66.69597">
+<ele>12</ele>
+<time>2026-02-10T01:12:15Z</time></trkpt>
+<trkpt lat="45.978489" lon="-66.694513">
+<ele>12</ele>
+<time>2026-02-10T01:12:56Z</time></trkpt>
+<trkpt lat="45.978543" lon="-66.693878">
+<ele>11</ele>
+<time>2026-02-10T01:13:13Z</time></trkpt>
+<trkpt lat="45.978644" lon="-66.693042">
+<ele>10</ele>
+<time>2026-02-10T01:13:37Z</time></trkpt>
+<trkpt lat="45.978695" lon="-66.6927">
+<ele>10</ele>
+<time>2026-02-10T01:13:47Z</time></trkpt>
+<trkpt lat="45.978723" lon="-66.69264">
+<ele>10</ele>
+<time>2026-02-10T01:13:49Z</time></trkpt>
+<trkpt lat="45.978733" lon="-66.692631">
+<ele>10</ele>
+<time>2026-02-10T01:13:49Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.692608">
+<ele>10</ele>
+<time>2026-02-10T01:13:54Z</time></trkpt>
+<trkpt lat="45.978782" lon="-66.692065">
+<ele>10</ele>
+<time>2026-02-10T01:14:09Z</time></trkpt>
+<trkpt lat="45.979041" lon="-66.690623">
+<ele>16</ele>
+<time>2026-02-10T01:14:51Z</time></trkpt>
+<trkpt lat="45.979288" lon="-66.689529">
+<ele>17</ele>
+<time>2026-02-10T01:15:23Z</time></trkpt>
+<trkpt lat="45.981326" lon="-66.681447">
+<ele>12</ele>
+<time>2026-02-10T01:19:22Z</time></trkpt>
+<trkpt lat="45.982487" lon="-66.676841">
+<ele>15</ele>
+<time>2026-02-10T01:21:39Z</time></trkpt>
+<trkpt lat="45.985204" lon="-66.666054">
+<ele>8</ele>
+<time>2026-02-10T01:26:58Z</time></trkpt>
+<trkpt lat="45.985234" lon="-66.665874">
+<ele>7</ele>
+<time>2026-02-10T01:27:03Z</time></trkpt>
+<trkpt lat="45.985256" lon="-66.665378">
+<ele>9</ele>
+<time>2026-02-10T01:27:17Z</time></trkpt>
+<trkpt lat="45.985171" lon="-66.664557">
+<ele>11</ele>
+<time>2026-02-10T01:27:40Z</time></trkpt>
+<trkpt lat="45.98514" lon="-66.664376">
+<ele>12</ele>
+<time>2026-02-10T01:27:46Z</time></trkpt>
+<trkpt lat="45.985021" lon="-66.664005">
+<ele>12</ele>
+<time>2026-02-10T01:27:57Z</time></trkpt>
+<trkpt lat="45.984855" lon="-66.66363">
+<ele>12</ele>
+<time>2026-02-10T01:28:09Z</time></trkpt>
+<trkpt lat="45.98464" lon="-66.663258">
+<ele>14</ele>
+<time>2026-02-10T01:28:23Z</time></trkpt>
+<trkpt lat="45.984298" lon="-66.66288">
+<ele>15</ele>
+<time>2026-02-10T01:28:40Z</time></trkpt>
+<trkpt lat="45.984143" lon="-66.662745">
+<ele>16</ele>
+<time>2026-02-10T01:28:47Z</time></trkpt>
+<trkpt lat="45.9835" lon="-66.66236">
+<ele>16</ele>
+<time>2026-02-10T01:29:15Z</time></trkpt>
+<trkpt lat="45.98328" lon="-66.662203">
+<ele>16</ele>
+<time>2026-02-10T01:29:25Z</time></trkpt>
+<trkpt lat="45.982829" lon="-66.661806">
+<ele>17</ele>
+<time>2026-02-10T01:29:46Z</time></trkpt>
+<trkpt lat="45.982542" lon="-66.661474">
+<ele>18</ele>
+<time>2026-02-10T01:30:01Z</time></trkpt>
+<trkpt lat="45.982332" lon="-66.661179">
+<ele>18</ele>
+<time>2026-02-10T01:30:13Z</time></trkpt>
+<trkpt lat="45.982123" lon="-66.660807">
+<ele>18</ele>
+<time>2026-02-10T01:30:26Z</time></trkpt>
+<trkpt lat="45.98101" lon="-66.658415">
+<ele>13</ele>
+<time>2026-02-10T01:31:46Z</time></trkpt>
+<trkpt lat="45.98074" lon="-66.657895">
+<ele>12</ele>
+<time>2026-02-10T01:32:04Z</time></trkpt>
+<trkpt lat="45.980697" lon="-66.657702">
+<ele>12</ele>
+<time>2026-02-10T01:32:10Z</time></trkpt>
+<trkpt lat="45.980604" lon="-66.657551">
+<ele>11</ele>
+<time>2026-02-10T01:32:16Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-02-10T01:32:46Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-02-10T01:32:46Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-02-10T01:32:47Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-02-10T01:32:47Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-02-10T01:32:47Z</time></trkpt>
+<trkpt lat="45.979219" lon="-66.654489">
+<ele>18</ele>
+<time>2026-02-10T01:33:59Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-02-10T01:34:48Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-02-10T01:34:48Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-02-10T01:38:02Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-02-10T01:38:02Z</time></trkpt>
+<trkpt lat="45.975454" lon="-66.64332">
+<ele>15</ele>
+<time>2026-02-10T01:39:44Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-02-10T01:40:42Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-02-10T01:40:42Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-02-10T01:41:21Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-02-10T01:41:28Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T01:42:21Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T01:42:21Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T01:42:22Z</time></trkpt>
+<trkpt lat="45.9737509" lon="-66.6382492">
+<ele>11</ele>
+<time>2026-02-10T01:42:22Z</time></trkpt>
+<trkpt lat="45.9735813" lon="-66.6377503">
+<ele>11</ele>
+<time>2026-02-10T01:42:37Z</time></trkpt>
+<trkpt lat="45.9729717" lon="-66.6359103">
+<ele>10</ele>
+<time>2026-02-10T01:43:34Z</time></trkpt>
+<trkpt lat="45.9727555" lon="-66.6352236">
+<ele>12</ele>
+<time>2026-02-10T01:43:55Z</time></trkpt>
+<trkpt lat="45.9725244" lon="-66.6346014">
+<ele>15</ele>
+<time>2026-02-10T01:44:15Z</time></trkpt>
+<trkpt lat="45.9723976" lon="-66.6342688">
+<ele>16</ele>
+<time>2026-02-10T01:44:25Z</time></trkpt>
+<trkpt lat="45.9722634" lon="-66.6339362">
+<ele>16</ele>
+<time>2026-02-10T01:44:36Z</time></trkpt>
+<trkpt lat="45.9720919" lon="-66.6335714">
+<ele>16</ele>
+<time>2026-02-10T01:44:48Z</time></trkpt>
+<trkpt lat="45.9719129" lon="-66.6331744">
+<ele>15</ele>
+<time>2026-02-10T01:45:01Z</time></trkpt>
+<trkpt lat="45.9716818" lon="-66.6327238">
+<ele>14</ele>
+<time>2026-02-10T01:45:17Z</time></trkpt>
+<trkpt lat="45.9714208" lon="-66.6323483">
+<ele>14</ele>
+<time>2026-02-10T01:45:32Z</time></trkpt>
+<trkpt lat="45.9712354" lon="-66.6320807">
+<ele>14</ele>
+<time>2026-02-10T01:45:42Z</time></trkpt>
+<trkpt lat="45.9710181" lon="-66.6317689">
+<ele>14</ele>
+<time>2026-02-10T01:45:54Z</time></trkpt>
+<trkpt lat="45.9707571" lon="-66.6315114">
+<ele>13</ele>
+<time>2026-02-10T01:46:07Z</time></trkpt>
+<trkpt lat="45.9705632" lon="-66.6312754">
+<ele>13</ele>
+<time>2026-02-10T01:46:17Z</time></trkpt>
+<trkpt lat="45.9702724" lon="-66.6308463">
+<ele>12</ele>
+<time>2026-02-10T01:46:34Z</time></trkpt>
+<trkpt lat="45.9700785" lon="-66.6305244">
+<ele>12</ele>
+<time>2026-02-10T01:46:46Z</time></trkpt>
+<trkpt lat="45.9697877" lon="-66.6301167">
+<ele>11</ele>
+<time>2026-02-10T01:47:02Z</time></trkpt>
+<trkpt lat="45.9692881" lon="-66.629473">
+<ele>10</ele>
+<time>2026-02-10T01:47:29Z</time></trkpt>
+<trkpt lat="45.9685574" lon="-66.6285373">
+<ele>11</ele>
+<time>2026-02-10T01:48:08Z</time></trkpt>
+<trkpt lat="45.9675431" lon="-66.6272092">
+<ele>12</ele>
+<time>2026-02-10T01:49:03Z</time></trkpt>
+<trkpt lat="45.9664096" lon="-66.6257286">
+<ele>12</ele>
+<time>2026-02-10T01:50:05Z</time></trkpt>
+<trkpt lat="45.9658727" lon="-66.6250634">
+<ele>13</ele>
+<time>2026-02-10T01:50:33Z</time></trkpt>
+<trkpt lat="45.9653954" lon="-66.6243339">
+<ele>14</ele>
+<time>2026-02-10T01:51:01Z</time></trkpt>
+<trkpt lat="45.9644259" lon="-66.6230249">
+<ele>13</ele>
+<time>2026-02-10T01:51:54Z</time></trkpt>
+<trkpt lat="45.9632327" lon="-66.6214371">
+<ele>12</ele>
+<time>2026-02-10T01:52:59Z</time></trkpt>
+<trkpt lat="45.9626062" lon="-66.6206002">
+<ele>12</ele>
+<time>2026-02-10T01:53:34Z</time></trkpt>
+<trkpt lat="45.9619201" lon="-66.6197419">
+<ele>14</ele>
+<time>2026-02-10T01:54:10Z</time></trkpt>
+<trkpt lat="45.9613682" lon="-66.6193771">
+<ele>13</ele>
+<time>2026-02-10T01:54:34Z</time></trkpt>
+<trkpt lat="45.9609058" lon="-66.6192484">
+<ele>12</ele>
+<time>2026-02-10T01:54:53Z</time></trkpt>
+<trkpt lat="45.9603837" lon="-66.6192484">
+<ele>11</ele>
+<time>2026-02-10T01:55:14Z</time></trkpt>
+<trkpt lat="45.9598915" lon="-66.6194201">
+<ele>10</ele>
+<time>2026-02-10T01:55:34Z</time></trkpt>
+<trkpt lat="45.9595782" lon="-66.6192698">
+<ele>10</ele>
+<time>2026-02-10T01:55:48Z</time></trkpt>
+<trkpt lat="45.95958" lon="-66.619267">
+<ele>10</ele>
+<time>2026-02-10T01:55:48Z</time></trkpt>
+<trkpt lat="45.959588" lon="-66.619275">
+<ele>10</ele>
+<time>2026-02-10T01:55:48Z</time></trkpt>
+<trkpt lat="45.9595809" lon="-66.6192893">
+<ele>10</ele>
+<time>2026-02-10T01:55:49Z</time></trkpt>
+<trkpt lat="45.9589879" lon="-66.6203308">
+<ele>10</ele>
+<time>2026-02-10T01:56:26Z</time></trkpt>
+<trkpt lat="45.9584583" lon="-66.6215003">
+<ele>10</ele>
+<time>2026-02-10T01:57:05Z</time></trkpt>
+<trkpt lat="45.9580854" lon="-66.6235068">
+<ele>7</ele>
+<time>2026-02-10T01:58:03Z</time></trkpt>
+<trkpt lat="45.9574365" lon="-66.6271979">
+<ele>2</ele>
+<time>2026-02-10T01:59:49Z</time></trkpt>
+<trkpt lat="45.9564882" lon="-66.6325076">
+<ele>5</ele>
+<time>2026-02-10T02:02:22Z</time></trkpt>
+<trkpt lat="45.9562495" lon="-66.6339015">
+<ele>9</ele>
+<time>2026-02-10T02:03:02Z</time></trkpt>
+<trkpt lat="45.956247" lon="-66.6339">
+<ele>9</ele>
+<time>2026-02-10T02:03:02Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-02-10T02:03:14Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-02-10T02:03:21Z</time></trkpt>
+<trkpt lat="45.955902" lon="-66.634947">
+<ele>10</ele>
+<time>2026-02-10T02:03:34Z</time></trkpt>
+<trkpt lat="45.955902" lon="-66.634947">
+<ele>10</ele>
+<time>2026-02-10T02:03:34Z</time></trkpt>
+<trkpt lat="45.955809" lon="-66.635139">
+<ele>10</ele>
+<time>2026-02-10T02:03:41Z</time></trkpt>
+<trkpt lat="45.955809" lon="-66.635139">
+<ele>10</ele>
+<time>2026-02-10T02:03:41Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-02-10T02:03:46Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-02-10T02:03:50Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-02-10T02:03:50Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-02-10T02:04:08Z</time></trkpt>
+<trkpt lat="45.9549" lon="-66.636123">
+<ele>10</ele>
+<time>2026-02-10T02:04:27Z</time></trkpt>
+<trkpt lat="45.9549" lon="-66.636123">
+<ele>10</ele>
+<time>2026-02-10T02:04:27Z</time></trkpt>
+<trkpt lat="45.953965" lon="-66.636905">
+<ele>9</ele>
+<time>2026-02-10T02:05:10Z</time></trkpt>
+<trkpt lat="45.953965" lon="-66.636905">
+<ele>9</ele>
+<time>2026-02-10T02:05:10Z</time></trkpt>
+<trkpt lat="45.953053" lon="-66.637674">
+<ele>8</ele>
+<time>2026-02-10T02:05:53Z</time></trkpt>
+<trkpt lat="45.953053" lon="-66.637674">
+<ele>8</ele>
+<time>2026-02-10T02:05:53Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-02-10T02:05:54Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-02-10T02:05:59Z</time></trkpt>
+<trkpt lat="45.9536" lon="-66.639076">
+<ele>9</ele>
+<time>2026-02-10T02:06:39Z</time></trkpt>
+<trkpt lat="45.953614" lon="-66.639064">
+<ele>9</ele>
+<time>2026-02-10T02:06:40Z</time></trkpt>
+<trkpt lat="45.953614" lon="-66.639064">
+<ele>9</ele>
+<time>2026-02-10T02:06:40Z</time></trkpt>
+<trkpt lat="45.9536" lon="-66.639076">
+<ele>9</ele>
+<time>2026-02-10T02:06:40Z</time></trkpt>
+<trkpt lat="45.954552" lon="-66.641325">
+<ele>10</ele>
+<time>2026-02-10T02:07:54Z</time></trkpt>
+<trkpt lat="45.954552" lon="-66.641325">
+<ele>10</ele>
+<time>2026-02-10T02:07:54Z</time></trkpt>
+<trkpt lat="45.954559" lon="-66.641341">
+<ele>10</ele>
+<time>2026-02-10T02:07:54Z</time></trkpt>
+<trkpt lat="45.953274" lon="-66.642464">
+<ele>9</ele>
+<time>2026-02-10T02:08:54Z</time></trkpt>
+<trkpt lat="45.953274" lon="-66.642464">
+<ele>9</ele>
+<time>2026-02-10T02:08:54Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.642474">
+<ele>9</ele>
+<time>2026-02-10T02:08:55Z</time></trkpt>
+<trkpt lat="45.95313" lon="-66.642248">
+<ele>8</ele>
+<time>2026-02-10T02:09:03Z</time></trkpt>
+<trkpt lat="45.952945" lon="-66.642015">
+<ele>8</ele>
+<time>2026-02-10T02:09:13Z</time></trkpt>
+<trkpt lat="45.952945" lon="-66.642015">
+<ele>8</ele>
+<time>2026-02-10T02:09:13Z</time></trkpt>
+<trkpt lat="45.952837" lon="-66.641845">
+<ele>7</ele>
+<time>2026-02-10T02:09:19Z</time></trkpt>
+<trkpt lat="45.952607" lon="-66.641307">
+<ele>8</ele>
+<time>2026-02-10T02:09:37Z</time></trkpt>
+<trkpt lat="45.952607" lon="-66.641307">
+<ele>8</ele>
+<time>2026-02-10T02:09:37Z</time></trkpt>
+<trkpt lat="45.952272" lon="-66.640526">
+<ele>9</ele>
+<time>2026-02-10T02:10:03Z</time></trkpt>
+<trkpt lat="45.952272" lon="-66.640526">
+<ele>9</ele>
+<time>2026-02-10T02:10:03Z</time></trkpt>
+<trkpt lat="45.952164" lon="-66.640423">
+<ele>9</ele>
+<time>2026-02-10T02:10:08Z</time></trkpt>
+<trkpt lat="45.952078" lon="-66.640406">
+<ele>10</ele>
+<time>2026-02-10T02:10:11Z</time></trkpt>
+<trkpt lat="45.952065" lon="-66.640308">
+<ele>10</ele>
+<time>2026-02-10T02:10:14Z</time></trkpt>
+<trkpt lat="45.952016" lon="-66.640322">
+<ele>10</ele>
+<time>2026-02-10T02:10:16Z</time></trkpt>
+<trkpt lat="45.952016" lon="-66.640322">
+<ele>10</ele>
+<time>2026-02-10T02:10:16Z</time></trkpt>
+<trkpt lat="45.951885" lon="-66.640411">
+<ele>10</ele>
+<time>2026-02-10T02:10:22Z</time></trkpt>
+<trkpt lat="45.951918" lon="-66.640503">
+<ele>10</ele>
+<time>2026-02-10T02:10:25Z</time></trkpt>
+<trkpt lat="45.951799" lon="-66.640615">
+<ele>10</ele>
+<time>2026-02-10T02:10:30Z</time></trkpt>
+<trkpt lat="45.951752" lon="-66.640682">
+<ele>10</ele>
+<time>2026-02-10T02:10:33Z</time></trkpt>
+<trkpt lat="45.951752" lon="-66.640682">
+<ele>10</ele>
+<time>2026-02-10T02:10:33Z</time></trkpt>
+<trkpt lat="45.95166" lon="-66.640814">
+<ele>10</ele>
+<time>2026-02-10T02:10:38Z</time></trkpt>
+<trkpt lat="45.95163" lon="-66.640884">
+<ele>10</ele>
+<time>2026-02-10T02:10:41Z</time></trkpt>
+<trkpt lat="45.951567" lon="-66.640825">
+<ele>10</ele>
+<time>2026-02-10T02:10:44Z</time></trkpt>
+<trkpt lat="45.951482" lon="-66.641095">
+<ele>9</ele>
+<time>2026-02-10T02:10:52Z</time></trkpt>
+<trkpt lat="45.951482" lon="-66.641095">
+<ele>9</ele>
+<time>2026-02-10T02:10:52Z</time></trkpt>
+<trkpt lat="45.951476" lon="-66.641114">
+<ele>9</ele>
+<time>2026-02-10T02:10:52Z</time></trkpt>
+<trkpt lat="45.951308" lon="-66.641177">
+<ele>9</ele>
+<time>2026-02-10T02:10:59Z</time></trkpt>
+<trkpt lat="45.951308" lon="-66.641177">
+<ele>9</ele>
+<time>2026-02-10T02:10:59Z</time></trkpt>
+<trkpt lat="45.951244" lon="-66.64119">
+<ele>10</ele>
+<time>2026-02-10T02:11:02Z</time></trkpt>
+<trkpt lat="45.951091" lon="-66.641168">
+<ele>10</ele>
+<time>2026-02-10T02:11:08Z</time></trkpt>
+<trkpt lat="45.950944" lon="-66.64109">
+<ele>11</ele>
+<time>2026-02-10T02:11:14Z</time></trkpt>
+<trkpt lat="45.951036" lon="-66.64123">
+<ele>11</ele>
+<time>2026-02-10T02:11:20Z</time></trkpt>
+<trkpt lat="45.951036" lon="-66.64123">
+<ele>11</ele>
+<time>2026-02-10T02:11:20Z</time></trkpt>
+<trkpt lat="45.95021" lon="-66.640061">
+<ele>11</ele>
+<time>2026-02-10T02:12:06Z</time></trkpt>
+<trkpt lat="45.950211" lon="-66.64005">
+<ele>11</ele>
+<time>2026-02-10T02:12:07Z</time></trkpt>
+<trkpt lat="45.950211" lon="-66.64005">
+<ele>11</ele>
+<time>2026-02-10T02:12:07Z</time></trkpt>
+<trkpt lat="45.95024" lon="-66.639638">
+<ele>10</ele>
+<time>2026-02-10T02:12:18Z</time></trkpt>
+<trkpt lat="45.950231" lon="-66.639635">
+<ele>10</ele>
+<time>2026-02-10T02:12:18Z</time></trkpt>
+<trkpt lat="45.950231" lon="-66.639635">
+<ele>10</ele>
+<time>2026-02-10T02:12:18Z</time></trkpt>
+<trkpt lat="45.950589" lon="-66.639644">
+<ele>10</ele>
+<time>2026-02-10T02:12:33Z</time></trkpt>
+<trkpt lat="45.950737" lon="-66.639597">
+<ele>10</ele>
+<time>2026-02-10T02:12:39Z</time></trkpt>
+<trkpt lat="45.950737" lon="-66.639597">
+<ele>10</ele>
+<time>2026-02-10T02:12:39Z</time></trkpt>
+<trkpt lat="45.951004" lon="-66.639437">
+<ele>10</ele>
+<time>2026-02-10T02:12:50Z</time></trkpt>
+<trkpt lat="45.951181" lon="-66.639287">
+<ele>9</ele>
+<time>2026-02-10T02:12:59Z</time></trkpt>
+<trkpt lat="45.951181" lon="-66.639287">
+<ele>9</ele>
+<time>2026-02-10T02:12:59Z</time></trkpt>
+<trkpt lat="45.951746" lon="-66.638803">
+<ele>8</ele>
+<time>2026-02-10T02:13:25Z</time></trkpt>
+<trkpt lat="45.951743" lon="-66.6388">
+<ele>8</ele>
+<time>2026-02-10T02:13:25Z</time></trkpt>
+<trkpt lat="45.951743" lon="-66.6388">
+<ele>8</ele>
+<time>2026-02-10T02:13:25Z</time></trkpt>
+<trkpt lat="45.951746" lon="-66.638803">
+<ele>8</ele>
+<time>2026-02-10T02:13:25Z</time></trkpt>
+<trkpt lat="45.952965" lon="-66.637749">
+<ele>8</ele>
+<time>2026-02-10T02:14:22Z</time></trkpt>
+<trkpt lat="45.952965" lon="-66.637749">
+<ele>8</ele>
+<time>2026-02-10T02:14:22Z</time></trkpt>
+<trkpt lat="45.953973" lon="-66.636898">
+<ele>9</ele>
+<time>2026-02-10T02:15:09Z</time></trkpt>
+<trkpt lat="45.953973" lon="-66.636898">
+<ele>9</ele>
+<time>2026-02-10T02:15:09Z</time></trkpt>
+<trkpt lat="45.954912" lon="-66.636113">
+<ele>10</ele>
+<time>2026-02-10T02:15:53Z</time></trkpt>
+<trkpt lat="45.954912" lon="-66.636113">
+<ele>10</ele>
+<time>2026-02-10T02:15:53Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-02-10T02:16:12Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-02-10T02:16:29Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-02-10T02:16:33Z</time></trkpt>
+<trkpt lat="45.955794" lon="-66.63517">
+<ele>10</ele>
+<time>2026-02-10T02:16:37Z</time></trkpt>
+<trkpt lat="45.955794" lon="-66.63517">
+<ele>10</ele>
+<time>2026-02-10T02:16:37Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-02-10T02:16:58Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-02-10T02:17:05Z</time></trkpt>
+<trkpt lat="45.956304" lon="-66.633616">
+<ele>8</ele>
+<time>2026-02-10T02:17:26Z</time></trkpt>
+<trkpt lat="45.956304" lon="-66.633616">
+<ele>8</ele>
+<time>2026-02-10T02:17:26Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-02-10T02:17:48Z</time></trkpt>
+<trkpt lat="45.956497" lon="-66.632517">
+<ele>5</ele>
+<time>2026-02-10T02:17:57Z</time></trkpt>
+<trkpt lat="45.956497" lon="-66.632517">
+<ele>5</ele>
+<time>2026-02-10T02:17:57Z</time></trkpt>
+<trkpt lat="45.957091" lon="-66.629159">
+<ele>2</ele>
+<time>2026-02-10T02:19:34Z</time></trkpt>
+<trkpt lat="45.957091" lon="-66.629159">
+<ele>2</ele>
+<time>2026-02-10T02:19:34Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-02-10T02:21:29Z</time></trkpt>
+<trkpt lat="45.957852" lon="-66.624821">
+<ele>4</ele>
+<time>2026-02-10T02:21:38Z</time></trkpt>
+<trkpt lat="45.957852" lon="-66.624821">
+<ele>4</ele>
+<time>2026-02-10T02:21:38Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-02-10T02:21:46Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-02-10T02:21:50Z</time></trkpt>
+<trkpt lat="45.957941" lon="-66.624263">
+<ele>6</ele>
+<time>2026-02-10T02:21:54Z</time></trkpt>
+<trkpt lat="45.958013" lon="-66.623831">
+<ele>7</ele>
+<time>2026-02-10T02:22:07Z</time></trkpt>
+<trkpt lat="45.958013" lon="-66.623831">
+<ele>7</ele>
+<time>2026-02-10T02:22:07Z</time></trkpt>
+<trkpt lat="45.958301" lon="-66.622218">
+<ele>10</ele>
+<time>2026-02-10T02:22:53Z</time></trkpt>
+<trkpt lat="45.958328" lon="-66.622067">
+<ele>10</ele>
+<time>2026-02-10T02:22:57Z</time></trkpt>
+<trkpt lat="45.958328" lon="-66.622067">
+<ele>10</ele>
+<time>2026-02-10T02:22:57Z</time></trkpt>
+<trkpt lat="45.958397" lon="-66.621747">
+<ele>10</ele>
+<time>2026-02-10T02:23:07Z</time></trkpt>
+<trkpt lat="45.958397" lon="-66.621747">
+<ele>10</ele>
+<time>2026-02-10T02:23:07Z</time></trkpt>
+<trkpt lat="45.958433" lon="-66.621584">
+<ele>10</ele>
+<time>2026-02-10T02:23:11Z</time></trkpt>
+<trkpt lat="45.958486" lon="-66.621393">
+<ele>10</ele>
+<time>2026-02-10T02:23:17Z</time></trkpt>
+<trkpt lat="45.958561" lon="-66.621199">
+<ele>10</ele>
+<time>2026-02-10T02:23:23Z</time></trkpt>
+<trkpt lat="45.958561" lon="-66.621199">
+<ele>10</ele>
+<time>2026-02-10T02:23:23Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-02-10T02:23:33Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-02-10T02:23:44Z</time></trkpt>
+<trkpt lat="45.958915" lon="-66.620444">
+<ele>10</ele>
+<time>2026-02-10T02:23:49Z</time></trkpt>
+<trkpt lat="45.958915" lon="-66.620444">
+<ele>10</ele>
+<time>2026-02-10T02:23:49Z</time></trkpt>
+<trkpt lat="45.958962" lon="-66.62037">
+<ele>10</ele>
+<time>2026-02-10T02:23:52Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620304">
+<ele>10</ele>
+<time>2026-02-10T02:23:53Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620304">
+<ele>10</ele>
+<time>2026-02-10T02:23:53Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620292">
+<ele>10</ele>
+<time>2026-02-10T02:23:54Z</time></trkpt>
+<trkpt lat="45.95894" lon="-66.620251">
+<ele>10</ele>
+<time>2026-02-10T02:23:55Z</time></trkpt>
+<trkpt lat="45.958898" lon="-66.620214">
+<ele>10</ele>
+<time>2026-02-10T02:23:57Z</time></trkpt>
+<trkpt lat="45.958905" lon="-66.62021">
+<ele>10</ele>
+<time>2026-02-10T02:23:58Z</time></trkpt>
+<trkpt lat="45.958905" lon="-66.62021">
+<ele>10</ele>
+<time>2026-02-10T02:23:58Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-02-10T02:23:58Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-02-10T02:23:58Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-02-10T02:23:58Z</time></trkpt>
+<trkpt lat="45.958625" lon="-66.620306">
+<ele>9</ele>
+<time>2026-02-10T02:24:09Z</time></trkpt>
+<trkpt lat="45.95833" lon="-66.620318">
+<ele>9</ele>
+<time>2026-02-10T02:24:21Z</time></trkpt>
+<trkpt lat="45.958134" lon="-66.620282">
+<ele>9</ele>
+<time>2026-02-10T02:24:29Z</time></trkpt>
+<trkpt lat="45.957933" lon="-66.620207">
+<ele>9</ele>
+<time>2026-02-10T02:24:37Z</time></trkpt>
+<trkpt lat="45.957728" lon="-66.620097">
+<ele>9</ele>
+<time>2026-02-10T02:24:46Z</time></trkpt>
+<trkpt lat="45.95718" lon="-66.619732">
+<ele>6</ele>
+<time>2026-02-10T02:25:10Z</time></trkpt>
+<trkpt lat="45.956327" lon="-66.619138">
+<ele>3</ele>
+<time>2026-02-10T02:25:48Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-02-10T02:26:21Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-02-10T02:26:21Z</time></trkpt>
+<trkpt lat="45.953955" lon="-66.617486">
+<ele>10</ele>
+<time>2026-02-10T02:27:34Z</time></trkpt>
+<trkpt lat="45.953846" lon="-66.617411">
+<ele>10</ele>
+<time>2026-02-10T02:27:39Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-02-10T02:27:41Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-02-10T02:27:42Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-02-10T02:27:42Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-02-10T02:27:42Z</time></trkpt>
+<trkpt lat="45.953661" lon="-66.617407">
+<ele>9</ele>
+<time>2026-02-10T02:27:47Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-02-10T02:27:56Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-02-10T02:27:56Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-02-10T02:29:03Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-02-10T02:29:03Z</time></trkpt>
+<trkpt lat="45.95177" lon="-66.615978">
+<ele>10</ele>
+<time>2026-02-10T02:29:13Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-02-10T02:29:41Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-02-10T02:29:41Z</time></trkpt>
+<trkpt lat="45.950773" lon="-66.615278">
+<ele>9</ele>
+<time>2026-02-10T02:29:57Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-02-10T02:30:30Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-02-10T02:30:30Z</time></trkpt>
+<trkpt lat="45.950003" lon="-66.614738">
+<ele>9</ele>
+<time>2026-02-10T02:30:31Z</time></trkpt>
+<trkpt lat="45.949917" lon="-66.614497">
+<ele>9</ele>
+<time>2026-02-10T02:30:39Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-02-10T02:30:41Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-02-10T02:30:41Z</time></trkpt>
+<trkpt lat="45.949908" lon="-66.614348">
+<ele>9</ele>
+<time>2026-02-10T02:30:43Z</time></trkpt>
+<trkpt lat="45.949942" lon="-66.614185">
+<ele>9</ele>
+<time>2026-02-10T02:30:48Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-02-10T02:30:52Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-02-10T02:30:52Z</time></trkpt>
+<trkpt lat="45.950333" lon="-66.613966">
+<ele>9</ele>
+<time>2026-02-10T02:31:05Z</time></trkpt>
+<trkpt lat="45.950635" lon="-66.613663">
+<ele>10</ele>
+<time>2026-02-10T02:31:20Z</time></trkpt>
+<trkpt lat="45.950902" lon="-66.61323">
+<ele>10</ele>
+<time>2026-02-10T02:31:36Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-02-10T02:31:50Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-02-10T02:31:50Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-02-10T02:31:50Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-02-10T02:31:51Z</time></trkpt>
+<trkpt lat="45.951176" lon="-66.612384">
+<ele>10</ele>
+<time>2026-02-10T02:32:03Z</time></trkpt>
+<trkpt lat="45.951354" lon="-66.611746">
+<ele>10</ele>
+<time>2026-02-10T02:32:22Z</time></trkpt>
+<trkpt lat="45.95143" lon="-66.61128">
+<ele>10</ele>
+<time>2026-02-10T02:32:35Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-02-10T02:32:43Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-02-10T02:32:44Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-02-10T02:32:44Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-02-10T02:32:44Z</time></trkpt>
+<trkpt lat="45.951461" lon="-66.610792">
+<ele>10</ele>
+<time>2026-02-10T02:32:50Z</time></trkpt>
+<trkpt lat="45.951556" lon="-66.610483">
+<ele>10</ele>
+<time>2026-02-10T02:33:00Z</time></trkpt>
+<trkpt lat="45.951635" lon="-66.610362">
+<ele>10</ele>
+<time>2026-02-10T02:33:04Z</time></trkpt>
+<trkpt lat="45.951716" lon="-66.610289">
+<ele>10</ele>
+<time>2026-02-10T02:33:08Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-02-10T02:33:11Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-02-10T02:33:11Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-02-10T02:34:14Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-02-10T02:34:14Z</time></trkpt>
+<trkpt lat="45.952532" lon="-66.607543">
+<ele>12</ele>
+<time>2026-02-10T02:34:32Z</time></trkpt>
+<trkpt lat="45.952784" lon="-66.607017">
+<ele>10</ele>
+<time>2026-02-10T02:34:49Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-02-10T02:35:15Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-02-10T02:35:15Z</time></trkpt>
+<trkpt lat="45.953282" lon="-66.606382">
+<ele>10</ele>
+<time>2026-02-10T02:35:16Z</time></trkpt>
+<trkpt lat="45.953384" lon="-66.606251">
+<ele>10</ele>
+<time>2026-02-10T02:35:22Z</time></trkpt>
+<trkpt lat="45.953925" lon="-66.605723">
+<ele>10</ele>
+<time>2026-02-10T02:35:48Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-02-10T02:36:03Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-02-10T02:36:03Z</time></trkpt>
+<trkpt lat="45.954387" lon="-66.605232">
+<ele>10</ele>
+<time>2026-02-10T02:36:11Z</time></trkpt>
+<trkpt lat="45.954745" lon="-66.60476">
+<ele>10</ele>
+<time>2026-02-10T02:36:30Z</time></trkpt>
+<trkpt lat="45.955223" lon="-66.603919">
+<ele>10</ele>
+<time>2026-02-10T02:37:00Z</time></trkpt>
+<trkpt lat="45.955571" lon="-66.603154">
+<ele>12</ele>
+<time>2026-02-10T02:37:26Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-02-10T02:38:55Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-02-10T02:38:55Z</time></trkpt>
+<trkpt lat="45.958914" lon="-66.596075">
+<ele>15</ele>
+<time>2026-02-10T02:41:24Z</time></trkpt>
+<trkpt lat="45.959408" lon="-66.595054">
+<ele>12</ele>
+<time>2026-02-10T02:41:59Z</time></trkpt>
+<trkpt lat="45.959986" lon="-66.593886">
+<ele>9</ele>
+<time>2026-02-10T02:42:39Z</time></trkpt>
+<trkpt lat="45.960677" lon="-66.592592">
+<ele>10</ele>
+<time>2026-02-10T02:43:24Z</time></trkpt>
+<trkpt lat="45.960883" lon="-66.592242">
+<ele>11</ele>
+<time>2026-02-10T02:43:37Z</time></trkpt>
+<trkpt lat="45.96131" lon="-66.591631">
+<ele>11</ele>
+<time>2026-02-10T02:44:01Z</time></trkpt>
+<trkpt lat="45.963861" lon="-66.588577">
+<ele>12</ele>
+<time>2026-02-10T02:46:14Z</time></trkpt>
+<trkpt lat="45.964377" lon="-66.587911">
+<ele>11</ele>
+<time>2026-02-10T02:46:42Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-02-10T02:46:56Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-02-10T02:46:56Z</time></trkpt>
+<trkpt lat="45.965429" lon="-66.586262">
+<ele>7</ele>
+<time>2026-02-10T02:47:44Z</time></trkpt>
+<trkpt lat="45.966107" lon="-66.585312">
+<ele>8</ele>
+<time>2026-02-10T02:48:22Z</time></trkpt>
+<trkpt lat="45.966364" lon="-66.585057">
+<ele>8</ele>
+<time>2026-02-10T02:48:35Z</time></trkpt>
+<trkpt lat="45.966634" lon="-66.584828">
+<ele>8</ele>
+<time>2026-02-10T02:48:47Z</time></trkpt>
+<trkpt lat="45.96688" lon="-66.584676">
+<ele>8</ele>
+<time>2026-02-10T02:48:58Z</time></trkpt>
+<trkpt lat="45.96727" lon="-66.584548">
+<ele>8</ele>
+<time>2026-02-10T02:49:14Z</time></trkpt>
+<trkpt lat="45.967399" lon="-66.584523">
+<ele>8</ele>
+<time>2026-02-10T02:49:19Z</time></trkpt>
+<trkpt lat="45.967658" lon="-66.584517">
+<ele>8</ele>
+<time>2026-02-10T02:49:30Z</time></trkpt>
+<trkpt lat="45.967891" lon="-66.584555">
+<ele>9</ele>
+<time>2026-02-10T02:49:39Z</time></trkpt>
+<trkpt lat="45.968123" lon="-66.584619">
+<ele>8</ele>
+<time>2026-02-10T02:49:49Z</time></trkpt>
+<trkpt lat="45.96836" lon="-66.584715">
+<ele>8</ele>
+<time>2026-02-10T02:49:59Z</time></trkpt>
+<trkpt lat="45.968593" lon="-66.584857">
+<ele>8</ele>
+<time>2026-02-10T02:50:09Z</time></trkpt>
+<trkpt lat="45.972289" lon="-66.587553">
+<ele>10</ele>
+<time>2026-02-10T02:52:55Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-02-10T02:53:23Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-02-10T02:53:23Z</time></trkpt>
+<trkpt lat="45.973398" lon="-66.588427">
+<ele>9</ele>
+<time>2026-02-10T02:53:45Z</time></trkpt>
+<trkpt lat="45.973712" lon="-66.588627">
+<ele>8</ele>
+<time>2026-02-10T02:53:59Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-02-10T02:54:10Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-02-10T02:54:10Z</time></trkpt>
+<trkpt lat="45.974595" lon="-66.589095">
+<ele>8</ele>
+<time>2026-02-10T02:54:37Z</time></trkpt>
+<trkpt lat="45.974902" lon="-66.589197">
+<ele>9</ele>
+<time>2026-02-10T02:54:50Z</time></trkpt>
+<trkpt lat="45.97523" lon="-66.589266">
+<ele>9</ele>
+<time>2026-02-10T02:55:03Z</time></trkpt>
+<trkpt lat="45.975815" lon="-66.589324">
+<ele>9</ele>
+<time>2026-02-10T02:55:26Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-02-10T02:55:42Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-02-10T02:55:42Z</time></trkpt>
+<trkpt lat="45.976297" lon="-66.589324">
+<ele>10</ele>
+<time>2026-02-10T02:55:46Z</time></trkpt>
+<trkpt lat="45.976388" lon="-66.589479">
+<ele>10</ele>
+<time>2026-02-10T02:55:51Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-02-10T02:55:52Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-02-10T02:55:52Z</time></trkpt>
+<trkpt lat="45.97647" lon="-66.58953">
+<ele>10</ele>
+<time>2026-02-10T02:55:55Z</time></trkpt>
+<trkpt lat="45.976864" lon="-66.589543">
+<ele>11</ele>
+<time>2026-02-10T02:56:11Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T02:57:04Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T02:57:04Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T02:57:28Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T02:57:28Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T02:57:29Z</time></trkpt>
+<trkpt lat="45.978813" lon="-66.589615">
+<ele>10</ele>
+<time>2026-02-10T02:57:31Z</time></trkpt>
+<trkpt lat="45.978811" lon="-66.589684">
+<ele>10</ele>
+<time>2026-02-10T02:57:33Z</time></trkpt>
+<trkpt lat="45.978846" lon="-66.589722">
+<ele>10</ele>
+<time>2026-02-10T02:57:34Z</time></trkpt>
+<trkpt lat="45.978852" lon="-66.589755">
+<ele>10</ele>
+<time>2026-02-10T02:57:35Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-02-10T02:57:37Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-02-10T02:57:37Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-02-10T02:58:15Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-02-10T02:58:15Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.591785">
+<ele>11</ele>
+<time>2026-02-10T02:58:32Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T02:58:36Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-02-10T02:58:37Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-02-10T02:58:37Z</time></trkpt>
+<trkpt lat="45.978791" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T02:58:38Z</time></trkpt>
+<trkpt lat="45.978791" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T02:58:38Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-02-10T02:58:44Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-02-10T02:58:54Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-02-10T02:59:17Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-02-10T02:59:53Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-02-10T03:00:19Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-02-10T03:01:21Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-02-10T03:01:42Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-02-10T03:02:37Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-02-10T03:02:58Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-02-10T03:03:17Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-02-10T03:03:31Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-02-10T03:03:47Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-02-10T03:04:09Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-02-10T03:04:32Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-02-10T03:05:11Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-02-10T03:05:41Z</time></trkpt>
+<trkpt lat="45.987819" lon="-66.586563">
+<ele>11</ele>
+<time>2026-02-10T03:06:00Z</time></trkpt>
+<trkpt lat="45.987851" lon="-66.586415">
+<ele>11</ele>
+<time>2026-02-10T03:06:04Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-02-10T03:06:24Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-02-10T03:07:13Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-02-10T03:07:22Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-02-10T03:07:30Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-02-10T03:08:11Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-02-10T03:09:43Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-02-10T03:10:01Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-02-10T03:10:13Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-02-10T03:10:21Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-02-10T03:13:25Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-02-10T03:13:41Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-02-10T03:14:05Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-02-10T03:14:07Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-02-10T03:14:08Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-02-10T03:14:57Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-02-10T03:15:10Z</time></trkpt>
+<trkpt lat="45.99783" lon="-66.573644">
+<ele>12</ele>
+<time>2026-02-10T03:15:23Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-02-10T03:15:29Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-02-10T03:15:36Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-02-10T03:15:51Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-02-10T03:16:14Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-02-10T03:16:54Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-02-10T03:17:19Z</time></trkpt>
+<trkpt lat="46.003025" lon="-66.57611">
+<ele>14</ele>
+<time>2026-02-10T03:19:03Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-02-10T03:20:47Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-02-10T03:21:12Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-02-10T03:21:53Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-02-10T03:22:16Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-02-10T03:22:30Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-02-10T03:22:37Z</time></trkpt>
+<trkpt lat="45.99783" lon="-66.573644">
+<ele>12</ele>
+<time>2026-02-10T03:22:44Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-02-10T03:22:57Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-02-10T03:23:10Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-02-10T03:23:59Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-02-10T03:24:00Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-02-10T03:24:01Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-02-10T03:24:26Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-02-10T03:24:41Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-02-10T03:27:46Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-02-10T03:27:53Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-02-10T03:28:05Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-02-10T03:28:24Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-02-10T03:29:55Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-02-10T03:30:37Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-02-10T03:30:45Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-02-10T03:30:54Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-02-10T03:31:42Z</time></trkpt>
+<trkpt lat="45.987851" lon="-66.586415">
+<ele>11</ele>
+<time>2026-02-10T03:32:03Z</time></trkpt>
+<trkpt lat="45.987819" lon="-66.586563">
+<ele>11</ele>
+<time>2026-02-10T03:32:07Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-02-10T03:32:26Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-02-10T03:32:56Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-02-10T03:33:34Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-02-10T03:33:58Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-02-10T03:34:19Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-02-10T03:34:36Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-02-10T03:34:49Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-02-10T03:35:08Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-02-10T03:35:29Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-02-10T03:36:25Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-02-10T03:36:46Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-02-10T03:37:48Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-02-10T03:38:14Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-02-10T03:38:50Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-02-10T03:39:13Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-02-10T03:39:23Z</time></trkpt>
+<trkpt lat="45.978791" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T03:39:28Z</time></trkpt>
+<trkpt lat="45.978791" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T03:39:28Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T03:39:29Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-02-10T03:39:29Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-02-10T03:39:29Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-02-10T03:39:29Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T03:39:29Z</time></trkpt>
+<trkpt lat="45.978099" lon="-66.592014">
+<ele>13</ele>
+<time>2026-02-10T03:39:57Z</time></trkpt>
+<trkpt lat="45.97754" lon="-66.592055">
+<ele>15</ele>
+<time>2026-02-10T03:40:19Z</time></trkpt>
+<trkpt lat="45.976207" lon="-66.592051">
+<ele>11</ele>
+<time>2026-02-10T03:41:13Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-02-10T03:41:32Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-02-10T03:41:32Z</time></trkpt>
+<trkpt lat="45.975632" lon="-66.592094">
+<ele>9</ele>
+<time>2026-02-10T03:41:36Z</time></trkpt>
+<trkpt lat="45.975623" lon="-66.592254">
+<ele>14</ele>
+<time>2026-02-10T03:41:40Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-02-10T03:41:42Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-02-10T03:41:42Z</time></trkpt>
+<trkpt lat="45.975214" lon="-66.592189">
+<ele>12</ele>
+<time>2026-02-10T03:41:57Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-02-10T03:41:58Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-02-10T03:41:58Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592442">
+<ele>15</ele>
+<time>2026-02-10T03:42:30Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592443">
+<ele>15</ele>
+<time>2026-02-10T03:42:30Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-02-10T03:43:21Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-02-10T03:43:21Z</time></trkpt>
+<trkpt lat="45.97213" lon="-66.593132">
+<ele>17</ele>
+<time>2026-02-10T03:44:03Z</time></trkpt>
+<trkpt lat="45.971525" lon="-66.593357">
+<ele>21</ele>
+<time>2026-02-10T03:44:28Z</time></trkpt>
+<trkpt lat="45.969886" lon="-66.594119">
+<ele>22</ele>
+<time>2026-02-10T03:45:37Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-02-10T03:45:50Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-02-10T03:45:50Z</time></trkpt>
+<trkpt lat="45.969415" lon="-66.594422">
+<ele>21</ele>
+<time>2026-02-10T03:45:58Z</time></trkpt>
+<trkpt lat="45.969227" lon="-66.594605">
+<ele>21</ele>
+<time>2026-02-10T03:46:07Z</time></trkpt>
+<trkpt lat="45.968963" lon="-66.59493">
+<ele>21</ele>
+<time>2026-02-10T03:46:21Z</time></trkpt>
+<trkpt lat="45.968815" lon="-66.595151">
+<ele>21</ele>
+<time>2026-02-10T03:46:29Z</time></trkpt>
+<trkpt lat="45.9686" lon="-66.595546">
+<ele>21</ele>
+<time>2026-02-10T03:46:43Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-02-10T03:46:51Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-02-10T03:46:51Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-02-10T03:49:00Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-02-10T03:49:00Z</time></trkpt>
+<trkpt lat="45.966112" lon="-66.603183">
+<ele>17</ele>
+<time>2026-02-10T03:50:38Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-02-10T03:50:42Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-02-10T03:50:42Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-02-10T03:50:42Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-02-10T03:50:42Z</time></trkpt>
+<trkpt lat="45.96605" lon="-66.603353">
+<ele>17</ele>
+<time>2026-02-10T03:50:46Z</time></trkpt>
+<trkpt lat="45.965996" lon="-66.603402">
+<ele>17</ele>
+<time>2026-02-10T03:50:48Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-02-10T03:50:49Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-02-10T03:50:49Z</time></trkpt>
+<trkpt lat="45.965942" lon="-66.603501">
+<ele>17</ele>
+<time>2026-02-10T03:50:52Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-02-10T03:50:59Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-02-10T03:50:59Z</time></trkpt>
+<trkpt lat="45.965665" lon="-66.604843">
+<ele>16</ele>
+<time>2026-02-10T03:51:31Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-02-10T03:52:06Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-02-10T03:52:06Z</time></trkpt>
+<trkpt lat="45.965181" lon="-66.608383">
+<ele>11</ele>
+<time>2026-02-10T03:53:11Z</time></trkpt>
+<trkpt lat="45.965033" lon="-66.609132">
+<ele>12</ele>
+<time>2026-02-10T03:53:33Z</time></trkpt>
+<trkpt lat="45.964803" lon="-66.609859">
+<ele>12</ele>
+<time>2026-02-10T03:53:55Z</time></trkpt>
+<trkpt lat="45.964626" lon="-66.610341">
+<ele>11</ele>
+<time>2026-02-10T03:54:10Z</time></trkpt>
+<trkpt lat="45.964553" lon="-66.610469">
+<ele>11</ele>
+<time>2026-02-10T03:54:15Z</time></trkpt>
+<trkpt lat="45.963882" lon="-66.611228">
+<ele>11</ele>
+<time>2026-02-10T03:54:49Z</time></trkpt>
+<trkpt lat="45.963738" lon="-66.611445">
+<ele>12</ele>
+<time>2026-02-10T03:54:57Z</time></trkpt>
+<trkpt lat="45.963251" lon="-66.612346">
+<ele>11</ele>
+<time>2026-02-10T03:55:29Z</time></trkpt>
+<trkpt lat="45.963102" lon="-66.612555">
+<ele>10</ele>
+<time>2026-02-10T03:55:38Z</time></trkpt>
+<trkpt lat="45.962888" lon="-66.6132">
+<ele>9</ele>
+<time>2026-02-10T03:55:57Z</time></trkpt>
+<trkpt lat="45.962803" lon="-66.613403">
+<ele>8</ele>
+<time>2026-02-10T03:56:04Z</time></trkpt>
+<trkpt lat="45.962527" lon="-66.613859">
+<ele>9</ele>
+<time>2026-02-10T03:56:21Z</time></trkpt>
+<trkpt lat="45.962084" lon="-66.614756">
+<ele>10</ele>
+<time>2026-02-10T03:56:52Z</time></trkpt>
+<trkpt lat="45.96169" lon="-66.615396">
+<ele>10</ele>
+<time>2026-02-10T03:57:15Z</time></trkpt>
+<trkpt lat="45.961234" lon="-66.615961">
+<ele>11</ele>
+<time>2026-02-10T03:57:40Z</time></trkpt>
+<trkpt lat="45.961024" lon="-66.616296">
+<ele>11</ele>
+<time>2026-02-10T03:57:52Z</time></trkpt>
+<trkpt lat="45.960565" lon="-66.617191">
+<ele>11</ele>
+<time>2026-02-10T03:58:23Z</time></trkpt>
+<trkpt lat="45.959944" lon="-66.618459">
+<ele>10</ele>
+<time>2026-02-10T03:59:06Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-02-10T03:59:33Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-02-10T03:59:41Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-02-10T03:59:41Z</time></trkpt>
+<trkpt lat="45.959154" lon="-66.620054">
+<ele>9</ele>
+<time>2026-02-10T04:00:01Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-02-10T04:00:20Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-02-10T04:00:31Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-02-10T04:00:47Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-02-10T04:00:47Z</time></trkpt>
+<trkpt lat="45.958337" lon="-66.622017">
+<ele>10</ele>
+<time>2026-02-10T04:01:05Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-02-10T04:01:53Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-02-10T04:01:53Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-02-10T04:02:14Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-02-10T04:02:19Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-02-10T04:02:36Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-02-10T04:02:36Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-02-10T04:06:07Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-02-10T04:06:07Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-02-10T04:06:16Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-02-10T04:06:43Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-02-10T04:06:43Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-02-10T04:07:00Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-02-10T04:07:07Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-02-10T04:07:26Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-02-10T04:07:26Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-02-10T04:07:31Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-02-10T04:07:35Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-02-10T04:07:53Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-02-10T04:08:10Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-02-10T04:08:10Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-02-10T04:08:54Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-02-10T04:08:54Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-02-10T04:09:38Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-02-10T04:09:38Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-02-10T04:09:38Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-02-10T04:09:44Z</time></trkpt>
+<trkpt lat="45.953944" lon="-66.639888">
+<ele>9</ele>
+<time>2026-02-10T04:10:50Z</time></trkpt>
+<trkpt lat="45.953933" lon="-66.639899">
+<ele>9</ele>
+<time>2026-02-10T04:10:51Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/00_full_new.gpx
+++ b/cursor/plotaroute/00_full_new.gpx
@@ -1,0 +1,2850 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.954489" lon="-66.641395">
+<time>2026-06-01T00:00:00Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Saint John Street</cmt>
+<desc>Start on Rue Saint John Street</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954492" lon="-66.6414">
+<time>2026-06-01T00:00:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-06-01T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rang Churchill Row</cmt>
+<desc>Turn right onto Rang Churchill Row</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-06-01T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956374" lon="-66.639758">
+<time>2026-06-01T00:01:29Z</time>
+<name>At roundab</name>
+<cmt>At roundabout, take exit 2 onto Rue Saint John Street</cmt>
+<desc>At roundabout, take exit 2 onto Rue Saint John Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-06-01T00:01:35Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-06-01T00:01:35Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-06-01T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Brunswick Street</cmt>
+<desc>Turn right onto Rue Brunswick Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-06-01T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-06-01T00:03:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue King Street</cmt>
+<desc>Turn right onto Rue King Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-06-01T00:03:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-06-01T00:04:28Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-06-01T00:04:29Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Queen Street</cmt>
+<desc>Turn left onto Rue Queen Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.96099" lon="-66.638372">
+<time>2026-06-01T00:05:33Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.961255" lon="-66.638537">
+<time>2026-06-01T00:05:45Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</cmt>
+<desc>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.964051" lon="-66.641227">
+<time>2026-06-01T00:08:24Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966872" lon="-66.643476">
+<time>2026-06-01T00:10:42Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Westmorland Street Bridge</cmt>
+<desc>Turn slight right onto Westmorland Street Bridge</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971269" lon="-66.641336">
+<time>2026-06-01T00:13:48Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971842" lon="-66.640842">
+<time>2026-06-01T00:14:15Z</time>
+<name>Keep left</name>
+<cmt>Keep left</cmt>
+<desc>Keep left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973279" lon="-66.639509">
+<time>2026-06-01T00:15:25Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Rue Union Street</cmt>
+<desc>Turn slight right onto Rue Union Street</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973069" lon="-66.638821">
+<time>2026-06-01T00:15:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Friel Street</cmt>
+<desc>Turn right onto Rue Friel Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973747" lon="-66.638243">
+<time>2026-06-01T00:16:18Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Northside Trail</cmt>
+<desc>Turn left onto Northside Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973749" lon="-66.63825">
+<time>2026-06-01T00:16:18Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Friel Street</cmt>
+<desc>Start on Rue Friel Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.977804" lon="-66.723732">
+<time>2026-06-01T00:59:20Z</time>
+<name>Make a U-t</name>
+<cmt>Make a U-turn onto Northside Trail</cmt>
+<desc>Make a U-turn onto Northside Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978723" lon="-66.69264">
+<time>2026-06-01T01:13:49Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Northside Trail</cmt>
+<desc>Keep left onto Northside Trail</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978782" lon="-66.692065">
+<time>2026-06-01T01:14:09Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Northside Trail</cmt>
+<desc>Keep left onto Northside Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.980194" lon="-66.656652">
+<time>2026-06-01T01:32:47Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959573" lon="-66.61926">
+<time>2026-06-01T01:55:48Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958898" lon="-66.620214">
+<time>2026-06-01T01:56:28Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959154" lon="-66.620054">
+<time>2026-06-01T01:56:39Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Sentier Nashwaak Trail</cmt>
+<desc>Turn slight right onto Sentier Nashwaak Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959573" lon="-66.61926">
+<time>2026-06-01T01:57:07Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Northside Trail</cmt>
+<desc>Turn left onto Northside Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-06-01T02:07:13Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9536" lon="-66.639076">
+<time>2026-06-01T02:07:58Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Church Street</cmt>
+<desc>Turn right onto Rue Church Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9536" lon="-66.639076">
+<time>2026-06-01T02:08:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Aberdeen Street</cmt>
+<desc>Turn right onto Rue Aberdeen Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954559" lon="-66.641341">
+<time>2026-06-01T02:09:13Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953262" lon="-66.642474">
+<time>2026-06-01T02:10:14Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Avenue McLeod Avenue</cmt>
+<desc>Turn left onto Avenue McLeod Avenue</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.952078" lon="-66.640406">
+<time>2026-06-01T02:11:31Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.952065" lon="-66.640308">
+<time>2026-06-01T02:11:33Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951885" lon="-66.640411">
+<time>2026-06-01T02:11:41Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951918" lon="-66.640503">
+<time>2026-06-01T02:11:44Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Avenue McLeod Avenue</cmt>
+<desc>Turn left onto Avenue McLeod Avenue</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95163" lon="-66.640884">
+<time>2026-06-01T02:12:00Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951567" lon="-66.640825">
+<time>2026-06-01T02:12:03Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951476" lon="-66.641114">
+<time>2026-06-01T02:12:12Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950944" lon="-66.64109">
+<time>2026-06-01T02:12:34Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right onto Crosstown Trail</cmt>
+<desc>Turn sharp right onto Crosstown Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95021" lon="-66.640061">
+<time>2026-06-01T02:13:26Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Crosstown Trail</cmt>
+<desc>Turn left onto Crosstown Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95024" lon="-66.639638">
+<time>2026-06-01T02:13:37Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Lincoln Trail</cmt>
+<desc>Turn right onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951746" lon="-66.638803">
+<time>2026-06-01T02:14:44Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951746" lon="-66.638803">
+<time>2026-06-01T02:14:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Lincoln Trail</cmt>
+<desc>Turn right onto Lincoln Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958962" lon="-66.62037">
+<time>2026-06-01T02:25:11Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958961" lon="-66.620292">
+<time>2026-06-01T02:25:13Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Gibson Trail</cmt>
+<desc>Turn slight right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95894" lon="-66.620251">
+<time>2026-06-01T02:25:15Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958898" lon="-66.620214">
+<time>2026-06-01T02:25:17Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Gibson Trail</cmt>
+<desc>Turn sharp left onto Gibson Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958909" lon="-66.620208">
+<time>2026-06-01T02:25:17Z</time>
+<name>Start on G</name>
+<cmt>Start on Gibson Trail</cmt>
+<desc>Start on Gibson Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-06-01T02:29:01Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-06-01T02:29:01Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Sentier Gibson Trail</cmt>
+<desc>Turn left onto Sentier Gibson Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950003" lon="-66.614738">
+<time>2026-06-01T02:31:51Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Gibson Trail</cmt>
+<desc>Keep left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.949942" lon="-66.614185">
+<time>2026-06-01T02:32:07Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Gibson Trail</cmt>
+<desc>Turn left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-06-01T02:33:09Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-06-01T02:33:10Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-06-01T02:34:02Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-06-01T02:34:04Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.976297" lon="-66.589324">
+<time>2026-06-01T02:57:05Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue McGloin Street</cmt>
+<desc>Turn left onto Rue McGloin Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978815" lon="-66.589547">
+<time>2026-06-01T02:58:48Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978811" lon="-66.589684">
+<time>2026-06-01T02:58:52Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-06-01T02:59:55Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978817" lon="-66.591903">
+<time>2026-06-01T02:59:59Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.996057" lon="-66.574357">
+<time>2026-06-01T03:24:57Z</time>
+<name>Start on N</name>
+<cmt>Start on Nashwaak Trail</cmt>
+<desc>Start on Nashwaak Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978851" lon="-66.591896">
+<time>2026-06-01T03:40:25Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Bridge Street</cmt>
+<desc>Turn right onto Rue Bridge Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978851" lon="-66.591896">
+<time>2026-06-01T03:40:27Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Nashwaak Trail</cmt>
+<desc>Turn right onto Nashwaak Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-06-01T03:40:29Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.97879" lon="-66.591898">
+<time>2026-06-01T03:40:29Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-06-01T03:40:30Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.975623" lon="-66.592254">
+<time>2026-06-01T03:42:41Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966115" lon="-66.603295">
+<time>2026-06-01T03:51:43Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-06-01T04:10:39Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953944" lon="-66.639888">
+<time>2026-06-01T04:11:51Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953933" lon="-66.639899">
+<time>2026-06-01T04:11:51Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>00_full_new</name>
+<trkseg>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.954492" lon="-66.6414">
+<ele>10</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-06-01T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-06-01T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-06-01T00:00:47Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-06-01T00:00:47Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639772">
+<ele>13</ele>
+<time>2026-06-01T00:01:28Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639771">
+<ele>13</ele>
+<time>2026-06-01T00:01:28Z</time></trkpt>
+<trkpt lat="45.956374" lon="-66.639758">
+<ele>13</ele>
+<time>2026-06-01T00:01:29Z</time></trkpt>
+<trkpt lat="45.956371" lon="-66.639719">
+<ele>13</ele>
+<time>2026-06-01T00:01:30Z</time></trkpt>
+<trkpt lat="45.956394" lon="-66.639674">
+<ele>13</ele>
+<time>2026-06-01T00:01:31Z</time></trkpt>
+<trkpt lat="45.956428" lon="-66.639667">
+<ele>13</ele>
+<time>2026-06-01T00:01:33Z</time></trkpt>
+<trkpt lat="45.956454" lon="-66.639689">
+<ele>13</ele>
+<time>2026-06-01T00:01:34Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-06-01T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-06-01T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-06-01T00:01:35Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-06-01T00:01:35Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-06-01T00:02:16Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-06-01T00:02:16Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-06-01T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-06-01T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-06-01T00:03:00Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-06-01T00:03:00Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-06-01T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-06-01T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-06-01T00:03:44Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-06-01T00:03:45Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-06-01T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-06-01T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-06-01T00:04:28Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-06-01T00:04:29Z</time></trkpt>
+<trkpt lat="45.960461" lon="-66.637131">
+<ele>8</ele>
+<time>2026-06-01T00:04:52Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-06-01T00:05:33Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-06-01T00:05:33Z</time></trkpt>
+<trkpt lat="45.96099" lon="-66.638372">
+<ele>9</ele>
+<time>2026-06-01T00:05:33Z</time></trkpt>
+<trkpt lat="45.961139" lon="-66.638502">
+<ele>9</ele>
+<time>2026-06-01T00:05:40Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-06-01T00:05:43Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-06-01T00:05:43Z</time></trkpt>
+<trkpt lat="45.961255" lon="-66.638537">
+<ele>9</ele>
+<time>2026-06-01T00:05:45Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-06-01T00:06:08Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-06-01T00:06:08Z</time></trkpt>
+<trkpt lat="45.961916" lon="-66.638033">
+<ele>8</ele>
+<time>2026-06-01T00:06:15Z</time></trkpt>
+<trkpt lat="45.962057" lon="-66.638009">
+<ele>8</ele>
+<time>2026-06-01T00:06:21Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-06-01T00:06:30Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-06-01T00:06:30Z</time></trkpt>
+<trkpt lat="45.962472" lon="-66.638212">
+<ele>7</ele>
+<time>2026-06-01T00:06:38Z</time></trkpt>
+<trkpt lat="45.96257" lon="-66.638353">
+<ele>7</ele>
+<time>2026-06-01T00:06:44Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-06-01T00:07:04Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-06-01T00:07:04Z</time></trkpt>
+<trkpt lat="45.964051" lon="-66.641227">
+<ele>8</ele>
+<time>2026-06-01T00:08:24Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-06-01T00:08:30Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-06-01T00:08:30Z</time></trkpt>
+<trkpt lat="45.964399" lon="-66.641753">
+<ele>8</ele>
+<time>2026-06-01T00:08:44Z</time></trkpt>
+<trkpt lat="45.965254" lon="-66.642927">
+<ele>7</ele>
+<time>2026-06-01T00:09:31Z</time></trkpt>
+<trkpt lat="45.965528" lon="-66.643281">
+<ele>6</ele>
+<time>2026-06-01T00:09:46Z</time></trkpt>
+<trkpt lat="45.965639" lon="-66.643394">
+<ele>6</ele>
+<time>2026-06-01T00:09:51Z</time></trkpt>
+<trkpt lat="45.965748" lon="-66.643484">
+<ele>4</ele>
+<time>2026-06-01T00:09:56Z</time></trkpt>
+<trkpt lat="45.965873" lon="-66.643545">
+<ele>3</ele>
+<time>2026-06-01T00:10:02Z</time></trkpt>
+<trkpt lat="45.966106" lon="-66.643575">
+<ele>3</ele>
+<time>2026-06-01T00:10:11Z</time></trkpt>
+<trkpt lat="45.966613" lon="-66.643482">
+<ele>3</ele>
+<time>2026-06-01T00:10:32Z</time></trkpt>
+<trkpt lat="45.966872" lon="-66.643476">
+<ele>3</ele>
+<time>2026-06-01T00:10:42Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-06-01T00:10:43Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-06-01T00:10:43Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-06-01T00:11:54Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-06-01T00:11:54Z</time></trkpt>
+<trkpt lat="45.971269" lon="-66.641336">
+<ele>6</ele>
+<time>2026-06-01T00:13:48Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-06-01T00:14:02Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-06-01T00:14:02Z</time></trkpt>
+<trkpt lat="45.971679" lon="-66.640971">
+<ele>7</ele>
+<time>2026-06-01T00:14:07Z</time></trkpt>
+<trkpt lat="45.971842" lon="-66.640842">
+<ele>8</ele>
+<time>2026-06-01T00:14:15Z</time></trkpt>
+<trkpt lat="45.97315" lon="-66.639854">
+<ele>10</ele>
+<time>2026-06-01T00:15:14Z</time></trkpt>
+<trkpt lat="45.97324" lon="-66.639695">
+<ele>10</ele>
+<time>2026-06-01T00:15:20Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-06-01T00:15:22Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-06-01T00:15:22Z</time></trkpt>
+<trkpt lat="45.973279" lon="-66.639509">
+<ele>10</ele>
+<time>2026-06-01T00:15:25Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-06-01T00:15:46Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-06-01T00:15:46Z</time></trkpt>
+<trkpt lat="45.973069" lon="-66.638821">
+<ele>10</ele>
+<time>2026-06-01T00:15:47Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-06-01T00:16:18Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-06-01T00:16:18Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-06-01T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-06-01T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-06-01T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-06-01T00:16:18Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-06-01T00:17:11Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-06-01T00:17:19Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-06-01T00:17:56Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-06-01T00:17:56Z</time></trkpt>
+<trkpt lat="45.975824" lon="-66.644429">
+<ele>15</ele>
+<time>2026-06-01T00:19:29Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-06-01T00:20:37Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-06-01T00:20:37Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-06-01T00:23:51Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-06-01T00:23:51Z</time></trkpt>
+<trkpt lat="45.978997" lon="-66.653873">
+<ele>18</ele>
+<time>2026-06-01T00:24:22Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-06-01T00:24:29Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-06-01T00:24:29Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-06-01T00:24:47Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-06-01T00:24:47Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-06-01T00:25:53Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-06-01T00:25:53Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-06-01T00:25:53Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-06-01T00:25:53Z</time></trkpt>
+<trkpt lat="45.980604" lon="-66.657551">
+<ele>11</ele>
+<time>2026-06-01T00:26:24Z</time></trkpt>
+<trkpt lat="45.980697" lon="-66.657702">
+<ele>12</ele>
+<time>2026-06-01T00:26:29Z</time></trkpt>
+<trkpt lat="45.98074" lon="-66.657895">
+<ele>12</ele>
+<time>2026-06-01T00:26:35Z</time></trkpt>
+<trkpt lat="45.98101" lon="-66.658415">
+<ele>13</ele>
+<time>2026-06-01T00:26:53Z</time></trkpt>
+<trkpt lat="45.982123" lon="-66.660807">
+<ele>18</ele>
+<time>2026-06-01T00:28:13Z</time></trkpt>
+<trkpt lat="45.982332" lon="-66.661179">
+<ele>18</ele>
+<time>2026-06-01T00:28:26Z</time></trkpt>
+<trkpt lat="45.982542" lon="-66.661474">
+<ele>18</ele>
+<time>2026-06-01T00:28:38Z</time></trkpt>
+<trkpt lat="45.982829" lon="-66.661806">
+<ele>17</ele>
+<time>2026-06-01T00:28:53Z</time></trkpt>
+<trkpt lat="45.98328" lon="-66.662203">
+<ele>16</ele>
+<time>2026-06-01T00:29:14Z</time></trkpt>
+<trkpt lat="45.9835" lon="-66.66236">
+<ele>16</ele>
+<time>2026-06-01T00:29:24Z</time></trkpt>
+<trkpt lat="45.984143" lon="-66.662745">
+<ele>16</ele>
+<time>2026-06-01T00:29:52Z</time></trkpt>
+<trkpt lat="45.984298" lon="-66.66288">
+<ele>15</ele>
+<time>2026-06-01T00:29:59Z</time></trkpt>
+<trkpt lat="45.98464" lon="-66.663258">
+<ele>14</ele>
+<time>2026-06-01T00:30:16Z</time></trkpt>
+<trkpt lat="45.984913" lon="-66.663744">
+<ele>12</ele>
+<time>2026-06-01T00:30:34Z</time></trkpt>
+<trkpt lat="45.985021" lon="-66.664005">
+<ele>12</ele>
+<time>2026-06-01T00:30:42Z</time></trkpt>
+<trkpt lat="45.98514" lon="-66.664376">
+<ele>12</ele>
+<time>2026-06-01T00:30:54Z</time></trkpt>
+<trkpt lat="45.985171" lon="-66.664557">
+<ele>11</ele>
+<time>2026-06-01T00:30:59Z</time></trkpt>
+<trkpt lat="45.985256" lon="-66.665378">
+<ele>9</ele>
+<time>2026-06-01T00:31:22Z</time></trkpt>
+<trkpt lat="45.985234" lon="-66.665874">
+<ele>7</ele>
+<time>2026-06-01T00:31:36Z</time></trkpt>
+<trkpt lat="45.985204" lon="-66.666054">
+<ele>8</ele>
+<time>2026-06-01T00:31:41Z</time></trkpt>
+<trkpt lat="45.981326" lon="-66.681447">
+<ele>12</ele>
+<time>2026-06-01T00:39:17Z</time></trkpt>
+<trkpt lat="45.979288" lon="-66.689529">
+<ele>17</ele>
+<time>2026-06-01T00:43:16Z</time></trkpt>
+<trkpt lat="45.979041" lon="-66.690623">
+<ele>16</ele>
+<time>2026-06-01T00:43:48Z</time></trkpt>
+<trkpt lat="45.978782" lon="-66.692065">
+<ele>10</ele>
+<time>2026-06-01T00:44:30Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.692608">
+<ele>10</ele>
+<time>2026-06-01T00:44:45Z</time></trkpt>
+<trkpt lat="45.978733" lon="-66.692631">
+<ele>10</ele>
+<time>2026-06-01T00:44:50Z</time></trkpt>
+<trkpt lat="45.978695" lon="-66.6927">
+<ele>10</ele>
+<time>2026-06-01T00:44:52Z</time></trkpt>
+<trkpt lat="45.978543" lon="-66.693878">
+<ele>11</ele>
+<time>2026-06-01T00:45:26Z</time></trkpt>
+<trkpt lat="45.978489" lon="-66.694513">
+<ele>12</ele>
+<time>2026-06-01T00:45:44Z</time></trkpt>
+<trkpt lat="45.978412" lon="-66.69597">
+<ele>12</ele>
+<time>2026-06-01T00:46:24Z</time></trkpt>
+<trkpt lat="45.978396" lon="-66.696948">
+<ele>13</ele>
+<time>2026-06-01T00:46:52Z</time></trkpt>
+<trkpt lat="45.978403" lon="-66.699644">
+<ele>13</ele>
+<time>2026-06-01T00:48:07Z</time></trkpt>
+<trkpt lat="45.978433" lon="-66.700431">
+<ele>13</ele>
+<time>2026-06-01T00:48:29Z</time></trkpt>
+<trkpt lat="45.978423" lon="-66.701015">
+<ele>13</ele>
+<time>2026-06-01T00:48:45Z</time></trkpt>
+<trkpt lat="45.978021" lon="-66.707083">
+<ele>21</ele>
+<time>2026-06-01T00:51:35Z</time></trkpt>
+<trkpt lat="45.977706" lon="-66.71324">
+<ele>14</ele>
+<time>2026-06-01T00:54:27Z</time></trkpt>
+<trkpt lat="45.977504" lon="-66.716414">
+<ele>17</ele>
+<time>2026-06-01T00:55:55Z</time></trkpt>
+<trkpt lat="45.977494" lon="-66.717682">
+<ele>16</ele>
+<time>2026-06-01T00:56:31Z</time></trkpt>
+<trkpt lat="45.977569" lon="-66.719148">
+<ele>15</ele>
+<time>2026-06-01T00:57:12Z</time></trkpt>
+<trkpt lat="45.977804" lon="-66.723732">
+<ele>17</ele>
+<time>2026-06-01T00:59:20Z</time></trkpt>
+<trkpt lat="45.977569" lon="-66.719148">
+<ele>15</ele>
+<time>2026-06-01T01:01:28Z</time></trkpt>
+<trkpt lat="45.977494" lon="-66.717682">
+<ele>16</ele>
+<time>2026-06-01T01:02:08Z</time></trkpt>
+<trkpt lat="45.977504" lon="-66.716414">
+<ele>17</ele>
+<time>2026-06-01T01:02:44Z</time></trkpt>
+<trkpt lat="45.977706" lon="-66.71324">
+<ele>14</ele>
+<time>2026-06-01T01:04:13Z</time></trkpt>
+<trkpt lat="45.978021" lon="-66.707083">
+<ele>21</ele>
+<time>2026-06-01T01:07:05Z</time></trkpt>
+<trkpt lat="45.978423" lon="-66.701015">
+<ele>13</ele>
+<time>2026-06-01T01:09:54Z</time></trkpt>
+<trkpt lat="45.978433" lon="-66.700431">
+<ele>13</ele>
+<time>2026-06-01T01:10:11Z</time></trkpt>
+<trkpt lat="45.978403" lon="-66.699644">
+<ele>13</ele>
+<time>2026-06-01T01:10:32Z</time></trkpt>
+<trkpt lat="45.978396" lon="-66.696948">
+<ele>13</ele>
+<time>2026-06-01T01:11:48Z</time></trkpt>
+<trkpt lat="45.978412" lon="-66.69597">
+<ele>12</ele>
+<time>2026-06-01T01:12:15Z</time></trkpt>
+<trkpt lat="45.978489" lon="-66.694513">
+<ele>12</ele>
+<time>2026-06-01T01:12:56Z</time></trkpt>
+<trkpt lat="45.978543" lon="-66.693878">
+<ele>11</ele>
+<time>2026-06-01T01:13:13Z</time></trkpt>
+<trkpt lat="45.978644" lon="-66.693042">
+<ele>10</ele>
+<time>2026-06-01T01:13:37Z</time></trkpt>
+<trkpt lat="45.978695" lon="-66.6927">
+<ele>10</ele>
+<time>2026-06-01T01:13:47Z</time></trkpt>
+<trkpt lat="45.978723" lon="-66.69264">
+<ele>10</ele>
+<time>2026-06-01T01:13:49Z</time></trkpt>
+<trkpt lat="45.978733" lon="-66.692631">
+<ele>10</ele>
+<time>2026-06-01T01:13:49Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.692608">
+<ele>10</ele>
+<time>2026-06-01T01:13:54Z</time></trkpt>
+<trkpt lat="45.978782" lon="-66.692065">
+<ele>10</ele>
+<time>2026-06-01T01:14:09Z</time></trkpt>
+<trkpt lat="45.979041" lon="-66.690623">
+<ele>16</ele>
+<time>2026-06-01T01:14:51Z</time></trkpt>
+<trkpt lat="45.979288" lon="-66.689529">
+<ele>17</ele>
+<time>2026-06-01T01:15:23Z</time></trkpt>
+<trkpt lat="45.981326" lon="-66.681447">
+<ele>12</ele>
+<time>2026-06-01T01:19:22Z</time></trkpt>
+<trkpt lat="45.982487" lon="-66.676841">
+<ele>15</ele>
+<time>2026-06-01T01:21:39Z</time></trkpt>
+<trkpt lat="45.985204" lon="-66.666054">
+<ele>8</ele>
+<time>2026-06-01T01:26:58Z</time></trkpt>
+<trkpt lat="45.985234" lon="-66.665874">
+<ele>7</ele>
+<time>2026-06-01T01:27:03Z</time></trkpt>
+<trkpt lat="45.985256" lon="-66.665378">
+<ele>9</ele>
+<time>2026-06-01T01:27:17Z</time></trkpt>
+<trkpt lat="45.985171" lon="-66.664557">
+<ele>11</ele>
+<time>2026-06-01T01:27:40Z</time></trkpt>
+<trkpt lat="45.98514" lon="-66.664376">
+<ele>12</ele>
+<time>2026-06-01T01:27:46Z</time></trkpt>
+<trkpt lat="45.985021" lon="-66.664005">
+<ele>12</ele>
+<time>2026-06-01T01:27:57Z</time></trkpt>
+<trkpt lat="45.984855" lon="-66.66363">
+<ele>12</ele>
+<time>2026-06-01T01:28:09Z</time></trkpt>
+<trkpt lat="45.98464" lon="-66.663258">
+<ele>14</ele>
+<time>2026-06-01T01:28:23Z</time></trkpt>
+<trkpt lat="45.984298" lon="-66.66288">
+<ele>15</ele>
+<time>2026-06-01T01:28:40Z</time></trkpt>
+<trkpt lat="45.984143" lon="-66.662745">
+<ele>16</ele>
+<time>2026-06-01T01:28:47Z</time></trkpt>
+<trkpt lat="45.9835" lon="-66.66236">
+<ele>16</ele>
+<time>2026-06-01T01:29:15Z</time></trkpt>
+<trkpt lat="45.98328" lon="-66.662203">
+<ele>16</ele>
+<time>2026-06-01T01:29:25Z</time></trkpt>
+<trkpt lat="45.982829" lon="-66.661806">
+<ele>17</ele>
+<time>2026-06-01T01:29:46Z</time></trkpt>
+<trkpt lat="45.982542" lon="-66.661474">
+<ele>18</ele>
+<time>2026-06-01T01:30:01Z</time></trkpt>
+<trkpt lat="45.982332" lon="-66.661179">
+<ele>18</ele>
+<time>2026-06-01T01:30:13Z</time></trkpt>
+<trkpt lat="45.982123" lon="-66.660807">
+<ele>18</ele>
+<time>2026-06-01T01:30:26Z</time></trkpt>
+<trkpt lat="45.98101" lon="-66.658415">
+<ele>13</ele>
+<time>2026-06-01T01:31:46Z</time></trkpt>
+<trkpt lat="45.98074" lon="-66.657895">
+<ele>12</ele>
+<time>2026-06-01T01:32:04Z</time></trkpt>
+<trkpt lat="45.980697" lon="-66.657702">
+<ele>12</ele>
+<time>2026-06-01T01:32:10Z</time></trkpt>
+<trkpt lat="45.980604" lon="-66.657551">
+<ele>11</ele>
+<time>2026-06-01T01:32:16Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-06-01T01:32:46Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-06-01T01:32:46Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-06-01T01:32:47Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-06-01T01:32:47Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-06-01T01:32:47Z</time></trkpt>
+<trkpt lat="45.979219" lon="-66.654489">
+<ele>18</ele>
+<time>2026-06-01T01:33:59Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-06-01T01:34:48Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-06-01T01:34:48Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-06-01T01:38:02Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-06-01T01:38:02Z</time></trkpt>
+<trkpt lat="45.975454" lon="-66.64332">
+<ele>15</ele>
+<time>2026-06-01T01:39:44Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-06-01T01:40:42Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-06-01T01:40:42Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-06-01T01:41:21Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-06-01T01:41:28Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-06-01T01:42:21Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-06-01T01:42:21Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-06-01T01:42:22Z</time></trkpt>
+<trkpt lat="45.9737509" lon="-66.6382492">
+<ele>11</ele>
+<time>2026-06-01T01:42:22Z</time></trkpt>
+<trkpt lat="45.9735813" lon="-66.6377503">
+<ele>11</ele>
+<time>2026-06-01T01:42:37Z</time></trkpt>
+<trkpt lat="45.9729717" lon="-66.6359103">
+<ele>10</ele>
+<time>2026-06-01T01:43:34Z</time></trkpt>
+<trkpt lat="45.9727555" lon="-66.6352236">
+<ele>12</ele>
+<time>2026-06-01T01:43:55Z</time></trkpt>
+<trkpt lat="45.9725244" lon="-66.6346014">
+<ele>15</ele>
+<time>2026-06-01T01:44:15Z</time></trkpt>
+<trkpt lat="45.9723976" lon="-66.6342688">
+<ele>16</ele>
+<time>2026-06-01T01:44:25Z</time></trkpt>
+<trkpt lat="45.9722634" lon="-66.6339362">
+<ele>16</ele>
+<time>2026-06-01T01:44:36Z</time></trkpt>
+<trkpt lat="45.9720919" lon="-66.6335714">
+<ele>16</ele>
+<time>2026-06-01T01:44:48Z</time></trkpt>
+<trkpt lat="45.9719129" lon="-66.6331744">
+<ele>15</ele>
+<time>2026-06-01T01:45:01Z</time></trkpt>
+<trkpt lat="45.9716818" lon="-66.6327238">
+<ele>14</ele>
+<time>2026-06-01T01:45:17Z</time></trkpt>
+<trkpt lat="45.9714208" lon="-66.6323483">
+<ele>14</ele>
+<time>2026-06-01T01:45:32Z</time></trkpt>
+<trkpt lat="45.9712354" lon="-66.6320807">
+<ele>14</ele>
+<time>2026-06-01T01:45:42Z</time></trkpt>
+<trkpt lat="45.9710181" lon="-66.6317689">
+<ele>14</ele>
+<time>2026-06-01T01:45:54Z</time></trkpt>
+<trkpt lat="45.9707571" lon="-66.6315114">
+<ele>13</ele>
+<time>2026-06-01T01:46:07Z</time></trkpt>
+<trkpt lat="45.9705632" lon="-66.6312754">
+<ele>13</ele>
+<time>2026-06-01T01:46:17Z</time></trkpt>
+<trkpt lat="45.9702724" lon="-66.6308463">
+<ele>12</ele>
+<time>2026-06-01T01:46:34Z</time></trkpt>
+<trkpt lat="45.9700785" lon="-66.6305244">
+<ele>12</ele>
+<time>2026-06-01T01:46:46Z</time></trkpt>
+<trkpt lat="45.9697877" lon="-66.6301167">
+<ele>11</ele>
+<time>2026-06-01T01:47:02Z</time></trkpt>
+<trkpt lat="45.9692881" lon="-66.629473">
+<ele>10</ele>
+<time>2026-06-01T01:47:29Z</time></trkpt>
+<trkpt lat="45.9685574" lon="-66.6285373">
+<ele>11</ele>
+<time>2026-06-01T01:48:08Z</time></trkpt>
+<trkpt lat="45.9675431" lon="-66.6272092">
+<ele>12</ele>
+<time>2026-06-01T01:49:03Z</time></trkpt>
+<trkpt lat="45.9664096" lon="-66.6257286">
+<ele>12</ele>
+<time>2026-06-01T01:50:05Z</time></trkpt>
+<trkpt lat="45.9658727" lon="-66.6250634">
+<ele>13</ele>
+<time>2026-06-01T01:50:33Z</time></trkpt>
+<trkpt lat="45.9653954" lon="-66.6243339">
+<ele>14</ele>
+<time>2026-06-01T01:51:01Z</time></trkpt>
+<trkpt lat="45.9644259" lon="-66.6230249">
+<ele>13</ele>
+<time>2026-06-01T01:51:54Z</time></trkpt>
+<trkpt lat="45.9632327" lon="-66.6214371">
+<ele>12</ele>
+<time>2026-06-01T01:52:59Z</time></trkpt>
+<trkpt lat="45.9626062" lon="-66.6206002">
+<ele>12</ele>
+<time>2026-06-01T01:53:34Z</time></trkpt>
+<trkpt lat="45.9619201" lon="-66.6197419">
+<ele>14</ele>
+<time>2026-06-01T01:54:10Z</time></trkpt>
+<trkpt lat="45.9613682" lon="-66.6193771">
+<ele>13</ele>
+<time>2026-06-01T01:54:34Z</time></trkpt>
+<trkpt lat="45.9609058" lon="-66.6192484">
+<ele>12</ele>
+<time>2026-06-01T01:54:53Z</time></trkpt>
+<trkpt lat="45.9603837" lon="-66.6192484">
+<ele>11</ele>
+<time>2026-06-01T01:55:14Z</time></trkpt>
+<trkpt lat="45.9598915" lon="-66.6194201">
+<ele>10</ele>
+<time>2026-06-01T01:55:34Z</time></trkpt>
+<trkpt lat="45.9595782" lon="-66.6192698">
+<ele>10</ele>
+<time>2026-06-01T01:55:48Z</time></trkpt>
+<trkpt lat="45.95958" lon="-66.619267">
+<ele>10</ele>
+<time>2026-06-01T01:55:48Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-06-01T01:55:48Z</time></trkpt>
+<trkpt lat="45.959574" lon="-66.619256">
+<ele>10</ele>
+<time>2026-06-01T01:55:48Z</time></trkpt>
+<trkpt lat="45.959572" lon="-66.6192542">
+<ele>10</ele>
+<time>2026-06-01T01:55:48Z</time></trkpt>
+<trkpt lat="45.9594916" lon="-66.6194552">
+<ele>10</ele>
+<time>2026-06-01T01:55:55Z</time></trkpt>
+<trkpt lat="45.9592734" lon="-66.6198601">
+<ele>9</ele>
+<time>2026-06-01T01:56:09Z</time></trkpt>
+<trkpt lat="45.9591243" lon="-66.6200801">
+<ele>9</ele>
+<time>2026-06-01T01:56:18Z</time></trkpt>
+<trkpt lat="45.9590068" lon="-66.6201579">
+<ele>10</ele>
+<time>2026-06-01T01:56:23Z</time></trkpt>
+<trkpt lat="45.958895" lon="-66.6202169">
+<ele>10</ele>
+<time>2026-06-01T01:56:28Z</time></trkpt>
+<trkpt lat="45.958895" lon="-66.620215">
+<ele>10</ele>
+<time>2026-06-01T01:56:28Z</time></trkpt>
+<trkpt lat="45.958898" lon="-66.620214">
+<ele>10</ele>
+<time>2026-06-01T01:56:28Z</time></trkpt>
+<trkpt lat="45.959154" lon="-66.620054">
+<ele>9</ele>
+<time>2026-06-01T01:56:39Z</time></trkpt>
+<trkpt lat="45.959428" lon="-66.619587">
+<ele>9</ele>
+<time>2026-06-01T01:56:56Z</time></trkpt>
+<trkpt lat="45.959542" lon="-66.619336">
+<ele>10</ele>
+<time>2026-06-01T01:57:04Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-06-01T01:57:07Z</time></trkpt>
+<trkpt lat="45.959588" lon="-66.619275">
+<ele>10</ele>
+<time>2026-06-01T01:57:08Z</time></trkpt>
+<trkpt lat="45.9595809" lon="-66.6192893">
+<ele>10</ele>
+<time>2026-06-01T01:57:08Z</time></trkpt>
+<trkpt lat="45.9589879" lon="-66.6203308">
+<ele>10</ele>
+<time>2026-06-01T01:57:45Z</time></trkpt>
+<trkpt lat="45.9584583" lon="-66.6215003">
+<ele>10</ele>
+<time>2026-06-01T01:58:24Z</time></trkpt>
+<trkpt lat="45.9580854" lon="-66.6235068">
+<ele>7</ele>
+<time>2026-06-01T01:59:22Z</time></trkpt>
+<trkpt lat="45.9574365" lon="-66.6271979">
+<ele>2</ele>
+<time>2026-06-01T02:01:08Z</time></trkpt>
+<trkpt lat="45.9564882" lon="-66.6325076">
+<ele>5</ele>
+<time>2026-06-01T02:03:41Z</time></trkpt>
+<trkpt lat="45.9562495" lon="-66.6339015">
+<ele>9</ele>
+<time>2026-06-01T02:04:21Z</time></trkpt>
+<trkpt lat="45.956247" lon="-66.6339">
+<ele>9</ele>
+<time>2026-06-01T02:04:21Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-06-01T02:04:34Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-06-01T02:04:41Z</time></trkpt>
+<trkpt lat="45.955902" lon="-66.634947">
+<ele>10</ele>
+<time>2026-06-01T02:04:54Z</time></trkpt>
+<trkpt lat="45.955902" lon="-66.634947">
+<ele>10</ele>
+<time>2026-06-01T02:04:54Z</time></trkpt>
+<trkpt lat="45.955809" lon="-66.635139">
+<ele>10</ele>
+<time>2026-06-01T02:05:00Z</time></trkpt>
+<trkpt lat="45.955809" lon="-66.635139">
+<ele>10</ele>
+<time>2026-06-01T02:05:00Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-06-01T02:05:05Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-06-01T02:05:10Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-06-01T02:05:10Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-06-01T02:05:27Z</time></trkpt>
+<trkpt lat="45.9549" lon="-66.636123">
+<ele>10</ele>
+<time>2026-06-01T02:05:46Z</time></trkpt>
+<trkpt lat="45.9549" lon="-66.636123">
+<ele>10</ele>
+<time>2026-06-01T02:05:46Z</time></trkpt>
+<trkpt lat="45.953965" lon="-66.636905">
+<ele>9</ele>
+<time>2026-06-01T02:06:30Z</time></trkpt>
+<trkpt lat="45.953965" lon="-66.636905">
+<ele>9</ele>
+<time>2026-06-01T02:06:30Z</time></trkpt>
+<trkpt lat="45.953053" lon="-66.637674">
+<ele>8</ele>
+<time>2026-06-01T02:07:12Z</time></trkpt>
+<trkpt lat="45.953053" lon="-66.637674">
+<ele>8</ele>
+<time>2026-06-01T02:07:12Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-06-01T02:07:13Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-06-01T02:07:19Z</time></trkpt>
+<trkpt lat="45.9536" lon="-66.639076">
+<ele>9</ele>
+<time>2026-06-01T02:07:58Z</time></trkpt>
+<trkpt lat="45.953614" lon="-66.639064">
+<ele>9</ele>
+<time>2026-06-01T02:07:59Z</time></trkpt>
+<trkpt lat="45.953614" lon="-66.639064">
+<ele>9</ele>
+<time>2026-06-01T02:07:59Z</time></trkpt>
+<trkpt lat="45.9536" lon="-66.639076">
+<ele>9</ele>
+<time>2026-06-01T02:08:00Z</time></trkpt>
+<trkpt lat="45.954552" lon="-66.641325">
+<ele>10</ele>
+<time>2026-06-01T02:09:13Z</time></trkpt>
+<trkpt lat="45.954552" lon="-66.641325">
+<ele>10</ele>
+<time>2026-06-01T02:09:13Z</time></trkpt>
+<trkpt lat="45.954559" lon="-66.641341">
+<ele>10</ele>
+<time>2026-06-01T02:09:13Z</time></trkpt>
+<trkpt lat="45.953274" lon="-66.642464">
+<ele>9</ele>
+<time>2026-06-01T02:10:14Z</time></trkpt>
+<trkpt lat="45.953274" lon="-66.642464">
+<ele>9</ele>
+<time>2026-06-01T02:10:14Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.642474">
+<ele>9</ele>
+<time>2026-06-01T02:10:14Z</time></trkpt>
+<trkpt lat="45.95313" lon="-66.642248">
+<ele>8</ele>
+<time>2026-06-01T02:10:22Z</time></trkpt>
+<trkpt lat="45.952945" lon="-66.642015">
+<ele>8</ele>
+<time>2026-06-01T02:10:32Z</time></trkpt>
+<trkpt lat="45.952945" lon="-66.642015">
+<ele>8</ele>
+<time>2026-06-01T02:10:32Z</time></trkpt>
+<trkpt lat="45.952837" lon="-66.641845">
+<ele>7</ele>
+<time>2026-06-01T02:10:39Z</time></trkpt>
+<trkpt lat="45.952607" lon="-66.641307">
+<ele>8</ele>
+<time>2026-06-01T02:10:56Z</time></trkpt>
+<trkpt lat="45.952607" lon="-66.641307">
+<ele>8</ele>
+<time>2026-06-01T02:10:56Z</time></trkpt>
+<trkpt lat="45.952272" lon="-66.640526">
+<ele>9</ele>
+<time>2026-06-01T02:11:22Z</time></trkpt>
+<trkpt lat="45.952272" lon="-66.640526">
+<ele>9</ele>
+<time>2026-06-01T02:11:22Z</time></trkpt>
+<trkpt lat="45.952164" lon="-66.640423">
+<ele>9</ele>
+<time>2026-06-01T02:11:27Z</time></trkpt>
+<trkpt lat="45.952078" lon="-66.640406">
+<ele>10</ele>
+<time>2026-06-01T02:11:31Z</time></trkpt>
+<trkpt lat="45.952065" lon="-66.640308">
+<ele>10</ele>
+<time>2026-06-01T02:11:33Z</time></trkpt>
+<trkpt lat="45.952016" lon="-66.640322">
+<ele>10</ele>
+<time>2026-06-01T02:11:35Z</time></trkpt>
+<trkpt lat="45.952016" lon="-66.640322">
+<ele>10</ele>
+<time>2026-06-01T02:11:35Z</time></trkpt>
+<trkpt lat="45.951885" lon="-66.640411">
+<ele>10</ele>
+<time>2026-06-01T02:11:41Z</time></trkpt>
+<trkpt lat="45.951918" lon="-66.640503">
+<ele>10</ele>
+<time>2026-06-01T02:11:44Z</time></trkpt>
+<trkpt lat="45.951799" lon="-66.640615">
+<ele>10</ele>
+<time>2026-06-01T02:11:50Z</time></trkpt>
+<trkpt lat="45.951752" lon="-66.640682">
+<ele>10</ele>
+<time>2026-06-01T02:11:52Z</time></trkpt>
+<trkpt lat="45.951752" lon="-66.640682">
+<ele>10</ele>
+<time>2026-06-01T02:11:52Z</time></trkpt>
+<trkpt lat="45.95166" lon="-66.640814">
+<ele>10</ele>
+<time>2026-06-01T02:11:58Z</time></trkpt>
+<trkpt lat="45.95163" lon="-66.640884">
+<ele>10</ele>
+<time>2026-06-01T02:12:00Z</time></trkpt>
+<trkpt lat="45.951567" lon="-66.640825">
+<ele>10</ele>
+<time>2026-06-01T02:12:03Z</time></trkpt>
+<trkpt lat="45.951482" lon="-66.641095">
+<ele>9</ele>
+<time>2026-06-01T02:12:11Z</time></trkpt>
+<trkpt lat="45.951482" lon="-66.641095">
+<ele>9</ele>
+<time>2026-06-01T02:12:11Z</time></trkpt>
+<trkpt lat="45.951476" lon="-66.641114">
+<ele>9</ele>
+<time>2026-06-01T02:12:12Z</time></trkpt>
+<trkpt lat="45.951308" lon="-66.641177">
+<ele>9</ele>
+<time>2026-06-01T02:12:19Z</time></trkpt>
+<trkpt lat="45.951308" lon="-66.641177">
+<ele>9</ele>
+<time>2026-06-01T02:12:19Z</time></trkpt>
+<trkpt lat="45.951244" lon="-66.64119">
+<ele>10</ele>
+<time>2026-06-01T02:12:21Z</time></trkpt>
+<trkpt lat="45.951091" lon="-66.641168">
+<ele>10</ele>
+<time>2026-06-01T02:12:27Z</time></trkpt>
+<trkpt lat="45.950944" lon="-66.64109">
+<ele>11</ele>
+<time>2026-06-01T02:12:34Z</time></trkpt>
+<trkpt lat="45.951036" lon="-66.64123">
+<ele>11</ele>
+<time>2026-06-01T02:12:39Z</time></trkpt>
+<trkpt lat="45.951036" lon="-66.64123">
+<ele>11</ele>
+<time>2026-06-01T02:12:39Z</time></trkpt>
+<trkpt lat="45.95021" lon="-66.640061">
+<ele>11</ele>
+<time>2026-06-01T02:13:26Z</time></trkpt>
+<trkpt lat="45.950211" lon="-66.64005">
+<ele>11</ele>
+<time>2026-06-01T02:13:26Z</time></trkpt>
+<trkpt lat="45.950211" lon="-66.64005">
+<ele>11</ele>
+<time>2026-06-01T02:13:26Z</time></trkpt>
+<trkpt lat="45.95024" lon="-66.639638">
+<ele>10</ele>
+<time>2026-06-01T02:13:37Z</time></trkpt>
+<trkpt lat="45.950231" lon="-66.639635">
+<ele>10</ele>
+<time>2026-06-01T02:13:38Z</time></trkpt>
+<trkpt lat="45.950231" lon="-66.639635">
+<ele>10</ele>
+<time>2026-06-01T02:13:38Z</time></trkpt>
+<trkpt lat="45.950589" lon="-66.639644">
+<ele>10</ele>
+<time>2026-06-01T02:13:52Z</time></trkpt>
+<trkpt lat="45.950737" lon="-66.639597">
+<ele>10</ele>
+<time>2026-06-01T02:13:58Z</time></trkpt>
+<trkpt lat="45.950737" lon="-66.639597">
+<ele>10</ele>
+<time>2026-06-01T02:13:58Z</time></trkpt>
+<trkpt lat="45.951004" lon="-66.639437">
+<ele>10</ele>
+<time>2026-06-01T02:14:10Z</time></trkpt>
+<trkpt lat="45.951181" lon="-66.639287">
+<ele>9</ele>
+<time>2026-06-01T02:14:18Z</time></trkpt>
+<trkpt lat="45.951181" lon="-66.639287">
+<ele>9</ele>
+<time>2026-06-01T02:14:18Z</time></trkpt>
+<trkpt lat="45.951746" lon="-66.638803">
+<ele>8</ele>
+<time>2026-06-01T02:14:44Z</time></trkpt>
+<trkpt lat="45.951743" lon="-66.6388">
+<ele>8</ele>
+<time>2026-06-01T02:14:45Z</time></trkpt>
+<trkpt lat="45.951743" lon="-66.6388">
+<ele>8</ele>
+<time>2026-06-01T02:14:45Z</time></trkpt>
+<trkpt lat="45.951746" lon="-66.638803">
+<ele>8</ele>
+<time>2026-06-01T02:14:45Z</time></trkpt>
+<trkpt lat="45.952965" lon="-66.637749">
+<ele>8</ele>
+<time>2026-06-01T02:15:42Z</time></trkpt>
+<trkpt lat="45.952965" lon="-66.637749">
+<ele>8</ele>
+<time>2026-06-01T02:15:42Z</time></trkpt>
+<trkpt lat="45.953973" lon="-66.636898">
+<ele>9</ele>
+<time>2026-06-01T02:16:28Z</time></trkpt>
+<trkpt lat="45.953973" lon="-66.636898">
+<ele>9</ele>
+<time>2026-06-01T02:16:28Z</time></trkpt>
+<trkpt lat="45.954912" lon="-66.636113">
+<ele>10</ele>
+<time>2026-06-01T02:17:12Z</time></trkpt>
+<trkpt lat="45.954912" lon="-66.636113">
+<ele>10</ele>
+<time>2026-06-01T02:17:12Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-06-01T02:17:31Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-06-01T02:17:48Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-06-01T02:17:52Z</time></trkpt>
+<trkpt lat="45.955794" lon="-66.63517">
+<ele>10</ele>
+<time>2026-06-01T02:17:57Z</time></trkpt>
+<trkpt lat="45.955794" lon="-66.63517">
+<ele>10</ele>
+<time>2026-06-01T02:17:57Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-06-01T02:18:17Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-06-01T02:18:24Z</time></trkpt>
+<trkpt lat="45.956304" lon="-66.633616">
+<ele>8</ele>
+<time>2026-06-01T02:18:45Z</time></trkpt>
+<trkpt lat="45.956304" lon="-66.633616">
+<ele>8</ele>
+<time>2026-06-01T02:18:45Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-06-01T02:19:08Z</time></trkpt>
+<trkpt lat="45.956497" lon="-66.632517">
+<ele>5</ele>
+<time>2026-06-01T02:19:16Z</time></trkpt>
+<trkpt lat="45.956497" lon="-66.632517">
+<ele>5</ele>
+<time>2026-06-01T02:19:16Z</time></trkpt>
+<trkpt lat="45.957091" lon="-66.629159">
+<ele>2</ele>
+<time>2026-06-01T02:20:53Z</time></trkpt>
+<trkpt lat="45.957091" lon="-66.629159">
+<ele>2</ele>
+<time>2026-06-01T02:20:53Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-06-01T02:22:48Z</time></trkpt>
+<trkpt lat="45.957852" lon="-66.624821">
+<ele>4</ele>
+<time>2026-06-01T02:22:58Z</time></trkpt>
+<trkpt lat="45.957852" lon="-66.624821">
+<ele>4</ele>
+<time>2026-06-01T02:22:58Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-06-01T02:23:05Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-06-01T02:23:09Z</time></trkpt>
+<trkpt lat="45.957941" lon="-66.624263">
+<ele>6</ele>
+<time>2026-06-01T02:23:14Z</time></trkpt>
+<trkpt lat="45.958013" lon="-66.623831">
+<ele>7</ele>
+<time>2026-06-01T02:23:26Z</time></trkpt>
+<trkpt lat="45.958013" lon="-66.623831">
+<ele>7</ele>
+<time>2026-06-01T02:23:26Z</time></trkpt>
+<trkpt lat="45.958301" lon="-66.622218">
+<ele>10</ele>
+<time>2026-06-01T02:24:12Z</time></trkpt>
+<trkpt lat="45.958328" lon="-66.622067">
+<ele>10</ele>
+<time>2026-06-01T02:24:17Z</time></trkpt>
+<trkpt lat="45.958328" lon="-66.622067">
+<ele>10</ele>
+<time>2026-06-01T02:24:17Z</time></trkpt>
+<trkpt lat="45.958397" lon="-66.621747">
+<ele>10</ele>
+<time>2026-06-01T02:24:26Z</time></trkpt>
+<trkpt lat="45.958397" lon="-66.621747">
+<ele>10</ele>
+<time>2026-06-01T02:24:26Z</time></trkpt>
+<trkpt lat="45.958433" lon="-66.621584">
+<ele>10</ele>
+<time>2026-06-01T02:24:31Z</time></trkpt>
+<trkpt lat="45.958486" lon="-66.621393">
+<ele>10</ele>
+<time>2026-06-01T02:24:37Z</time></trkpt>
+<trkpt lat="45.958561" lon="-66.621199">
+<ele>10</ele>
+<time>2026-06-01T02:24:43Z</time></trkpt>
+<trkpt lat="45.958561" lon="-66.621199">
+<ele>10</ele>
+<time>2026-06-01T02:24:43Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-06-01T02:24:52Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-06-01T02:25:04Z</time></trkpt>
+<trkpt lat="45.958915" lon="-66.620444">
+<ele>10</ele>
+<time>2026-06-01T02:25:08Z</time></trkpt>
+<trkpt lat="45.958915" lon="-66.620444">
+<ele>10</ele>
+<time>2026-06-01T02:25:08Z</time></trkpt>
+<trkpt lat="45.958962" lon="-66.62037">
+<ele>10</ele>
+<time>2026-06-01T02:25:11Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620304">
+<ele>10</ele>
+<time>2026-06-01T02:25:13Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620304">
+<ele>10</ele>
+<time>2026-06-01T02:25:13Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620292">
+<ele>10</ele>
+<time>2026-06-01T02:25:13Z</time></trkpt>
+<trkpt lat="45.95894" lon="-66.620251">
+<ele>10</ele>
+<time>2026-06-01T02:25:15Z</time></trkpt>
+<trkpt lat="45.958898" lon="-66.620214">
+<ele>10</ele>
+<time>2026-06-01T02:25:17Z</time></trkpt>
+<trkpt lat="45.958905" lon="-66.62021">
+<ele>10</ele>
+<time>2026-06-01T02:25:17Z</time></trkpt>
+<trkpt lat="45.958905" lon="-66.62021">
+<ele>10</ele>
+<time>2026-06-01T02:25:17Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-06-01T02:25:17Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-06-01T02:25:17Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-06-01T02:25:17Z</time></trkpt>
+<trkpt lat="45.958625" lon="-66.620306">
+<ele>9</ele>
+<time>2026-06-01T02:25:29Z</time></trkpt>
+<trkpt lat="45.95833" lon="-66.620318">
+<ele>9</ele>
+<time>2026-06-01T02:25:41Z</time></trkpt>
+<trkpt lat="45.958134" lon="-66.620282">
+<ele>9</ele>
+<time>2026-06-01T02:25:48Z</time></trkpt>
+<trkpt lat="45.957933" lon="-66.620207">
+<ele>9</ele>
+<time>2026-06-01T02:25:57Z</time></trkpt>
+<trkpt lat="45.957728" lon="-66.620097">
+<ele>9</ele>
+<time>2026-06-01T02:26:06Z</time></trkpt>
+<trkpt lat="45.95718" lon="-66.619732">
+<ele>6</ele>
+<time>2026-06-01T02:26:30Z</time></trkpt>
+<trkpt lat="45.956327" lon="-66.619138">
+<ele>3</ele>
+<time>2026-06-01T02:27:08Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-06-01T02:27:40Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-06-01T02:27:40Z</time></trkpt>
+<trkpt lat="45.953955" lon="-66.617486">
+<ele>10</ele>
+<time>2026-06-01T02:28:53Z</time></trkpt>
+<trkpt lat="45.953846" lon="-66.617411">
+<ele>10</ele>
+<time>2026-06-01T02:28:58Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-06-01T02:29:01Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-06-01T02:29:01Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-06-01T02:29:01Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-06-01T02:29:01Z</time></trkpt>
+<trkpt lat="45.953661" lon="-66.617407">
+<ele>9</ele>
+<time>2026-06-01T02:29:06Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-06-01T02:29:16Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-06-01T02:29:16Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-06-01T02:30:23Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-06-01T02:30:23Z</time></trkpt>
+<trkpt lat="45.95177" lon="-66.615978">
+<ele>10</ele>
+<time>2026-06-01T02:30:32Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-06-01T02:31:00Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-06-01T02:31:00Z</time></trkpt>
+<trkpt lat="45.950773" lon="-66.615278">
+<ele>9</ele>
+<time>2026-06-01T02:31:16Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-06-01T02:31:49Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-06-01T02:31:49Z</time></trkpt>
+<trkpt lat="45.950003" lon="-66.614738">
+<ele>9</ele>
+<time>2026-06-01T02:31:51Z</time></trkpt>
+<trkpt lat="45.949917" lon="-66.614497">
+<ele>9</ele>
+<time>2026-06-01T02:31:58Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-06-01T02:32:00Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-06-01T02:32:00Z</time></trkpt>
+<trkpt lat="45.949908" lon="-66.614348">
+<ele>9</ele>
+<time>2026-06-01T02:32:03Z</time></trkpt>
+<trkpt lat="45.949942" lon="-66.614185">
+<ele>9</ele>
+<time>2026-06-01T02:32:07Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-06-01T02:32:11Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-06-01T02:32:11Z</time></trkpt>
+<trkpt lat="45.950333" lon="-66.613966">
+<ele>9</ele>
+<time>2026-06-01T02:32:24Z</time></trkpt>
+<trkpt lat="45.950635" lon="-66.613663">
+<ele>10</ele>
+<time>2026-06-01T02:32:39Z</time></trkpt>
+<trkpt lat="45.950902" lon="-66.61323">
+<ele>10</ele>
+<time>2026-06-01T02:32:55Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-06-01T02:33:09Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-06-01T02:33:09Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-06-01T02:33:09Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-06-01T02:33:10Z</time></trkpt>
+<trkpt lat="45.951176" lon="-66.612384">
+<ele>10</ele>
+<time>2026-06-01T02:33:22Z</time></trkpt>
+<trkpt lat="45.951354" lon="-66.611746">
+<ele>10</ele>
+<time>2026-06-01T02:33:41Z</time></trkpt>
+<trkpt lat="45.95143" lon="-66.61128">
+<ele>10</ele>
+<time>2026-06-01T02:33:55Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-06-01T02:34:02Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-06-01T02:34:03Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-06-01T02:34:03Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-06-01T02:34:04Z</time></trkpt>
+<trkpt lat="45.951461" lon="-66.610792">
+<ele>10</ele>
+<time>2026-06-01T02:34:10Z</time></trkpt>
+<trkpt lat="45.951556" lon="-66.610483">
+<ele>10</ele>
+<time>2026-06-01T02:34:19Z</time></trkpt>
+<trkpt lat="45.951635" lon="-66.610362">
+<ele>10</ele>
+<time>2026-06-01T02:34:24Z</time></trkpt>
+<trkpt lat="45.951716" lon="-66.610289">
+<ele>10</ele>
+<time>2026-06-01T02:34:27Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-06-01T02:34:30Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-06-01T02:34:30Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-06-01T02:35:33Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-06-01T02:35:33Z</time></trkpt>
+<trkpt lat="45.952532" lon="-66.607543">
+<ele>12</ele>
+<time>2026-06-01T02:35:51Z</time></trkpt>
+<trkpt lat="45.952784" lon="-66.607017">
+<ele>10</ele>
+<time>2026-06-01T02:36:09Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-06-01T02:36:34Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-06-01T02:36:34Z</time></trkpt>
+<trkpt lat="45.953282" lon="-66.606382">
+<ele>10</ele>
+<time>2026-06-01T02:36:35Z</time></trkpt>
+<trkpt lat="45.953384" lon="-66.606251">
+<ele>10</ele>
+<time>2026-06-01T02:36:41Z</time></trkpt>
+<trkpt lat="45.953925" lon="-66.605723">
+<ele>10</ele>
+<time>2026-06-01T02:37:07Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-06-01T02:37:22Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-06-01T02:37:22Z</time></trkpt>
+<trkpt lat="45.954387" lon="-66.605232">
+<ele>10</ele>
+<time>2026-06-01T02:37:30Z</time></trkpt>
+<trkpt lat="45.954745" lon="-66.60476">
+<ele>10</ele>
+<time>2026-06-01T02:37:50Z</time></trkpt>
+<trkpt lat="45.955223" lon="-66.603919">
+<ele>10</ele>
+<time>2026-06-01T02:38:20Z</time></trkpt>
+<trkpt lat="45.955571" lon="-66.603154">
+<ele>12</ele>
+<time>2026-06-01T02:38:45Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-06-01T02:40:14Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-06-01T02:40:14Z</time></trkpt>
+<trkpt lat="45.958914" lon="-66.596075">
+<ele>15</ele>
+<time>2026-06-01T02:42:44Z</time></trkpt>
+<trkpt lat="45.959408" lon="-66.595054">
+<ele>12</ele>
+<time>2026-06-01T02:43:18Z</time></trkpt>
+<trkpt lat="45.959986" lon="-66.593886">
+<ele>9</ele>
+<time>2026-06-01T02:43:58Z</time></trkpt>
+<trkpt lat="45.960677" lon="-66.592592">
+<ele>10</ele>
+<time>2026-06-01T02:44:44Z</time></trkpt>
+<trkpt lat="45.960883" lon="-66.592242">
+<ele>11</ele>
+<time>2026-06-01T02:44:57Z</time></trkpt>
+<trkpt lat="45.96131" lon="-66.591631">
+<ele>11</ele>
+<time>2026-06-01T02:45:21Z</time></trkpt>
+<trkpt lat="45.963861" lon="-66.588577">
+<ele>12</ele>
+<time>2026-06-01T02:47:34Z</time></trkpt>
+<trkpt lat="45.964377" lon="-66.587911">
+<ele>11</ele>
+<time>2026-06-01T02:48:01Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-06-01T02:48:15Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-06-01T02:48:15Z</time></trkpt>
+<trkpt lat="45.965429" lon="-66.586262">
+<ele>7</ele>
+<time>2026-06-01T02:49:04Z</time></trkpt>
+<trkpt lat="45.966107" lon="-66.585312">
+<ele>8</ele>
+<time>2026-06-01T02:49:42Z</time></trkpt>
+<trkpt lat="45.966364" lon="-66.585057">
+<ele>8</ele>
+<time>2026-06-01T02:49:54Z</time></trkpt>
+<trkpt lat="45.966634" lon="-66.584828">
+<ele>8</ele>
+<time>2026-06-01T02:50:07Z</time></trkpt>
+<trkpt lat="45.96688" lon="-66.584676">
+<ele>8</ele>
+<time>2026-06-01T02:50:18Z</time></trkpt>
+<trkpt lat="45.96727" lon="-66.584548">
+<ele>8</ele>
+<time>2026-06-01T02:50:34Z</time></trkpt>
+<trkpt lat="45.967399" lon="-66.584523">
+<ele>8</ele>
+<time>2026-06-01T02:50:39Z</time></trkpt>
+<trkpt lat="45.967658" lon="-66.584517">
+<ele>8</ele>
+<time>2026-06-01T02:50:49Z</time></trkpt>
+<trkpt lat="45.967891" lon="-66.584555">
+<ele>9</ele>
+<time>2026-06-01T02:50:59Z</time></trkpt>
+<trkpt lat="45.968123" lon="-66.584619">
+<ele>8</ele>
+<time>2026-06-01T02:51:08Z</time></trkpt>
+<trkpt lat="45.96836" lon="-66.584715">
+<ele>8</ele>
+<time>2026-06-01T02:51:18Z</time></trkpt>
+<trkpt lat="45.968593" lon="-66.584857">
+<ele>8</ele>
+<time>2026-06-01T02:51:28Z</time></trkpt>
+<trkpt lat="45.972289" lon="-66.587553">
+<ele>10</ele>
+<time>2026-06-01T02:54:14Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-06-01T02:54:42Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-06-01T02:54:42Z</time></trkpt>
+<trkpt lat="45.973398" lon="-66.588427">
+<ele>9</ele>
+<time>2026-06-01T02:55:05Z</time></trkpt>
+<trkpt lat="45.973712" lon="-66.588627">
+<ele>8</ele>
+<time>2026-06-01T02:55:19Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-06-01T02:55:30Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-06-01T02:55:30Z</time></trkpt>
+<trkpt lat="45.974595" lon="-66.589095">
+<ele>8</ele>
+<time>2026-06-01T02:55:56Z</time></trkpt>
+<trkpt lat="45.974902" lon="-66.589197">
+<ele>9</ele>
+<time>2026-06-01T02:56:09Z</time></trkpt>
+<trkpt lat="45.97523" lon="-66.589266">
+<ele>9</ele>
+<time>2026-06-01T02:56:22Z</time></trkpt>
+<trkpt lat="45.975815" lon="-66.589324">
+<ele>9</ele>
+<time>2026-06-01T02:56:46Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-06-01T02:57:02Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-06-01T02:57:02Z</time></trkpt>
+<trkpt lat="45.976297" lon="-66.589324">
+<ele>10</ele>
+<time>2026-06-01T02:57:05Z</time></trkpt>
+<trkpt lat="45.976388" lon="-66.589479">
+<ele>10</ele>
+<time>2026-06-01T02:57:11Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-06-01T02:57:12Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-06-01T02:57:12Z</time></trkpt>
+<trkpt lat="45.97647" lon="-66.58953">
+<ele>10</ele>
+<time>2026-06-01T02:57:14Z</time></trkpt>
+<trkpt lat="45.976864" lon="-66.589543">
+<ele>11</ele>
+<time>2026-06-01T02:57:30Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-06-01T02:58:24Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-06-01T02:58:24Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-06-01T02:58:47Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-06-01T02:58:47Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.589547">
+<ele>11</ele>
+<time>2026-06-01T02:58:48Z</time></trkpt>
+<trkpt lat="45.978813" lon="-66.589615">
+<ele>10</ele>
+<time>2026-06-01T02:58:50Z</time></trkpt>
+<trkpt lat="45.978811" lon="-66.589684">
+<ele>10</ele>
+<time>2026-06-01T02:58:52Z</time></trkpt>
+<trkpt lat="45.978846" lon="-66.589722">
+<ele>10</ele>
+<time>2026-06-01T02:58:54Z</time></trkpt>
+<trkpt lat="45.978852" lon="-66.589755">
+<ele>10</ele>
+<time>2026-06-01T02:58:55Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-06-01T02:58:56Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-06-01T02:58:56Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-06-01T02:59:34Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-06-01T02:59:34Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.591785">
+<ele>11</ele>
+<time>2026-06-01T02:59:51Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-06-01T02:59:55Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-06-01T02:59:56Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-06-01T02:59:56Z</time></trkpt>
+<trkpt lat="45.978817" lon="-66.591903">
+<ele>12</ele>
+<time>2026-06-01T02:59:59Z</time></trkpt>
+<trkpt lat="45.978817" lon="-66.591903">
+<ele>12</ele>
+<time>2026-06-01T02:59:59Z</time></trkpt>
+<trkpt lat="45.978817" lon="-66.591903">
+<ele>12</ele>
+<time>2026-06-01T02:59:59Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-06-01T03:00:03Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-06-01T03:00:13Z</time></trkpt>
+<trkpt lat="45.979505" lon="-66.591875">
+<ele>12</ele>
+<time>2026-06-01T03:00:26Z</time></trkpt>
+<trkpt lat="45.979505" lon="-66.591875">
+<ele>12</ele>
+<time>2026-06-01T03:00:26Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-06-01T03:00:36Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-06-01T03:01:12Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-06-01T03:01:38Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-06-01T03:02:40Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-06-01T03:03:01Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-06-01T03:03:57Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-06-01T03:04:18Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-06-01T03:04:37Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-06-01T03:04:50Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-06-01T03:05:07Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-06-01T03:05:28Z</time></trkpt>
+<trkpt lat="45.986955" lon="-66.589677">
+<ele>12</ele>
+<time>2026-06-01T03:05:46Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-06-01T03:05:52Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-06-01T03:06:30Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-06-01T03:07:00Z</time></trkpt>
+<trkpt lat="45.987926" lon="-66.586193">
+<ele>11</ele>
+<time>2026-06-01T03:07:30Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-06-01T03:07:44Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-06-01T03:08:32Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-06-01T03:08:41Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-06-01T03:08:49Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-06-01T03:09:31Z</time></trkpt>
+<trkpt lat="45.990072" lon="-66.581083">
+<ele>13</ele>
+<time>2026-06-01T03:10:17Z</time></trkpt>
+<trkpt lat="45.990072" lon="-66.581083">
+<ele>13</ele>
+<time>2026-06-01T03:10:17Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-06-01T03:11:02Z</time></trkpt>
+<trkpt lat="45.9908" lon="-66.579277">
+<ele>13</ele>
+<time>2026-06-01T03:11:15Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-06-01T03:11:21Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-06-01T03:11:33Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-06-01T03:11:40Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-06-01T03:14:45Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-06-01T03:15:00Z</time></trkpt>
+<trkpt lat="45.995971" lon="-66.574397">
+<ele>4</ele>
+<time>2026-06-01T03:15:24Z</time></trkpt>
+<trkpt lat="45.995971" lon="-66.574397">
+<ele>4</ele>
+<time>2026-06-01T03:15:24Z</time></trkpt>
+<trkpt lat="45.995981" lon="-66.574392">
+<ele>4</ele>
+<time>2026-06-01T03:15:25Z</time></trkpt>
+<trkpt lat="45.9959839" lon="-66.5744058">
+<ele>4</ele>
+<time>2026-06-01T03:15:25Z</time></trkpt>
+<trkpt lat="45.995981" lon="-66.574392">
+<ele>4</ele>
+<time>2026-06-01T03:15:25Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T03:15:26Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T03:15:27Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T03:15:28Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-06-01T03:16:17Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-06-01T03:16:30Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T03:16:38Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T03:16:38Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-06-01T03:16:49Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-06-01T03:16:56Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-06-01T03:17:11Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T03:17:27Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T03:17:27Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-06-01T03:17:34Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-06-01T03:18:14Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-06-01T03:18:39Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T03:18:48Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T03:18:48Z</time></trkpt>
+<trkpt lat="46.002683" lon="-66.575951">
+<ele>14</ele>
+<time>2026-06-01T03:20:09Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T03:21:30Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T03:21:30Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-06-01T03:21:39Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-06-01T03:22:04Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-06-01T03:22:44Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T03:22:51Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T03:22:51Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-06-01T03:23:07Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-06-01T03:23:22Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-06-01T03:23:29Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T03:23:40Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T03:23:40Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-06-01T03:23:48Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-06-01T03:24:01Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T03:24:50Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T03:24:51Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T03:24:52Z</time></trkpt>
+<trkpt lat="45.995981" lon="-66.574392">
+<ele>4</ele>
+<time>2026-06-01T03:24:53Z</time></trkpt>
+<trkpt lat="45.9959839" lon="-66.5744058">
+<ele>4</ele>
+<time>2026-06-01T03:24:53Z</time></trkpt>
+<trkpt lat="45.995981" lon="-66.574392">
+<ele>4</ele>
+<time>2026-06-01T03:24:53Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T03:24:54Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T03:24:55Z</time></trkpt>
+<trkpt lat="45.996057" lon="-66.574357">
+<ele>4</ele>
+<time>2026-06-01T03:24:57Z</time></trkpt>
+<trkpt lat="45.996057" lon="-66.574357">
+<ele>4</ele>
+<time>2026-06-01T03:24:57Z</time></trkpt>
+<trkpt lat="45.996057" lon="-66.574357">
+<ele>4</ele>
+<time>2026-06-01T03:24:57Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T03:24:59Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T03:25:00Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-06-01T03:25:25Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-06-01T03:25:40Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-06-01T03:28:45Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-06-01T03:28:52Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-06-01T03:29:04Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-06-01T03:29:23Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-06-01T03:30:54Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-06-01T03:31:36Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-06-01T03:31:44Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-06-01T03:31:53Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-06-01T03:32:41Z</time></trkpt>
+<trkpt lat="45.987851" lon="-66.586415">
+<ele>11</ele>
+<time>2026-06-01T03:33:01Z</time></trkpt>
+<trkpt lat="45.987819" lon="-66.586563">
+<ele>11</ele>
+<time>2026-06-01T03:33:06Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-06-01T03:33:25Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-06-01T03:33:55Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-06-01T03:34:33Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-06-01T03:34:57Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-06-01T03:35:18Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-06-01T03:35:34Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-06-01T03:35:48Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-06-01T03:36:07Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-06-01T03:36:28Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-06-01T03:37:24Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-06-01T03:37:45Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-06-01T03:38:47Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-06-01T03:39:12Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-06-01T03:39:48Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-06-01T03:40:12Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-06-01T03:40:22Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.591896">
+<ele>12</ele>
+<time>2026-06-01T03:40:25Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.591931">
+<ele>12</ele>
+<time>2026-06-01T03:40:26Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.591931">
+<ele>12</ele>
+<time>2026-06-01T03:40:26Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.591896">
+<ele>12</ele>
+<time>2026-06-01T03:40:27Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-06-01T03:40:29Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-06-01T03:40:29Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-06-01T03:40:29Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-06-01T03:40:29Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-06-01T03:40:30Z</time></trkpt>
+<trkpt lat="45.978099" lon="-66.592014">
+<ele>13</ele>
+<time>2026-06-01T03:40:58Z</time></trkpt>
+<trkpt lat="45.97754" lon="-66.592055">
+<ele>15</ele>
+<time>2026-06-01T03:41:20Z</time></trkpt>
+<trkpt lat="45.976207" lon="-66.592051">
+<ele>11</ele>
+<time>2026-06-01T03:42:13Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-06-01T03:42:32Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-06-01T03:42:32Z</time></trkpt>
+<trkpt lat="45.975632" lon="-66.592094">
+<ele>9</ele>
+<time>2026-06-01T03:42:36Z</time></trkpt>
+<trkpt lat="45.975623" lon="-66.592254">
+<ele>14</ele>
+<time>2026-06-01T03:42:41Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-06-01T03:42:43Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-06-01T03:42:43Z</time></trkpt>
+<trkpt lat="45.975214" lon="-66.592189">
+<ele>12</ele>
+<time>2026-06-01T03:42:57Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-06-01T03:42:59Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-06-01T03:42:59Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592442">
+<ele>15</ele>
+<time>2026-06-01T03:43:31Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592443">
+<ele>15</ele>
+<time>2026-06-01T03:43:31Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-06-01T03:44:21Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-06-01T03:44:21Z</time></trkpt>
+<trkpt lat="45.97213" lon="-66.593132">
+<ele>17</ele>
+<time>2026-06-01T03:45:04Z</time></trkpt>
+<trkpt lat="45.971525" lon="-66.593357">
+<ele>21</ele>
+<time>2026-06-01T03:45:29Z</time></trkpt>
+<trkpt lat="45.969886" lon="-66.594119">
+<ele>22</ele>
+<time>2026-06-01T03:46:38Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-06-01T03:46:50Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-06-01T03:46:50Z</time></trkpt>
+<trkpt lat="45.969415" lon="-66.594422">
+<ele>21</ele>
+<time>2026-06-01T03:46:59Z</time></trkpt>
+<trkpt lat="45.969227" lon="-66.594605">
+<ele>21</ele>
+<time>2026-06-01T03:47:08Z</time></trkpt>
+<trkpt lat="45.968963" lon="-66.59493">
+<ele>21</ele>
+<time>2026-06-01T03:47:22Z</time></trkpt>
+<trkpt lat="45.968815" lon="-66.595151">
+<ele>21</ele>
+<time>2026-06-01T03:47:30Z</time></trkpt>
+<trkpt lat="45.9686" lon="-66.595546">
+<ele>21</ele>
+<time>2026-06-01T03:47:44Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-06-01T03:47:52Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-06-01T03:47:52Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-06-01T03:50:01Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-06-01T03:50:01Z</time></trkpt>
+<trkpt lat="45.966112" lon="-66.603183">
+<ele>17</ele>
+<time>2026-06-01T03:51:39Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-06-01T03:51:42Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-06-01T03:51:43Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-06-01T03:51:43Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-06-01T03:51:43Z</time></trkpt>
+<trkpt lat="45.96605" lon="-66.603353">
+<ele>17</ele>
+<time>2026-06-01T03:51:46Z</time></trkpt>
+<trkpt lat="45.965996" lon="-66.603402">
+<ele>17</ele>
+<time>2026-06-01T03:51:49Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-06-01T03:51:50Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-06-01T03:51:50Z</time></trkpt>
+<trkpt lat="45.965942" lon="-66.603501">
+<ele>17</ele>
+<time>2026-06-01T03:51:52Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-06-01T03:51:59Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-06-01T03:51:59Z</time></trkpt>
+<trkpt lat="45.965665" lon="-66.604843">
+<ele>16</ele>
+<time>2026-06-01T03:52:31Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-06-01T03:53:06Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-06-01T03:53:06Z</time></trkpt>
+<trkpt lat="45.965181" lon="-66.608383">
+<ele>11</ele>
+<time>2026-06-01T03:54:12Z</time></trkpt>
+<trkpt lat="45.965033" lon="-66.609132">
+<ele>12</ele>
+<time>2026-06-01T03:54:34Z</time></trkpt>
+<trkpt lat="45.964803" lon="-66.609859">
+<ele>12</ele>
+<time>2026-06-01T03:54:56Z</time></trkpt>
+<trkpt lat="45.964626" lon="-66.610341">
+<ele>11</ele>
+<time>2026-06-01T03:55:11Z</time></trkpt>
+<trkpt lat="45.964553" lon="-66.610469">
+<ele>11</ele>
+<time>2026-06-01T03:55:16Z</time></trkpt>
+<trkpt lat="45.963882" lon="-66.611228">
+<ele>11</ele>
+<time>2026-06-01T03:55:50Z</time></trkpt>
+<trkpt lat="45.963738" lon="-66.611445">
+<ele>12</ele>
+<time>2026-06-01T03:55:58Z</time></trkpt>
+<trkpt lat="45.963251" lon="-66.612346">
+<ele>11</ele>
+<time>2026-06-01T03:56:30Z</time></trkpt>
+<trkpt lat="45.963102" lon="-66.612555">
+<ele>10</ele>
+<time>2026-06-01T03:56:38Z</time></trkpt>
+<trkpt lat="45.962888" lon="-66.6132">
+<ele>9</ele>
+<time>2026-06-01T03:56:58Z</time></trkpt>
+<trkpt lat="45.962803" lon="-66.613403">
+<ele>8</ele>
+<time>2026-06-01T03:57:05Z</time></trkpt>
+<trkpt lat="45.962527" lon="-66.613859">
+<ele>9</ele>
+<time>2026-06-01T03:57:22Z</time></trkpt>
+<trkpt lat="45.962084" lon="-66.614756">
+<ele>10</ele>
+<time>2026-06-01T03:57:52Z</time></trkpt>
+<trkpt lat="45.96169" lon="-66.615396">
+<ele>10</ele>
+<time>2026-06-01T03:58:16Z</time></trkpt>
+<trkpt lat="45.961234" lon="-66.615961">
+<ele>11</ele>
+<time>2026-06-01T03:58:40Z</time></trkpt>
+<trkpt lat="45.961024" lon="-66.616296">
+<ele>11</ele>
+<time>2026-06-01T03:58:53Z</time></trkpt>
+<trkpt lat="45.960565" lon="-66.617191">
+<ele>11</ele>
+<time>2026-06-01T03:59:24Z</time></trkpt>
+<trkpt lat="45.959944" lon="-66.618459">
+<ele>10</ele>
+<time>2026-06-01T04:00:07Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-06-01T04:00:34Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-06-01T04:00:41Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-06-01T04:00:41Z</time></trkpt>
+<trkpt lat="45.959154" lon="-66.620054">
+<ele>9</ele>
+<time>2026-06-01T04:01:02Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-06-01T04:01:21Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-06-01T04:01:32Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-06-01T04:01:48Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-06-01T04:01:48Z</time></trkpt>
+<trkpt lat="45.958337" lon="-66.622017">
+<ele>10</ele>
+<time>2026-06-01T04:02:06Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-06-01T04:02:53Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-06-01T04:02:53Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-06-01T04:03:15Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-06-01T04:03:19Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-06-01T04:03:36Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-06-01T04:03:36Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-06-01T04:07:08Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-06-01T04:07:08Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-06-01T04:07:17Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-06-01T04:07:44Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-06-01T04:07:44Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-06-01T04:08:00Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-06-01T04:08:07Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-06-01T04:08:27Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-06-01T04:08:27Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-06-01T04:08:32Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-06-01T04:08:36Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-06-01T04:08:53Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-06-01T04:09:11Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-06-01T04:09:11Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-06-01T04:09:55Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-06-01T04:09:55Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-06-01T04:10:38Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-06-01T04:10:38Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-06-01T04:10:39Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-06-01T04:10:45Z</time></trkpt>
+<trkpt lat="45.953944" lon="-66.639888">
+<ele>9</ele>
+<time>2026-06-01T04:11:51Z</time></trkpt>
+<trkpt lat="45.953933" lon="-66.639899">
+<ele>9</ele>
+<time>2026-06-01T04:11:51Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/00_half.gpx
+++ b/cursor/plotaroute/00_half.gpx
@@ -1,0 +1,1714 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.954489" lon="-66.641395">
+<time>2026-02-10T00:00:00Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Saint John Street</cmt>
+<desc>Start on Rue Saint John Street</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954492" lon="-66.6414">
+<time>2026-02-10T00:00:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-10T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rang Churchill Row</cmt>
+<desc>Turn right onto Rang Churchill Row</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-10T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956374" lon="-66.639758">
+<time>2026-02-10T00:01:29Z</time>
+<name>At roundab</name>
+<cmt>At roundabout, take exit 2 onto Rue Saint John Street</cmt>
+<desc>At roundabout, take exit 2 onto Rue Saint John Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-10T00:01:35Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-10T00:01:35Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-10T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Brunswick Street</cmt>
+<desc>Turn right onto Rue Brunswick Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-10T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-10T00:03:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue King Street</cmt>
+<desc>Turn right onto Rue King Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-10T00:03:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-10T00:04:28Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-10T00:04:29Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Queen Street</cmt>
+<desc>Turn left onto Rue Queen Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.96099" lon="-66.638372">
+<time>2026-02-10T00:05:33Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.961255" lon="-66.638537">
+<time>2026-02-10T00:05:45Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</cmt>
+<desc>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.964051" lon="-66.641227">
+<time>2026-02-10T00:08:24Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966872" lon="-66.643476">
+<time>2026-02-10T00:10:42Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Westmorland Street Bridge</cmt>
+<desc>Turn slight right onto Westmorland Street Bridge</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971269" lon="-66.641336">
+<time>2026-02-10T00:13:48Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971842" lon="-66.640842">
+<time>2026-02-10T00:14:15Z</time>
+<name>Keep left</name>
+<cmt>Keep left</cmt>
+<desc>Keep left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973279" lon="-66.639509">
+<time>2026-02-10T00:15:25Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Rue Union Street</cmt>
+<desc>Turn slight right onto Rue Union Street</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973069" lon="-66.638821">
+<time>2026-02-10T00:15:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Friel Street</cmt>
+<desc>Turn right onto Rue Friel Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973747" lon="-66.638243">
+<time>2026-02-10T00:16:18Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Northside Trail</cmt>
+<desc>Turn left onto Northside Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959573" lon="-66.61926">
+<time>2026-02-10T00:29:45Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958898" lon="-66.620214">
+<time>2026-02-10T00:30:24Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958909" lon="-66.620208">
+<time>2026-02-10T00:30:25Z</time>
+<name>Start on G</name>
+<cmt>Start on Gibson Trail</cmt>
+<desc>Start on Gibson Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-02-10T00:34:09Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-02-10T00:34:09Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Sentier Gibson Trail</cmt>
+<desc>Turn left onto Sentier Gibson Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950003" lon="-66.614738">
+<time>2026-02-10T00:36:59Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Gibson Trail</cmt>
+<desc>Keep left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.949942" lon="-66.614185">
+<time>2026-02-10T00:37:15Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Gibson Trail</cmt>
+<desc>Turn left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-02-10T00:38:17Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-02-10T00:38:18Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-02-10T00:39:10Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-02-10T00:39:12Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.976297" lon="-66.589324">
+<time>2026-02-10T01:02:13Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue McGloin Street</cmt>
+<desc>Turn left onto Rue McGloin Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978815" lon="-66.589547">
+<time>2026-02-10T01:03:56Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978811" lon="-66.589684">
+<time>2026-02-10T01:04:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-02-10T01:05:03Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978812" lon="-66.591904">
+<time>2026-02-10T01:05:06Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-02-10T01:36:22Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.97879" lon="-66.591898">
+<time>2026-02-10T01:36:22Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-02-10T01:36:22Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.975623" lon="-66.592254">
+<time>2026-02-10T01:38:33Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966115" lon="-66.603295">
+<time>2026-02-10T01:47:35Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-02-10T02:06:31Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953944" lon="-66.639888">
+<time>2026-02-10T02:07:43Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953933" lon="-66.639899">
+<time>2026-02-10T02:07:44Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>00_half</name>
+<trkseg>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.954492" lon="-66.6414">
+<ele>10</ele>
+<time>2026-02-10T00:00:00Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-10T00:00:47Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639772">
+<ele>13</ele>
+<time>2026-02-10T00:01:28Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639771">
+<ele>13</ele>
+<time>2026-02-10T00:01:28Z</time></trkpt>
+<trkpt lat="45.956374" lon="-66.639758">
+<ele>13</ele>
+<time>2026-02-10T00:01:29Z</time></trkpt>
+<trkpt lat="45.956371" lon="-66.639719">
+<ele>13</ele>
+<time>2026-02-10T00:01:30Z</time></trkpt>
+<trkpt lat="45.956394" lon="-66.639674">
+<ele>13</ele>
+<time>2026-02-10T00:01:31Z</time></trkpt>
+<trkpt lat="45.956428" lon="-66.639667">
+<ele>13</ele>
+<time>2026-02-10T00:01:33Z</time></trkpt>
+<trkpt lat="45.956454" lon="-66.639689">
+<ele>13</ele>
+<time>2026-02-10T00:01:34Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-10T00:01:35Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-10T00:02:16Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-10T00:02:16Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-10T00:03:00Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-10T00:03:44Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-10T00:03:45Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-10T00:04:28Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-10T00:04:29Z</time></trkpt>
+<trkpt lat="45.960461" lon="-66.637131">
+<ele>8</ele>
+<time>2026-02-10T00:04:52Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.96099" lon="-66.638372">
+<ele>9</ele>
+<time>2026-02-10T00:05:33Z</time></trkpt>
+<trkpt lat="45.961139" lon="-66.638502">
+<ele>9</ele>
+<time>2026-02-10T00:05:40Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-10T00:05:43Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-10T00:05:43Z</time></trkpt>
+<trkpt lat="45.961255" lon="-66.638537">
+<ele>9</ele>
+<time>2026-02-10T00:05:45Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-10T00:06:08Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-10T00:06:08Z</time></trkpt>
+<trkpt lat="45.961916" lon="-66.638033">
+<ele>8</ele>
+<time>2026-02-10T00:06:15Z</time></trkpt>
+<trkpt lat="45.962057" lon="-66.638009">
+<ele>8</ele>
+<time>2026-02-10T00:06:21Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-10T00:06:30Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-10T00:06:30Z</time></trkpt>
+<trkpt lat="45.962472" lon="-66.638212">
+<ele>7</ele>
+<time>2026-02-10T00:06:38Z</time></trkpt>
+<trkpt lat="45.96257" lon="-66.638353">
+<ele>7</ele>
+<time>2026-02-10T00:06:44Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-10T00:07:04Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-10T00:07:04Z</time></trkpt>
+<trkpt lat="45.964051" lon="-66.641227">
+<ele>8</ele>
+<time>2026-02-10T00:08:24Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-10T00:08:30Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-10T00:08:30Z</time></trkpt>
+<trkpt lat="45.964399" lon="-66.641753">
+<ele>8</ele>
+<time>2026-02-10T00:08:44Z</time></trkpt>
+<trkpt lat="45.965254" lon="-66.642927">
+<ele>7</ele>
+<time>2026-02-10T00:09:31Z</time></trkpt>
+<trkpt lat="45.965528" lon="-66.643281">
+<ele>6</ele>
+<time>2026-02-10T00:09:46Z</time></trkpt>
+<trkpt lat="45.965639" lon="-66.643394">
+<ele>6</ele>
+<time>2026-02-10T00:09:51Z</time></trkpt>
+<trkpt lat="45.965748" lon="-66.643484">
+<ele>4</ele>
+<time>2026-02-10T00:09:56Z</time></trkpt>
+<trkpt lat="45.965873" lon="-66.643545">
+<ele>3</ele>
+<time>2026-02-10T00:10:02Z</time></trkpt>
+<trkpt lat="45.966106" lon="-66.643575">
+<ele>3</ele>
+<time>2026-02-10T00:10:11Z</time></trkpt>
+<trkpt lat="45.966613" lon="-66.643482">
+<ele>3</ele>
+<time>2026-02-10T00:10:32Z</time></trkpt>
+<trkpt lat="45.966872" lon="-66.643476">
+<ele>3</ele>
+<time>2026-02-10T00:10:42Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-10T00:10:43Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-10T00:10:43Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-10T00:11:54Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-10T00:11:54Z</time></trkpt>
+<trkpt lat="45.971269" lon="-66.641336">
+<ele>6</ele>
+<time>2026-02-10T00:13:48Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-10T00:14:02Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-10T00:14:02Z</time></trkpt>
+<trkpt lat="45.971679" lon="-66.640971">
+<ele>7</ele>
+<time>2026-02-10T00:14:07Z</time></trkpt>
+<trkpt lat="45.971842" lon="-66.640842">
+<ele>8</ele>
+<time>2026-02-10T00:14:15Z</time></trkpt>
+<trkpt lat="45.97315" lon="-66.639854">
+<ele>10</ele>
+<time>2026-02-10T00:15:14Z</time></trkpt>
+<trkpt lat="45.97324" lon="-66.639695">
+<ele>10</ele>
+<time>2026-02-10T00:15:20Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-10T00:15:22Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-10T00:15:22Z</time></trkpt>
+<trkpt lat="45.973279" lon="-66.639509">
+<ele>10</ele>
+<time>2026-02-10T00:15:25Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-10T00:15:46Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-10T00:15:46Z</time></trkpt>
+<trkpt lat="45.973069" lon="-66.638821">
+<ele>10</ele>
+<time>2026-02-10T00:15:47Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.9737509" lon="-66.6382492">
+<ele>11</ele>
+<time>2026-02-10T00:16:18Z</time></trkpt>
+<trkpt lat="45.9735813" lon="-66.6377503">
+<ele>11</ele>
+<time>2026-02-10T00:16:34Z</time></trkpt>
+<trkpt lat="45.9729717" lon="-66.6359103">
+<ele>10</ele>
+<time>2026-02-10T00:17:31Z</time></trkpt>
+<trkpt lat="45.9727555" lon="-66.6352236">
+<ele>12</ele>
+<time>2026-02-10T00:17:52Z</time></trkpt>
+<trkpt lat="45.9725244" lon="-66.6346014">
+<ele>15</ele>
+<time>2026-02-10T00:18:11Z</time></trkpt>
+<trkpt lat="45.9723976" lon="-66.6342688">
+<ele>16</ele>
+<time>2026-02-10T00:18:22Z</time></trkpt>
+<trkpt lat="45.9722634" lon="-66.6339362">
+<ele>16</ele>
+<time>2026-02-10T00:18:33Z</time></trkpt>
+<trkpt lat="45.9720919" lon="-66.6335714">
+<ele>16</ele>
+<time>2026-02-10T00:18:45Z</time></trkpt>
+<trkpt lat="45.9719129" lon="-66.6331744">
+<ele>15</ele>
+<time>2026-02-10T00:18:58Z</time></trkpt>
+<trkpt lat="45.9716818" lon="-66.6327238">
+<ele>14</ele>
+<time>2026-02-10T00:19:14Z</time></trkpt>
+<trkpt lat="45.9714208" lon="-66.6323483">
+<ele>14</ele>
+<time>2026-02-10T00:19:28Z</time></trkpt>
+<trkpt lat="45.9712354" lon="-66.6320807">
+<ele>14</ele>
+<time>2026-02-10T00:19:39Z</time></trkpt>
+<trkpt lat="45.9710181" lon="-66.6317689">
+<ele>14</ele>
+<time>2026-02-10T00:19:51Z</time></trkpt>
+<trkpt lat="45.9707571" lon="-66.6315114">
+<ele>13</ele>
+<time>2026-02-10T00:20:04Z</time></trkpt>
+<trkpt lat="45.9705632" lon="-66.6312754">
+<ele>13</ele>
+<time>2026-02-10T00:20:14Z</time></trkpt>
+<trkpt lat="45.9702724" lon="-66.6308463">
+<ele>12</ele>
+<time>2026-02-10T00:20:31Z</time></trkpt>
+<trkpt lat="45.9700785" lon="-66.6305244">
+<ele>12</ele>
+<time>2026-02-10T00:20:43Z</time></trkpt>
+<trkpt lat="45.9697877" lon="-66.6301167">
+<ele>11</ele>
+<time>2026-02-10T00:20:59Z</time></trkpt>
+<trkpt lat="45.9692881" lon="-66.629473">
+<ele>10</ele>
+<time>2026-02-10T00:21:26Z</time></trkpt>
+<trkpt lat="45.9685574" lon="-66.6285373">
+<ele>11</ele>
+<time>2026-02-10T00:22:05Z</time></trkpt>
+<trkpt lat="45.9675431" lon="-66.6272092">
+<ele>12</ele>
+<time>2026-02-10T00:23:00Z</time></trkpt>
+<trkpt lat="45.9664096" lon="-66.6257286">
+<ele>12</ele>
+<time>2026-02-10T00:24:01Z</time></trkpt>
+<trkpt lat="45.9658727" lon="-66.6250634">
+<ele>13</ele>
+<time>2026-02-10T00:24:30Z</time></trkpt>
+<trkpt lat="45.9653954" lon="-66.6243339">
+<ele>14</ele>
+<time>2026-02-10T00:24:58Z</time></trkpt>
+<trkpt lat="45.9644259" lon="-66.6230249">
+<ele>13</ele>
+<time>2026-02-10T00:25:51Z</time></trkpt>
+<trkpt lat="45.9632327" lon="-66.6214371">
+<ele>12</ele>
+<time>2026-02-10T00:26:56Z</time></trkpt>
+<trkpt lat="45.9626062" lon="-66.6206002">
+<ele>12</ele>
+<time>2026-02-10T00:27:30Z</time></trkpt>
+<trkpt lat="45.9619201" lon="-66.6197419">
+<ele>14</ele>
+<time>2026-02-10T00:28:07Z</time></trkpt>
+<trkpt lat="45.9613682" lon="-66.6193771">
+<ele>13</ele>
+<time>2026-02-10T00:28:31Z</time></trkpt>
+<trkpt lat="45.9609058" lon="-66.6192484">
+<ele>12</ele>
+<time>2026-02-10T00:28:50Z</time></trkpt>
+<trkpt lat="45.9603837" lon="-66.6192484">
+<ele>11</ele>
+<time>2026-02-10T00:29:11Z</time></trkpt>
+<trkpt lat="45.9598915" lon="-66.6194201">
+<ele>10</ele>
+<time>2026-02-10T00:29:31Z</time></trkpt>
+<trkpt lat="45.9595782" lon="-66.6192698">
+<ele>10</ele>
+<time>2026-02-10T00:29:44Z</time></trkpt>
+<trkpt lat="45.95958" lon="-66.619267">
+<ele>10</ele>
+<time>2026-02-10T00:29:45Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-02-10T00:29:45Z</time></trkpt>
+<trkpt lat="45.959574" lon="-66.619256">
+<ele>10</ele>
+<time>2026-02-10T00:29:45Z</time></trkpt>
+<trkpt lat="45.959572" lon="-66.6192542">
+<ele>10</ele>
+<time>2026-02-10T00:29:45Z</time></trkpt>
+<trkpt lat="45.9594916" lon="-66.6194552">
+<ele>10</ele>
+<time>2026-02-10T00:29:52Z</time></trkpt>
+<trkpt lat="45.9592734" lon="-66.6198601">
+<ele>9</ele>
+<time>2026-02-10T00:30:06Z</time></trkpt>
+<trkpt lat="45.9591243" lon="-66.6200801">
+<ele>9</ele>
+<time>2026-02-10T00:30:14Z</time></trkpt>
+<trkpt lat="45.9590068" lon="-66.6201579">
+<ele>10</ele>
+<time>2026-02-10T00:30:20Z</time></trkpt>
+<trkpt lat="45.958895" lon="-66.6202169">
+<ele>10</ele>
+<time>2026-02-10T00:30:24Z</time></trkpt>
+<trkpt lat="45.958895" lon="-66.620215">
+<ele>10</ele>
+<time>2026-02-10T00:30:24Z</time></trkpt>
+<trkpt lat="45.958898" lon="-66.620214">
+<ele>10</ele>
+<time>2026-02-10T00:30:24Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-02-10T00:30:25Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-02-10T00:30:25Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-02-10T00:30:25Z</time></trkpt>
+<trkpt lat="45.958625" lon="-66.620306">
+<ele>9</ele>
+<time>2026-02-10T00:30:37Z</time></trkpt>
+<trkpt lat="45.95833" lon="-66.620318">
+<ele>9</ele>
+<time>2026-02-10T00:30:48Z</time></trkpt>
+<trkpt lat="45.958134" lon="-66.620282">
+<ele>9</ele>
+<time>2026-02-10T00:30:56Z</time></trkpt>
+<trkpt lat="45.957933" lon="-66.620207">
+<ele>9</ele>
+<time>2026-02-10T00:31:05Z</time></trkpt>
+<trkpt lat="45.957728" lon="-66.620097">
+<ele>9</ele>
+<time>2026-02-10T00:31:14Z</time></trkpt>
+<trkpt lat="45.95718" lon="-66.619732">
+<ele>6</ele>
+<time>2026-02-10T00:31:38Z</time></trkpt>
+<trkpt lat="45.956327" lon="-66.619138">
+<ele>3</ele>
+<time>2026-02-10T00:32:16Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-02-10T00:32:48Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-02-10T00:32:48Z</time></trkpt>
+<trkpt lat="45.953955" lon="-66.617486">
+<ele>10</ele>
+<time>2026-02-10T00:34:01Z</time></trkpt>
+<trkpt lat="45.953846" lon="-66.617411">
+<ele>10</ele>
+<time>2026-02-10T00:34:06Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-02-10T00:34:09Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-02-10T00:34:09Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-02-10T00:34:09Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-02-10T00:34:09Z</time></trkpt>
+<trkpt lat="45.953661" lon="-66.617407">
+<ele>9</ele>
+<time>2026-02-10T00:34:14Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-02-10T00:34:24Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-02-10T00:34:24Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-02-10T00:35:31Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-02-10T00:35:31Z</time></trkpt>
+<trkpt lat="45.95177" lon="-66.615978">
+<ele>10</ele>
+<time>2026-02-10T00:35:40Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-02-10T00:36:08Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-02-10T00:36:08Z</time></trkpt>
+<trkpt lat="45.950773" lon="-66.615278">
+<ele>9</ele>
+<time>2026-02-10T00:36:24Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-02-10T00:36:57Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-02-10T00:36:57Z</time></trkpt>
+<trkpt lat="45.950003" lon="-66.614738">
+<ele>9</ele>
+<time>2026-02-10T00:36:59Z</time></trkpt>
+<trkpt lat="45.949917" lon="-66.614497">
+<ele>9</ele>
+<time>2026-02-10T00:37:06Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-02-10T00:37:08Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-02-10T00:37:08Z</time></trkpt>
+<trkpt lat="45.949908" lon="-66.614348">
+<ele>9</ele>
+<time>2026-02-10T00:37:10Z</time></trkpt>
+<trkpt lat="45.949942" lon="-66.614185">
+<ele>9</ele>
+<time>2026-02-10T00:37:15Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-02-10T00:37:19Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-02-10T00:37:19Z</time></trkpt>
+<trkpt lat="45.950333" lon="-66.613966">
+<ele>9</ele>
+<time>2026-02-10T00:37:32Z</time></trkpt>
+<trkpt lat="45.950635" lon="-66.613663">
+<ele>10</ele>
+<time>2026-02-10T00:37:47Z</time></trkpt>
+<trkpt lat="45.950902" lon="-66.61323">
+<ele>10</ele>
+<time>2026-02-10T00:38:03Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-02-10T00:38:17Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-02-10T00:38:17Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-02-10T00:38:17Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-02-10T00:38:18Z</time></trkpt>
+<trkpt lat="45.951176" lon="-66.612384">
+<ele>10</ele>
+<time>2026-02-10T00:38:30Z</time></trkpt>
+<trkpt lat="45.951354" lon="-66.611746">
+<ele>10</ele>
+<time>2026-02-10T00:38:49Z</time></trkpt>
+<trkpt lat="45.95143" lon="-66.61128">
+<ele>10</ele>
+<time>2026-02-10T00:39:03Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-02-10T00:39:10Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-02-10T00:39:11Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-02-10T00:39:11Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-02-10T00:39:12Z</time></trkpt>
+<trkpt lat="45.951461" lon="-66.610792">
+<ele>10</ele>
+<time>2026-02-10T00:39:18Z</time></trkpt>
+<trkpt lat="45.951556" lon="-66.610483">
+<ele>10</ele>
+<time>2026-02-10T00:39:27Z</time></trkpt>
+<trkpt lat="45.951635" lon="-66.610362">
+<ele>10</ele>
+<time>2026-02-10T00:39:32Z</time></trkpt>
+<trkpt lat="45.951716" lon="-66.610289">
+<ele>10</ele>
+<time>2026-02-10T00:39:35Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-02-10T00:39:38Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-02-10T00:39:38Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-02-10T00:40:41Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-02-10T00:40:41Z</time></trkpt>
+<trkpt lat="45.952532" lon="-66.607543">
+<ele>12</ele>
+<time>2026-02-10T00:40:59Z</time></trkpt>
+<trkpt lat="45.952784" lon="-66.607017">
+<ele>10</ele>
+<time>2026-02-10T00:41:17Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-02-10T00:41:42Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-02-10T00:41:42Z</time></trkpt>
+<trkpt lat="45.953282" lon="-66.606382">
+<ele>10</ele>
+<time>2026-02-10T00:41:43Z</time></trkpt>
+<trkpt lat="45.953384" lon="-66.606251">
+<ele>10</ele>
+<time>2026-02-10T00:41:49Z</time></trkpt>
+<trkpt lat="45.953925" lon="-66.605723">
+<ele>10</ele>
+<time>2026-02-10T00:42:15Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-02-10T00:42:30Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-02-10T00:42:30Z</time></trkpt>
+<trkpt lat="45.954387" lon="-66.605232">
+<ele>10</ele>
+<time>2026-02-10T00:42:38Z</time></trkpt>
+<trkpt lat="45.954745" lon="-66.60476">
+<ele>10</ele>
+<time>2026-02-10T00:42:57Z</time></trkpt>
+<trkpt lat="45.955223" lon="-66.603919">
+<ele>10</ele>
+<time>2026-02-10T00:43:28Z</time></trkpt>
+<trkpt lat="45.955571" lon="-66.603154">
+<ele>12</ele>
+<time>2026-02-10T00:43:53Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-02-10T00:45:22Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-02-10T00:45:22Z</time></trkpt>
+<trkpt lat="45.958914" lon="-66.596075">
+<ele>15</ele>
+<time>2026-02-10T00:47:52Z</time></trkpt>
+<trkpt lat="45.959408" lon="-66.595054">
+<ele>12</ele>
+<time>2026-02-10T00:48:26Z</time></trkpt>
+<trkpt lat="45.959986" lon="-66.593886">
+<ele>9</ele>
+<time>2026-02-10T00:49:06Z</time></trkpt>
+<trkpt lat="45.960677" lon="-66.592592">
+<ele>10</ele>
+<time>2026-02-10T00:49:52Z</time></trkpt>
+<trkpt lat="45.960883" lon="-66.592242">
+<ele>11</ele>
+<time>2026-02-10T00:50:04Z</time></trkpt>
+<trkpt lat="45.96131" lon="-66.591631">
+<ele>11</ele>
+<time>2026-02-10T00:50:29Z</time></trkpt>
+<trkpt lat="45.963861" lon="-66.588577">
+<ele>12</ele>
+<time>2026-02-10T00:52:42Z</time></trkpt>
+<trkpt lat="45.964377" lon="-66.587911">
+<ele>11</ele>
+<time>2026-02-10T00:53:09Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-02-10T00:53:23Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-02-10T00:53:23Z</time></trkpt>
+<trkpt lat="45.965429" lon="-66.586262">
+<ele>7</ele>
+<time>2026-02-10T00:54:12Z</time></trkpt>
+<trkpt lat="45.966107" lon="-66.585312">
+<ele>8</ele>
+<time>2026-02-10T00:54:50Z</time></trkpt>
+<trkpt lat="45.966364" lon="-66.585057">
+<ele>8</ele>
+<time>2026-02-10T00:55:02Z</time></trkpt>
+<trkpt lat="45.966634" lon="-66.584828">
+<ele>8</ele>
+<time>2026-02-10T00:55:15Z</time></trkpt>
+<trkpt lat="45.96688" lon="-66.584676">
+<ele>8</ele>
+<time>2026-02-10T00:55:25Z</time></trkpt>
+<trkpt lat="45.96727" lon="-66.584548">
+<ele>8</ele>
+<time>2026-02-10T00:55:41Z</time></trkpt>
+<trkpt lat="45.967399" lon="-66.584523">
+<ele>8</ele>
+<time>2026-02-10T00:55:47Z</time></trkpt>
+<trkpt lat="45.967658" lon="-66.584517">
+<ele>8</ele>
+<time>2026-02-10T00:55:57Z</time></trkpt>
+<trkpt lat="45.967891" lon="-66.584555">
+<ele>9</ele>
+<time>2026-02-10T00:56:06Z</time></trkpt>
+<trkpt lat="45.968123" lon="-66.584619">
+<ele>8</ele>
+<time>2026-02-10T00:56:16Z</time></trkpt>
+<trkpt lat="45.96836" lon="-66.584715">
+<ele>8</ele>
+<time>2026-02-10T00:56:26Z</time></trkpt>
+<trkpt lat="45.968593" lon="-66.584857">
+<ele>8</ele>
+<time>2026-02-10T00:56:36Z</time></trkpt>
+<trkpt lat="45.972289" lon="-66.587553">
+<ele>10</ele>
+<time>2026-02-10T00:59:22Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-02-10T00:59:50Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-02-10T00:59:50Z</time></trkpt>
+<trkpt lat="45.973398" lon="-66.588427">
+<ele>9</ele>
+<time>2026-02-10T01:00:13Z</time></trkpt>
+<trkpt lat="45.973712" lon="-66.588627">
+<ele>8</ele>
+<time>2026-02-10T01:00:26Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-02-10T01:00:38Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-02-10T01:00:38Z</time></trkpt>
+<trkpt lat="45.974595" lon="-66.589095">
+<ele>8</ele>
+<time>2026-02-10T01:01:04Z</time></trkpt>
+<trkpt lat="45.974902" lon="-66.589197">
+<ele>9</ele>
+<time>2026-02-10T01:01:17Z</time></trkpt>
+<trkpt lat="45.97523" lon="-66.589266">
+<ele>9</ele>
+<time>2026-02-10T01:01:30Z</time></trkpt>
+<trkpt lat="45.975815" lon="-66.589324">
+<ele>9</ele>
+<time>2026-02-10T01:01:54Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-02-10T01:02:10Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-02-10T01:02:10Z</time></trkpt>
+<trkpt lat="45.976297" lon="-66.589324">
+<ele>10</ele>
+<time>2026-02-10T01:02:13Z</time></trkpt>
+<trkpt lat="45.976388" lon="-66.589479">
+<ele>10</ele>
+<time>2026-02-10T01:02:19Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-02-10T01:02:20Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-02-10T01:02:20Z</time></trkpt>
+<trkpt lat="45.97647" lon="-66.58953">
+<ele>10</ele>
+<time>2026-02-10T01:02:22Z</time></trkpt>
+<trkpt lat="45.976864" lon="-66.589543">
+<ele>11</ele>
+<time>2026-02-10T01:02:38Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T01:03:32Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T01:03:32Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T01:03:55Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T01:03:55Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.589547">
+<ele>11</ele>
+<time>2026-02-10T01:03:56Z</time></trkpt>
+<trkpt lat="45.978813" lon="-66.589615">
+<ele>10</ele>
+<time>2026-02-10T01:03:58Z</time></trkpt>
+<trkpt lat="45.978811" lon="-66.589684">
+<ele>10</ele>
+<time>2026-02-10T01:04:00Z</time></trkpt>
+<trkpt lat="45.978846" lon="-66.589722">
+<ele>10</ele>
+<time>2026-02-10T01:04:02Z</time></trkpt>
+<trkpt lat="45.978852" lon="-66.589755">
+<ele>10</ele>
+<time>2026-02-10T01:04:03Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-02-10T01:04:04Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-02-10T01:04:04Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-02-10T01:04:42Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-02-10T01:04:42Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.591785">
+<ele>11</ele>
+<time>2026-02-10T01:04:59Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T01:05:03Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-02-10T01:05:04Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-02-10T01:05:04Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-02-10T01:05:06Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-02-10T01:05:06Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-02-10T01:05:06Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-02-10T01:05:11Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-02-10T01:05:21Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-02-10T01:05:44Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-02-10T01:05:56Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-02-10T01:05:56Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-02-10T01:06:20Z</time></trkpt>
+<trkpt lat="45.980922" lon="-66.592016">
+<ele>15</ele>
+<time>2026-02-10T01:06:31Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-02-10T01:06:46Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-02-10T01:07:01Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-02-10T01:07:01Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-02-10T01:07:48Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-02-10T01:08:09Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-02-10T01:09:05Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-02-10T01:09:25Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-02-10T01:09:45Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-02-10T01:09:58Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-02-10T01:10:15Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-02-10T01:10:36Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-02-10T01:10:38Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-02-10T01:10:38Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-02-10T01:10:59Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-02-10T01:11:38Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-02-10T01:12:08Z</time></trkpt>
+<trkpt lat="45.987926" lon="-66.586193">
+<ele>11</ele>
+<time>2026-02-10T01:12:38Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-02-10T01:12:52Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-02-10T01:13:40Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-02-10T01:13:49Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-02-10T01:13:57Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-02-10T01:14:39Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-02-10T01:16:10Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-02-10T01:16:29Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-02-10T01:16:41Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-02-10T01:16:48Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-02-10T01:19:53Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-02-10T01:20:08Z</time></trkpt>
+<trkpt lat="45.995963" lon="-66.574401">
+<ele>4</ele>
+<time>2026-02-10T01:20:32Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-02-10T01:20:56Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-02-10T01:21:11Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-02-10T01:24:16Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-02-10T01:24:23Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-02-10T01:24:35Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-02-10T01:24:54Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-02-10T01:26:25Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-02-10T01:27:07Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-02-10T01:27:15Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-02-10T01:27:24Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-02-10T01:28:12Z</time></trkpt>
+<trkpt lat="45.987926" lon="-66.586193">
+<ele>11</ele>
+<time>2026-02-10T01:28:25Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-02-10T01:28:56Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-02-10T01:29:26Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-02-10T01:30:04Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-02-10T01:30:25Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-02-10T01:30:25Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-02-10T01:30:28Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-02-10T01:30:49Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-02-10T01:31:05Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-02-10T01:31:19Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-02-10T01:31:38Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-02-10T01:31:59Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-02-10T01:32:55Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-02-10T01:33:16Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-02-10T01:34:02Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-02-10T01:34:02Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-02-10T01:34:18Z</time></trkpt>
+<trkpt lat="45.980922" lon="-66.592016">
+<ele>15</ele>
+<time>2026-02-10T01:34:32Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-02-10T01:34:43Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-02-10T01:35:08Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-02-10T01:35:08Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-02-10T01:35:19Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-02-10T01:35:43Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-02-10T01:35:53Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-02-10T01:35:57Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-02-10T01:35:57Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-02-10T01:35:57Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-02-10T01:36:02Z</time></trkpt>
+<trkpt lat="45.979101" lon="-66.59187">
+<ele>11</ele>
+<time>2026-02-10T01:36:09Z</time></trkpt>
+<trkpt lat="45.979101" lon="-66.59187">
+<ele>11</ele>
+<time>2026-02-10T01:36:09Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-02-10T01:36:16Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T01:36:22Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-02-10T01:36:22Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-02-10T01:36:22Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-02-10T01:36:22Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-02-10T01:36:22Z</time></trkpt>
+<trkpt lat="45.978099" lon="-66.592014">
+<ele>13</ele>
+<time>2026-02-10T01:36:50Z</time></trkpt>
+<trkpt lat="45.97754" lon="-66.592055">
+<ele>15</ele>
+<time>2026-02-10T01:37:12Z</time></trkpt>
+<trkpt lat="45.976207" lon="-66.592051">
+<ele>11</ele>
+<time>2026-02-10T01:38:06Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-02-10T01:38:25Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-02-10T01:38:25Z</time></trkpt>
+<trkpt lat="45.975632" lon="-66.592094">
+<ele>9</ele>
+<time>2026-02-10T01:38:29Z</time></trkpt>
+<trkpt lat="45.975623" lon="-66.592254">
+<ele>14</ele>
+<time>2026-02-10T01:38:33Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-02-10T01:38:35Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-02-10T01:38:35Z</time></trkpt>
+<trkpt lat="45.975214" lon="-66.592189">
+<ele>12</ele>
+<time>2026-02-10T01:38:50Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-02-10T01:38:51Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-02-10T01:38:51Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592442">
+<ele>15</ele>
+<time>2026-02-10T01:39:23Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592443">
+<ele>15</ele>
+<time>2026-02-10T01:39:23Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-02-10T01:40:14Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-02-10T01:40:14Z</time></trkpt>
+<trkpt lat="45.97213" lon="-66.593132">
+<ele>17</ele>
+<time>2026-02-10T01:40:56Z</time></trkpt>
+<trkpt lat="45.971525" lon="-66.593357">
+<ele>21</ele>
+<time>2026-02-10T01:41:21Z</time></trkpt>
+<trkpt lat="45.969886" lon="-66.594119">
+<ele>22</ele>
+<time>2026-02-10T01:42:30Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-02-10T01:42:43Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-02-10T01:42:43Z</time></trkpt>
+<trkpt lat="45.969415" lon="-66.594422">
+<ele>21</ele>
+<time>2026-02-10T01:42:51Z</time></trkpt>
+<trkpt lat="45.969227" lon="-66.594605">
+<ele>21</ele>
+<time>2026-02-10T01:43:00Z</time></trkpt>
+<trkpt lat="45.968963" lon="-66.59493">
+<ele>21</ele>
+<time>2026-02-10T01:43:14Z</time></trkpt>
+<trkpt lat="45.968815" lon="-66.595151">
+<ele>21</ele>
+<time>2026-02-10T01:43:22Z</time></trkpt>
+<trkpt lat="45.9686" lon="-66.595546">
+<ele>21</ele>
+<time>2026-02-10T01:43:36Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-02-10T01:43:44Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-02-10T01:43:44Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-02-10T01:45:53Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-02-10T01:45:53Z</time></trkpt>
+<trkpt lat="45.966112" lon="-66.603183">
+<ele>17</ele>
+<time>2026-02-10T01:47:31Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-02-10T01:47:35Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-02-10T01:47:35Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-02-10T01:47:35Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-02-10T01:47:35Z</time></trkpt>
+<trkpt lat="45.96605" lon="-66.603353">
+<ele>17</ele>
+<time>2026-02-10T01:47:39Z</time></trkpt>
+<trkpt lat="45.965996" lon="-66.603402">
+<ele>17</ele>
+<time>2026-02-10T01:47:41Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-02-10T01:47:42Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-02-10T01:47:42Z</time></trkpt>
+<trkpt lat="45.965942" lon="-66.603501">
+<ele>17</ele>
+<time>2026-02-10T01:47:45Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-02-10T01:47:52Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-02-10T01:47:52Z</time></trkpt>
+<trkpt lat="45.965665" lon="-66.604843">
+<ele>16</ele>
+<time>2026-02-10T01:48:24Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-02-10T01:48:59Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-02-10T01:48:59Z</time></trkpt>
+<trkpt lat="45.965181" lon="-66.608383">
+<ele>11</ele>
+<time>2026-02-10T01:50:04Z</time></trkpt>
+<trkpt lat="45.965033" lon="-66.609132">
+<ele>12</ele>
+<time>2026-02-10T01:50:26Z</time></trkpt>
+<trkpt lat="45.964803" lon="-66.609859">
+<ele>12</ele>
+<time>2026-02-10T01:50:48Z</time></trkpt>
+<trkpt lat="45.964626" lon="-66.610341">
+<ele>11</ele>
+<time>2026-02-10T01:51:03Z</time></trkpt>
+<trkpt lat="45.964553" lon="-66.610469">
+<ele>11</ele>
+<time>2026-02-10T01:51:08Z</time></trkpt>
+<trkpt lat="45.963882" lon="-66.611228">
+<ele>11</ele>
+<time>2026-02-10T01:51:42Z</time></trkpt>
+<trkpt lat="45.963738" lon="-66.611445">
+<ele>12</ele>
+<time>2026-02-10T01:51:50Z</time></trkpt>
+<trkpt lat="45.963251" lon="-66.612346">
+<ele>11</ele>
+<time>2026-02-10T01:52:22Z</time></trkpt>
+<trkpt lat="45.963102" lon="-66.612555">
+<ele>10</ele>
+<time>2026-02-10T01:52:31Z</time></trkpt>
+<trkpt lat="45.962888" lon="-66.6132">
+<ele>9</ele>
+<time>2026-02-10T01:52:51Z</time></trkpt>
+<trkpt lat="45.962803" lon="-66.613403">
+<ele>8</ele>
+<time>2026-02-10T01:52:57Z</time></trkpt>
+<trkpt lat="45.962527" lon="-66.613859">
+<ele>9</ele>
+<time>2026-02-10T01:53:14Z</time></trkpt>
+<trkpt lat="45.962084" lon="-66.614756">
+<ele>10</ele>
+<time>2026-02-10T01:53:45Z</time></trkpt>
+<trkpt lat="45.96169" lon="-66.615396">
+<ele>10</ele>
+<time>2026-02-10T01:54:08Z</time></trkpt>
+<trkpt lat="45.961234" lon="-66.615961">
+<ele>11</ele>
+<time>2026-02-10T01:54:33Z</time></trkpt>
+<trkpt lat="45.961024" lon="-66.616296">
+<ele>11</ele>
+<time>2026-02-10T01:54:45Z</time></trkpt>
+<trkpt lat="45.960565" lon="-66.617191">
+<ele>11</ele>
+<time>2026-02-10T01:55:16Z</time></trkpt>
+<trkpt lat="45.959944" lon="-66.618459">
+<ele>10</ele>
+<time>2026-02-10T01:55:59Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-02-10T01:56:26Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-02-10T01:56:34Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-02-10T01:56:34Z</time></trkpt>
+<trkpt lat="45.959154" lon="-66.620054">
+<ele>9</ele>
+<time>2026-02-10T01:56:54Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-02-10T01:57:13Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-02-10T01:57:24Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-02-10T01:57:40Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-02-10T01:57:40Z</time></trkpt>
+<trkpt lat="45.958337" lon="-66.622017">
+<ele>10</ele>
+<time>2026-02-10T01:57:58Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-02-10T01:58:46Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-02-10T01:58:46Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-02-10T01:59:07Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-02-10T01:59:12Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-02-10T01:59:29Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-02-10T01:59:29Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-02-10T02:03:00Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-02-10T02:03:00Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-02-10T02:03:09Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-02-10T02:03:36Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-02-10T02:03:36Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-02-10T02:03:53Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-02-10T02:04:00Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-02-10T02:04:19Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-02-10T02:04:19Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-02-10T02:04:24Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-02-10T02:04:28Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-02-10T02:04:46Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-02-10T02:05:03Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-02-10T02:05:03Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-02-10T02:05:47Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-02-10T02:05:47Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-02-10T02:06:31Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-02-10T02:06:31Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-02-10T02:06:31Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-02-10T02:06:37Z</time></trkpt>
+<trkpt lat="45.953944" lon="-66.639888">
+<ele>9</ele>
+<time>2026-02-10T02:07:43Z</time></trkpt>
+<trkpt lat="45.953933" lon="-66.639899">
+<ele>9</ele>
+<time>2026-02-10T02:07:44Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/01_start_friel.gpx
+++ b/cursor/plotaroute/01_start_friel.gpx
@@ -1,0 +1,427 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.954489" lon="-66.641395">
+<time>2026-02-11T00:00:00Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Saint John Street</cmt>
+<desc>Start on Rue Saint John Street</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954492" lon="-66.6414">
+<time>2026-02-11T00:00:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-11T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rang Churchill Row</cmt>
+<desc>Turn right onto Rang Churchill Row</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.955482" lon="-66.640537">
+<time>2026-02-11T00:00:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Saint John Street</cmt>
+<desc>Turn right onto Rue Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956374" lon="-66.639758">
+<time>2026-02-11T00:01:29Z</time>
+<name>At roundab</name>
+<cmt>At roundabout, take exit 2 onto Rue Saint John Street</cmt>
+<desc>At roundabout, take exit 2 onto Rue Saint John Street</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-11T00:01:35Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.956483" lon="-66.639664">
+<time>2026-02-11T00:01:35Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-11T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Brunswick Street</cmt>
+<desc>Turn right onto Rue Brunswick Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958288" lon="-66.638099">
+<time>2026-02-11T00:03:00Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-11T00:03:44Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue King Street</cmt>
+<desc>Turn right onto Rue King Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.959226" lon="-66.637275">
+<time>2026-02-11T00:03:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Saint John Street</cmt>
+<desc>Turn right onto Saint John Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-11T00:04:28Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.960146" lon="-66.636449">
+<time>2026-02-11T00:04:29Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Queen Street</cmt>
+<desc>Turn left onto Rue Queen Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.96099" lon="-66.638372">
+<time>2026-02-11T00:05:33Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left</cmt>
+<desc>Turn sharp left</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.961255" lon="-66.638537">
+<time>2026-02-11T00:05:45Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</cmt>
+<desc>Turn slight right onto Boulevard Point-Sainte-Anne Boulevard</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.964051" lon="-66.641227">
+<time>2026-02-11T00:08:24Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966872" lon="-66.643476">
+<time>2026-02-11T00:10:42Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Westmorland Street Bridge</cmt>
+<desc>Turn slight right onto Westmorland Street Bridge</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971269" lon="-66.641336">
+<time>2026-02-11T00:13:48Z</time>
+<name>Keep right</name>
+<cmt>Keep right</cmt>
+<desc>Keep right</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.971842" lon="-66.640842">
+<time>2026-02-11T00:14:15Z</time>
+<name>Keep left</name>
+<cmt>Keep left</cmt>
+<desc>Keep left</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973279" lon="-66.639509">
+<time>2026-02-11T00:15:25Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Rue Union Street</cmt>
+<desc>Turn slight right onto Rue Union Street</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973069" lon="-66.638821">
+<time>2026-02-11T00:15:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Friel Street</cmt>
+<desc>Turn right onto Rue Friel Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973742" lon="-66.638247">
+<time>2026-02-11T00:16:18Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>01_start_friel</name>
+<trkseg>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-11T00:00:00Z</time></trkpt>
+<trkpt lat="45.954489" lon="-66.641395">
+<ele>10</ele>
+<time>2026-02-11T00:00:00Z</time></trkpt>
+<trkpt lat="45.954492" lon="-66.6414">
+<ele>10</ele>
+<time>2026-02-11T00:00:00Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-11T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-11T00:00:47Z</time></trkpt>
+<trkpt lat="45.95548" lon="-66.640534">
+<ele>13</ele>
+<time>2026-02-11T00:00:47Z</time></trkpt>
+<trkpt lat="45.955482" lon="-66.640537">
+<ele>13</ele>
+<time>2026-02-11T00:00:47Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639772">
+<ele>13</ele>
+<time>2026-02-11T00:01:28Z</time></trkpt>
+<trkpt lat="45.956359" lon="-66.639771">
+<ele>13</ele>
+<time>2026-02-11T00:01:28Z</time></trkpt>
+<trkpt lat="45.956374" lon="-66.639758">
+<ele>13</ele>
+<time>2026-02-11T00:01:29Z</time></trkpt>
+<trkpt lat="45.956371" lon="-66.639719">
+<ele>13</ele>
+<time>2026-02-11T00:01:30Z</time></trkpt>
+<trkpt lat="45.956394" lon="-66.639674">
+<ele>13</ele>
+<time>2026-02-11T00:01:31Z</time></trkpt>
+<trkpt lat="45.956428" lon="-66.639667">
+<ele>13</ele>
+<time>2026-02-11T00:01:33Z</time></trkpt>
+<trkpt lat="45.956454" lon="-66.639689">
+<ele>13</ele>
+<time>2026-02-11T00:01:34Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-11T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-11T00:01:35Z</time></trkpt>
+<trkpt lat="45.956484" lon="-66.639666">
+<ele>13</ele>
+<time>2026-02-11T00:01:35Z</time></trkpt>
+<trkpt lat="45.956483" lon="-66.639664">
+<ele>13</ele>
+<time>2026-02-11T00:01:35Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-11T00:02:16Z</time></trkpt>
+<trkpt lat="45.957347" lon="-66.638911">
+<ele>12</ele>
+<time>2026-02-11T00:02:16Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-11T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-11T00:03:00Z</time></trkpt>
+<trkpt lat="45.958286" lon="-66.638093">
+<ele>11</ele>
+<time>2026-02-11T00:03:00Z</time></trkpt>
+<trkpt lat="45.958288" lon="-66.638099">
+<ele>11</ele>
+<time>2026-02-11T00:03:00Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-11T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-11T00:03:44Z</time></trkpt>
+<trkpt lat="45.959223" lon="-66.637269">
+<ele>10</ele>
+<time>2026-02-11T00:03:44Z</time></trkpt>
+<trkpt lat="45.959226" lon="-66.637275">
+<ele>10</ele>
+<time>2026-02-11T00:03:45Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-11T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-11T00:04:28Z</time></trkpt>
+<trkpt lat="45.960138" lon="-66.636448">
+<ele>8</ele>
+<time>2026-02-11T00:04:28Z</time></trkpt>
+<trkpt lat="45.960146" lon="-66.636449">
+<ele>8</ele>
+<time>2026-02-11T00:04:29Z</time></trkpt>
+<trkpt lat="45.960461" lon="-66.637131">
+<ele>8</ele>
+<time>2026-02-11T00:04:52Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-11T00:05:33Z</time></trkpt>
+<trkpt lat="45.960997" lon="-66.638387">
+<ele>9</ele>
+<time>2026-02-11T00:05:33Z</time></trkpt>
+<trkpt lat="45.96099" lon="-66.638372">
+<ele>9</ele>
+<time>2026-02-11T00:05:33Z</time></trkpt>
+<trkpt lat="45.961139" lon="-66.638502">
+<ele>9</ele>
+<time>2026-02-11T00:05:40Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-11T00:05:43Z</time></trkpt>
+<trkpt lat="45.961206" lon="-66.638522">
+<ele>9</ele>
+<time>2026-02-11T00:05:43Z</time></trkpt>
+<trkpt lat="45.961255" lon="-66.638537">
+<ele>9</ele>
+<time>2026-02-11T00:05:45Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-11T00:06:08Z</time></trkpt>
+<trkpt lat="45.961763" lon="-66.638114">
+<ele>8</ele>
+<time>2026-02-11T00:06:08Z</time></trkpt>
+<trkpt lat="45.961916" lon="-66.638033">
+<ele>8</ele>
+<time>2026-02-11T00:06:15Z</time></trkpt>
+<trkpt lat="45.962057" lon="-66.638009">
+<ele>8</ele>
+<time>2026-02-11T00:06:21Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-11T00:06:30Z</time></trkpt>
+<trkpt lat="45.962289" lon="-66.638069">
+<ele>7</ele>
+<time>2026-02-11T00:06:30Z</time></trkpt>
+<trkpt lat="45.962472" lon="-66.638212">
+<ele>7</ele>
+<time>2026-02-11T00:06:38Z</time></trkpt>
+<trkpt lat="45.96257" lon="-66.638353">
+<ele>7</ele>
+<time>2026-02-11T00:06:44Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-11T00:07:04Z</time></trkpt>
+<trkpt lat="45.962871" lon="-66.638937">
+<ele>8</ele>
+<time>2026-02-11T00:07:04Z</time></trkpt>
+<trkpt lat="45.964051" lon="-66.641227">
+<ele>8</ele>
+<time>2026-02-11T00:08:24Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-11T00:08:30Z</time></trkpt>
+<trkpt lat="45.964162" lon="-66.641395">
+<ele>8</ele>
+<time>2026-02-11T00:08:30Z</time></trkpt>
+<trkpt lat="45.964399" lon="-66.641753">
+<ele>8</ele>
+<time>2026-02-11T00:08:44Z</time></trkpt>
+<trkpt lat="45.965254" lon="-66.642927">
+<ele>7</ele>
+<time>2026-02-11T00:09:31Z</time></trkpt>
+<trkpt lat="45.965528" lon="-66.643281">
+<ele>6</ele>
+<time>2026-02-11T00:09:46Z</time></trkpt>
+<trkpt lat="45.965639" lon="-66.643394">
+<ele>6</ele>
+<time>2026-02-11T00:09:51Z</time></trkpt>
+<trkpt lat="45.965748" lon="-66.643484">
+<ele>4</ele>
+<time>2026-02-11T00:09:56Z</time></trkpt>
+<trkpt lat="45.965873" lon="-66.643545">
+<ele>3</ele>
+<time>2026-02-11T00:10:02Z</time></trkpt>
+<trkpt lat="45.966106" lon="-66.643575">
+<ele>3</ele>
+<time>2026-02-11T00:10:11Z</time></trkpt>
+<trkpt lat="45.966613" lon="-66.643482">
+<ele>3</ele>
+<time>2026-02-11T00:10:32Z</time></trkpt>
+<trkpt lat="45.966872" lon="-66.643476">
+<ele>3</ele>
+<time>2026-02-11T00:10:42Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-11T00:10:43Z</time></trkpt>
+<trkpt lat="45.966887" lon="-66.643468">
+<ele>3</ele>
+<time>2026-02-11T00:10:43Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-11T00:11:54Z</time></trkpt>
+<trkpt lat="45.968574" lon="-66.642642">
+<ele>3</ele>
+<time>2026-02-11T00:11:54Z</time></trkpt>
+<trkpt lat="45.971269" lon="-66.641336">
+<ele>6</ele>
+<time>2026-02-11T00:13:48Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-11T00:14:02Z</time></trkpt>
+<trkpt lat="45.97156" lon="-66.641077">
+<ele>7</ele>
+<time>2026-02-11T00:14:02Z</time></trkpt>
+<trkpt lat="45.971679" lon="-66.640971">
+<ele>7</ele>
+<time>2026-02-11T00:14:07Z</time></trkpt>
+<trkpt lat="45.971842" lon="-66.640842">
+<ele>8</ele>
+<time>2026-02-11T00:14:15Z</time></trkpt>
+<trkpt lat="45.97315" lon="-66.639854">
+<ele>10</ele>
+<time>2026-02-11T00:15:14Z</time></trkpt>
+<trkpt lat="45.97324" lon="-66.639695">
+<ele>10</ele>
+<time>2026-02-11T00:15:20Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-11T00:15:22Z</time></trkpt>
+<trkpt lat="45.973259" lon="-66.639603">
+<ele>10</ele>
+<time>2026-02-11T00:15:22Z</time></trkpt>
+<trkpt lat="45.973279" lon="-66.639509">
+<ele>10</ele>
+<time>2026-02-11T00:15:25Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-11T00:15:46Z</time></trkpt>
+<trkpt lat="45.973066" lon="-66.638813">
+<ele>10</ele>
+<time>2026-02-11T00:15:46Z</time></trkpt>
+<trkpt lat="45.973069" lon="-66.638821">
+<ele>10</ele>
+<time>2026-02-11T00:15:47Z</time></trkpt>
+<trkpt lat="45.973742" lon="-66.638247">
+<ele>11</ele>
+<time>2026-02-11T00:16:18Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/02_friel_10kturn.gpx
+++ b/cursor/plotaroute/02_friel_10kturn.gpx
@@ -1,0 +1,78 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.973749" lon="-66.63825">
+<time>2026-05-31T00:00:00Z</time>
+<name>Start on R</name>
+<cmt>Start on Rue Friel Street</cmt>
+<desc>Start on Rue Friel Street</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.980191" lon="-66.656647">
+<time>2026-05-31T00:09:34Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>02_friel_10kturn</name>
+<trkseg>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.973749" lon="-66.63825">
+<ele>11</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-05-31T00:00:53Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-05-31T00:01:00Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-05-31T00:01:37Z</time></trkpt>
+<trkpt lat="45.974796" lon="-66.641408">
+<ele>11</ele>
+<time>2026-05-31T00:01:37Z</time></trkpt>
+<trkpt lat="45.975824" lon="-66.644429">
+<ele>15</ele>
+<time>2026-05-31T00:03:11Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-05-31T00:04:19Z</time></trkpt>
+<trkpt lat="45.976555" lon="-66.64662">
+<ele>17</ele>
+<time>2026-05-31T00:04:19Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-05-31T00:07:33Z</time></trkpt>
+<trkpt lat="45.978655" lon="-66.652895">
+<ele>18</ele>
+<time>2026-05-31T00:07:33Z</time></trkpt>
+<trkpt lat="45.978997" lon="-66.653873">
+<ele>18</ele>
+<time>2026-05-31T00:08:03Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-05-31T00:08:11Z</time></trkpt>
+<trkpt lat="45.979083" lon="-66.654112">
+<ele>18</ele>
+<time>2026-05-31T00:08:11Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-05-31T00:08:29Z</time></trkpt>
+<trkpt lat="45.979301" lon="-66.654676">
+<ele>17</ele>
+<time>2026-05-31T00:08:29Z</time></trkpt>
+<trkpt lat="45.980191" lon="-66.656647">
+<ele>12</ele>
+<time>2026-05-31T00:09:34Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/03_10kturn_fullturn.gpx
+++ b/cursor/plotaroute/03_10kturn_fullturn.gpx
@@ -1,0 +1,295 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.977804" lon="-66.723732">
+<time>2026-05-31T00:33:27Z</time>
+<name>Make a U-t</name>
+<cmt>Make a U-turn onto Northside Trail</cmt>
+<desc>Make a U-turn onto Northside Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978723" lon="-66.69264">
+<time>2026-05-31T00:47:56Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Northside Trail</cmt>
+<desc>Keep left onto Northside Trail</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978782" lon="-66.692065">
+<time>2026-05-31T00:48:16Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Northside Trail</cmt>
+<desc>Keep left onto Northside Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.980185" lon="-66.656634">
+<time>2026-05-31T01:06:53Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>03_10kturn_fullturn</name>
+<trkseg>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.980604" lon="-66.657551">
+<ele>11</ele>
+<time>2026-05-31T00:00:31Z</time></trkpt>
+<trkpt lat="45.980697" lon="-66.657702">
+<ele>12</ele>
+<time>2026-05-31T00:00:36Z</time></trkpt>
+<trkpt lat="45.98074" lon="-66.657895">
+<ele>12</ele>
+<time>2026-05-31T00:00:42Z</time></trkpt>
+<trkpt lat="45.98101" lon="-66.658415">
+<ele>13</ele>
+<time>2026-05-31T00:01:00Z</time></trkpt>
+<trkpt lat="45.982123" lon="-66.660807">
+<ele>18</ele>
+<time>2026-05-31T00:02:20Z</time></trkpt>
+<trkpt lat="45.982332" lon="-66.661179">
+<ele>18</ele>
+<time>2026-05-31T00:02:33Z</time></trkpt>
+<trkpt lat="45.982542" lon="-66.661474">
+<ele>18</ele>
+<time>2026-05-31T00:02:45Z</time></trkpt>
+<trkpt lat="45.982829" lon="-66.661806">
+<ele>17</ele>
+<time>2026-05-31T00:03:00Z</time></trkpt>
+<trkpt lat="45.98328" lon="-66.662203">
+<ele>16</ele>
+<time>2026-05-31T00:03:21Z</time></trkpt>
+<trkpt lat="45.9835" lon="-66.66236">
+<ele>16</ele>
+<time>2026-05-31T00:03:31Z</time></trkpt>
+<trkpt lat="45.984143" lon="-66.662745">
+<ele>16</ele>
+<time>2026-05-31T00:03:59Z</time></trkpt>
+<trkpt lat="45.984298" lon="-66.66288">
+<ele>15</ele>
+<time>2026-05-31T00:04:06Z</time></trkpt>
+<trkpt lat="45.98464" lon="-66.663258">
+<ele>14</ele>
+<time>2026-05-31T00:04:23Z</time></trkpt>
+<trkpt lat="45.984913" lon="-66.663744">
+<ele>12</ele>
+<time>2026-05-31T00:04:41Z</time></trkpt>
+<trkpt lat="45.985021" lon="-66.664005">
+<ele>12</ele>
+<time>2026-05-31T00:04:49Z</time></trkpt>
+<trkpt lat="45.98514" lon="-66.664376">
+<ele>12</ele>
+<time>2026-05-31T00:05:01Z</time></trkpt>
+<trkpt lat="45.985171" lon="-66.664557">
+<ele>11</ele>
+<time>2026-05-31T00:05:06Z</time></trkpt>
+<trkpt lat="45.985256" lon="-66.665378">
+<ele>9</ele>
+<time>2026-05-31T00:05:29Z</time></trkpt>
+<trkpt lat="45.985234" lon="-66.665874">
+<ele>7</ele>
+<time>2026-05-31T00:05:43Z</time></trkpt>
+<trkpt lat="45.985204" lon="-66.666054">
+<ele>8</ele>
+<time>2026-05-31T00:05:48Z</time></trkpt>
+<trkpt lat="45.981326" lon="-66.681447">
+<ele>12</ele>
+<time>2026-05-31T00:13:24Z</time></trkpt>
+<trkpt lat="45.979288" lon="-66.689529">
+<ele>17</ele>
+<time>2026-05-31T00:17:23Z</time></trkpt>
+<trkpt lat="45.979041" lon="-66.690623">
+<ele>16</ele>
+<time>2026-05-31T00:17:55Z</time></trkpt>
+<trkpt lat="45.978782" lon="-66.692065">
+<ele>10</ele>
+<time>2026-05-31T00:18:37Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.692608">
+<ele>10</ele>
+<time>2026-05-31T00:18:52Z</time></trkpt>
+<trkpt lat="45.978733" lon="-66.692631">
+<ele>10</ele>
+<time>2026-05-31T00:18:57Z</time></trkpt>
+<trkpt lat="45.978695" lon="-66.6927">
+<ele>10</ele>
+<time>2026-05-31T00:18:59Z</time></trkpt>
+<trkpt lat="45.978543" lon="-66.693878">
+<ele>11</ele>
+<time>2026-05-31T00:19:33Z</time></trkpt>
+<trkpt lat="45.978489" lon="-66.694513">
+<ele>12</ele>
+<time>2026-05-31T00:19:51Z</time></trkpt>
+<trkpt lat="45.978412" lon="-66.69597">
+<ele>12</ele>
+<time>2026-05-31T00:20:31Z</time></trkpt>
+<trkpt lat="45.978396" lon="-66.696948">
+<ele>13</ele>
+<time>2026-05-31T00:20:59Z</time></trkpt>
+<trkpt lat="45.978403" lon="-66.699644">
+<ele>13</ele>
+<time>2026-05-31T00:22:14Z</time></trkpt>
+<trkpt lat="45.978433" lon="-66.700431">
+<ele>13</ele>
+<time>2026-05-31T00:22:36Z</time></trkpt>
+<trkpt lat="45.978423" lon="-66.701015">
+<ele>13</ele>
+<time>2026-05-31T00:22:52Z</time></trkpt>
+<trkpt lat="45.978021" lon="-66.707083">
+<ele>21</ele>
+<time>2026-05-31T00:25:42Z</time></trkpt>
+<trkpt lat="45.977706" lon="-66.71324">
+<ele>14</ele>
+<time>2026-05-31T00:28:34Z</time></trkpt>
+<trkpt lat="45.977504" lon="-66.716414">
+<ele>17</ele>
+<time>2026-05-31T00:30:02Z</time></trkpt>
+<trkpt lat="45.977494" lon="-66.717682">
+<ele>16</ele>
+<time>2026-05-31T00:30:38Z</time></trkpt>
+<trkpt lat="45.977569" lon="-66.719148">
+<ele>15</ele>
+<time>2026-05-31T00:31:19Z</time></trkpt>
+<trkpt lat="45.977804" lon="-66.723732">
+<ele>17</ele>
+<time>2026-05-31T00:33:27Z</time></trkpt>
+<trkpt lat="45.977569" lon="-66.719148">
+<ele>15</ele>
+<time>2026-05-31T00:35:35Z</time></trkpt>
+<trkpt lat="45.977494" lon="-66.717682">
+<ele>16</ele>
+<time>2026-05-31T00:36:16Z</time></trkpt>
+<trkpt lat="45.977504" lon="-66.716414">
+<ele>17</ele>
+<time>2026-05-31T00:36:51Z</time></trkpt>
+<trkpt lat="45.977706" lon="-66.71324">
+<ele>14</ele>
+<time>2026-05-31T00:38:20Z</time></trkpt>
+<trkpt lat="45.978021" lon="-66.707083">
+<ele>21</ele>
+<time>2026-05-31T00:41:12Z</time></trkpt>
+<trkpt lat="45.978423" lon="-66.701015">
+<ele>13</ele>
+<time>2026-05-31T00:44:01Z</time></trkpt>
+<trkpt lat="45.978433" lon="-66.700431">
+<ele>13</ele>
+<time>2026-05-31T00:44:18Z</time></trkpt>
+<trkpt lat="45.978403" lon="-66.699644">
+<ele>13</ele>
+<time>2026-05-31T00:44:39Z</time></trkpt>
+<trkpt lat="45.978396" lon="-66.696948">
+<ele>13</ele>
+<time>2026-05-31T00:45:55Z</time></trkpt>
+<trkpt lat="45.978412" lon="-66.69597">
+<ele>12</ele>
+<time>2026-05-31T00:46:22Z</time></trkpt>
+<trkpt lat="45.978489" lon="-66.694513">
+<ele>12</ele>
+<time>2026-05-31T00:47:03Z</time></trkpt>
+<trkpt lat="45.978543" lon="-66.693878">
+<ele>11</ele>
+<time>2026-05-31T00:47:20Z</time></trkpt>
+<trkpt lat="45.978644" lon="-66.693042">
+<ele>10</ele>
+<time>2026-05-31T00:47:44Z</time></trkpt>
+<trkpt lat="45.978695" lon="-66.6927">
+<ele>10</ele>
+<time>2026-05-31T00:47:54Z</time></trkpt>
+<trkpt lat="45.978723" lon="-66.69264">
+<ele>10</ele>
+<time>2026-05-31T00:47:56Z</time></trkpt>
+<trkpt lat="45.978733" lon="-66.692631">
+<ele>10</ele>
+<time>2026-05-31T00:47:56Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.692608">
+<ele>10</ele>
+<time>2026-05-31T00:48:01Z</time></trkpt>
+<trkpt lat="45.978782" lon="-66.692065">
+<ele>10</ele>
+<time>2026-05-31T00:48:16Z</time></trkpt>
+<trkpt lat="45.979041" lon="-66.690623">
+<ele>16</ele>
+<time>2026-05-31T00:48:58Z</time></trkpt>
+<trkpt lat="45.979288" lon="-66.689529">
+<ele>17</ele>
+<time>2026-05-31T00:49:30Z</time></trkpt>
+<trkpt lat="45.981326" lon="-66.681447">
+<ele>12</ele>
+<time>2026-05-31T00:53:29Z</time></trkpt>
+<trkpt lat="45.982487" lon="-66.676841">
+<ele>15</ele>
+<time>2026-05-31T00:55:46Z</time></trkpt>
+<trkpt lat="45.985204" lon="-66.666054">
+<ele>8</ele>
+<time>2026-05-31T01:01:05Z</time></trkpt>
+<trkpt lat="45.985234" lon="-66.665874">
+<ele>7</ele>
+<time>2026-05-31T01:01:10Z</time></trkpt>
+<trkpt lat="45.985256" lon="-66.665378">
+<ele>9</ele>
+<time>2026-05-31T01:01:24Z</time></trkpt>
+<trkpt lat="45.985171" lon="-66.664557">
+<ele>11</ele>
+<time>2026-05-31T01:01:47Z</time></trkpt>
+<trkpt lat="45.98514" lon="-66.664376">
+<ele>12</ele>
+<time>2026-05-31T01:01:53Z</time></trkpt>
+<trkpt lat="45.985021" lon="-66.664005">
+<ele>12</ele>
+<time>2026-05-31T01:02:04Z</time></trkpt>
+<trkpt lat="45.984855" lon="-66.66363">
+<ele>12</ele>
+<time>2026-05-31T01:02:16Z</time></trkpt>
+<trkpt lat="45.98464" lon="-66.663258">
+<ele>14</ele>
+<time>2026-05-31T01:02:30Z</time></trkpt>
+<trkpt lat="45.984298" lon="-66.66288">
+<ele>15</ele>
+<time>2026-05-31T01:02:47Z</time></trkpt>
+<trkpt lat="45.984143" lon="-66.662745">
+<ele>16</ele>
+<time>2026-05-31T01:02:54Z</time></trkpt>
+<trkpt lat="45.9835" lon="-66.66236">
+<ele>16</ele>
+<time>2026-05-31T01:03:22Z</time></trkpt>
+<trkpt lat="45.98328" lon="-66.662203">
+<ele>16</ele>
+<time>2026-05-31T01:03:32Z</time></trkpt>
+<trkpt lat="45.982829" lon="-66.661806">
+<ele>17</ele>
+<time>2026-05-31T01:03:53Z</time></trkpt>
+<trkpt lat="45.982542" lon="-66.661474">
+<ele>18</ele>
+<time>2026-05-31T01:04:08Z</time></trkpt>
+<trkpt lat="45.982332" lon="-66.661179">
+<ele>18</ele>
+<time>2026-05-31T01:04:20Z</time></trkpt>
+<trkpt lat="45.982123" lon="-66.660807">
+<ele>18</ele>
+<time>2026-05-31T01:04:33Z</time></trkpt>
+<trkpt lat="45.98101" lon="-66.658415">
+<ele>13</ele>
+<time>2026-05-31T01:05:53Z</time></trkpt>
+<trkpt lat="45.98074" lon="-66.657895">
+<ele>12</ele>
+<time>2026-05-31T01:06:11Z</time></trkpt>
+<trkpt lat="45.980697" lon="-66.657702">
+<ele>12</ele>
+<time>2026-05-31T01:06:17Z</time></trkpt>
+<trkpt lat="45.980604" lon="-66.657551">
+<ele>11</ele>
+<time>2026-05-31T01:06:23Z</time></trkpt>
+<trkpt lat="45.980185" lon="-66.656634">
+<ele>12</ele>
+<time>2026-05-31T01:06:53Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/04_10kturn_friel.gpx
+++ b/cursor/plotaroute/04_10kturn_friel.gpx
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.980194" lon="-66.656652">
+<time>2026-05-31T00:00:00Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.973747" lon="-66.638243">
+<time>2026-05-31T00:09:35Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>04_10kturn_friel</name>
+<trkseg>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.980194" lon="-66.656652">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.979219" lon="-66.654489">
+<ele>18</ele>
+<time>2026-05-31T00:01:12Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-05-31T00:02:01Z</time></trkpt>
+<trkpt lat="45.978663" lon="-66.652916">
+<ele>18</ele>
+<time>2026-05-31T00:02:01Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-05-31T00:05:15Z</time></trkpt>
+<trkpt lat="45.976557" lon="-66.646625">
+<ele>17</ele>
+<time>2026-05-31T00:05:15Z</time></trkpt>
+<trkpt lat="45.975454" lon="-66.64332">
+<ele>15</ele>
+<time>2026-05-31T00:06:58Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-05-31T00:07:55Z</time></trkpt>
+<trkpt lat="45.974819" lon="-66.641478">
+<ele>12</ele>
+<time>2026-05-31T00:07:55Z</time></trkpt>
+<trkpt lat="45.9744" lon="-66.640206">
+<ele>10</ele>
+<time>2026-05-31T00:08:34Z</time></trkpt>
+<trkpt lat="45.974311" lon="-66.639976">
+<ele>10</ele>
+<time>2026-05-31T00:08:41Z</time></trkpt>
+<trkpt lat="45.973747" lon="-66.638243">
+<ele>11</ele>
+<time>2026-05-31T00:09:35Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/05_friel_station.gpx
+++ b/cursor/plotaroute/05_friel_station.gpx
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.9595782" lon="-66.6192698">
+<time>2026-05-31T00:13:26Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>05_friel_station</name>
+<trkseg>
+<trkpt lat="45.9737509" lon="-66.6382492">
+<ele>11</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.9735813" lon="-66.6377503">
+<ele>11</ele>
+<time>2026-05-31T00:00:15Z</time></trkpt>
+<trkpt lat="45.9729717" lon="-66.6359103">
+<ele>10</ele>
+<time>2026-05-31T00:01:12Z</time></trkpt>
+<trkpt lat="45.9727555" lon="-66.6352236">
+<ele>12</ele>
+<time>2026-05-31T00:01:33Z</time></trkpt>
+<trkpt lat="45.9725244" lon="-66.6346014">
+<ele>15</ele>
+<time>2026-05-31T00:01:53Z</time></trkpt>
+<trkpt lat="45.9723976" lon="-66.6342688">
+<ele>16</ele>
+<time>2026-05-31T00:02:03Z</time></trkpt>
+<trkpt lat="45.9722634" lon="-66.6339362">
+<ele>16</ele>
+<time>2026-05-31T00:02:14Z</time></trkpt>
+<trkpt lat="45.9720919" lon="-66.6335714">
+<ele>16</ele>
+<time>2026-05-31T00:02:26Z</time></trkpt>
+<trkpt lat="45.9719129" lon="-66.6331744">
+<ele>15</ele>
+<time>2026-05-31T00:02:40Z</time></trkpt>
+<trkpt lat="45.9716818" lon="-66.6327238">
+<ele>14</ele>
+<time>2026-05-31T00:02:55Z</time></trkpt>
+<trkpt lat="45.9714208" lon="-66.6323483">
+<ele>14</ele>
+<time>2026-05-31T00:03:10Z</time></trkpt>
+<trkpt lat="45.9712354" lon="-66.6320807">
+<ele>14</ele>
+<time>2026-05-31T00:03:21Z</time></trkpt>
+<trkpt lat="45.9710181" lon="-66.6317689">
+<ele>14</ele>
+<time>2026-05-31T00:03:33Z</time></trkpt>
+<trkpt lat="45.9707571" lon="-66.6315114">
+<ele>13</ele>
+<time>2026-05-31T00:03:46Z</time></trkpt>
+<trkpt lat="45.9705632" lon="-66.6312754">
+<ele>13</ele>
+<time>2026-05-31T00:03:56Z</time></trkpt>
+<trkpt lat="45.9702724" lon="-66.6308463">
+<ele>12</ele>
+<time>2026-05-31T00:04:12Z</time></trkpt>
+<trkpt lat="45.9700785" lon="-66.6305244">
+<ele>12</ele>
+<time>2026-05-31T00:04:24Z</time></trkpt>
+<trkpt lat="45.9697877" lon="-66.6301167">
+<ele>11</ele>
+<time>2026-05-31T00:04:41Z</time></trkpt>
+<trkpt lat="45.9692881" lon="-66.629473">
+<ele>10</ele>
+<time>2026-05-31T00:05:07Z</time></trkpt>
+<trkpt lat="45.9685574" lon="-66.6285373">
+<ele>11</ele>
+<time>2026-05-31T00:05:47Z</time></trkpt>
+<trkpt lat="45.9675431" lon="-66.6272092">
+<ele>12</ele>
+<time>2026-05-31T00:06:42Z</time></trkpt>
+<trkpt lat="45.9664096" lon="-66.6257286">
+<ele>12</ele>
+<time>2026-05-31T00:07:43Z</time></trkpt>
+<trkpt lat="45.9658727" lon="-66.6250634">
+<ele>13</ele>
+<time>2026-05-31T00:08:11Z</time></trkpt>
+<trkpt lat="45.9653954" lon="-66.6243339">
+<ele>14</ele>
+<time>2026-05-31T00:08:39Z</time></trkpt>
+<trkpt lat="45.9644259" lon="-66.6230249">
+<ele>13</ele>
+<time>2026-05-31T00:09:32Z</time></trkpt>
+<trkpt lat="45.9632327" lon="-66.6214371">
+<ele>12</ele>
+<time>2026-05-31T00:10:38Z</time></trkpt>
+<trkpt lat="45.9626062" lon="-66.6206002">
+<ele>12</ele>
+<time>2026-05-31T00:11:12Z</time></trkpt>
+<trkpt lat="45.9619201" lon="-66.6197419">
+<ele>14</ele>
+<time>2026-05-31T00:11:48Z</time></trkpt>
+<trkpt lat="45.9613682" lon="-66.6193771">
+<ele>13</ele>
+<time>2026-05-31T00:12:13Z</time></trkpt>
+<trkpt lat="45.9609058" lon="-66.6192484">
+<ele>12</ele>
+<time>2026-05-31T00:12:32Z</time></trkpt>
+<trkpt lat="45.9603837" lon="-66.6192484">
+<ele>11</ele>
+<time>2026-05-31T00:12:52Z</time></trkpt>
+<trkpt lat="45.9598915" lon="-66.6194201">
+<ele>10</ele>
+<time>2026-05-31T00:13:13Z</time></trkpt>
+<trkpt lat="45.9595782" lon="-66.6192698">
+<ele>10</ele>
+<time>2026-05-31T00:13:26Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/06_station_gibsontrail.gpx
+++ b/cursor/plotaroute/06_station_gibsontrail.gpx
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.958895" lon="-66.6202169">
+<time>2026-05-31T00:00:39Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>06_station_gibsontrail</name>
+<trkseg>
+<trkpt lat="45.959572" lon="-66.6192542">
+<ele>10</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.9594916" lon="-66.6194552">
+<ele>10</ele>
+<time>2026-05-31T00:00:06Z</time></trkpt>
+<trkpt lat="45.9592734" lon="-66.6198601">
+<ele>9</ele>
+<time>2026-05-31T00:00:21Z</time></trkpt>
+<trkpt lat="45.9591243" lon="-66.6200801">
+<ele>9</ele>
+<time>2026-05-31T00:00:29Z</time></trkpt>
+<trkpt lat="45.9590068" lon="-66.6201579">
+<ele>10</ele>
+<time>2026-05-31T00:00:34Z</time></trkpt>
+<trkpt lat="45.958895" lon="-66.6202169">
+<ele>10</ele>
+<time>2026-05-31T00:00:39Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/07_station_qsloop.gpx
+++ b/cursor/plotaroute/07_station_qsloop.gpx
@@ -1,0 +1,580 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-05-31T00:10:05Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9536" lon="-66.639076">
+<time>2026-05-31T00:10:50Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Church Street</cmt>
+<desc>Turn right onto Rue Church Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9536" lon="-66.639076">
+<time>2026-05-31T00:10:52Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Aberdeen Street</cmt>
+<desc>Turn right onto Rue Aberdeen Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.954559" lon="-66.641341">
+<time>2026-05-31T00:12:05Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue Saint John Street</cmt>
+<desc>Turn left onto Rue Saint John Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953262" lon="-66.642474">
+<time>2026-05-31T00:13:06Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Avenue McLeod Avenue</cmt>
+<desc>Turn left onto Avenue McLeod Avenue</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.952078" lon="-66.640406">
+<time>2026-05-31T00:14:23Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.952065" lon="-66.640308">
+<time>2026-05-31T00:14:25Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951885" lon="-66.640411">
+<time>2026-05-31T00:14:33Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951918" lon="-66.640503">
+<time>2026-05-31T00:14:36Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Avenue McLeod Avenue</cmt>
+<desc>Turn left onto Avenue McLeod Avenue</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95163" lon="-66.640884">
+<time>2026-05-31T00:14:52Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951567" lon="-66.640825">
+<time>2026-05-31T00:14:55Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951476" lon="-66.641114">
+<time>2026-05-31T00:15:04Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950944" lon="-66.64109">
+<time>2026-05-31T00:15:26Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right onto Crosstown Trail</cmt>
+<desc>Turn sharp right onto Crosstown Trail</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95021" lon="-66.640061">
+<time>2026-05-31T00:16:18Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Crosstown Trail</cmt>
+<desc>Turn left onto Crosstown Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95024" lon="-66.639638">
+<time>2026-05-31T00:16:29Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Lincoln Trail</cmt>
+<desc>Turn right onto Lincoln Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951746" lon="-66.638803">
+<time>2026-05-31T00:17:36Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951746" lon="-66.638803">
+<time>2026-05-31T00:17:37Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Lincoln Trail</cmt>
+<desc>Turn right onto Lincoln Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958962" lon="-66.62037">
+<time>2026-05-31T00:28:03Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958961" lon="-66.620292">
+<time>2026-05-31T00:28:05Z</time>
+<name>Turn sligh</name>
+<cmt>Turn slight right onto Gibson Trail</cmt>
+<desc>Turn slight right onto Gibson Trail</desc>
+<sym>Right_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.95894" lon="-66.620251">
+<time>2026-05-31T00:28:07Z</time>
+<name>Keep right</name>
+<cmt>Keep right onto Gibson Trail</cmt>
+<desc>Keep right onto Gibson Trail</desc>
+<sym>Straight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958898" lon="-66.620214">
+<time>2026-05-31T00:28:09Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Gibson Trail</cmt>
+<desc>Turn sharp left onto Gibson Trail</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.958905" lon="-66.62021">
+<time>2026-05-31T00:28:09Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>07_station_qsloop</name>
+<trkseg>
+<trkpt lat="45.9595809" lon="-66.6192893">
+<ele>10</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.9589879" lon="-66.6203308">
+<ele>10</ele>
+<time>2026-05-31T00:00:38Z</time></trkpt>
+<trkpt lat="45.9584583" lon="-66.6215003">
+<ele>10</ele>
+<time>2026-05-31T00:01:16Z</time></trkpt>
+<trkpt lat="45.9580854" lon="-66.6235068">
+<ele>7</ele>
+<time>2026-05-31T00:02:14Z</time></trkpt>
+<trkpt lat="45.9574365" lon="-66.6271979">
+<ele>2</ele>
+<time>2026-05-31T00:04:00Z</time></trkpt>
+<trkpt lat="45.9564882" lon="-66.6325076">
+<ele>5</ele>
+<time>2026-05-31T00:06:33Z</time></trkpt>
+<trkpt lat="45.9562495" lon="-66.6339015">
+<ele>9</ele>
+<time>2026-05-31T00:07:13Z</time></trkpt>
+<trkpt lat="45.956247" lon="-66.6339">
+<ele>9</ele>
+<time>2026-05-31T00:07:13Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-05-31T00:07:26Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-05-31T00:07:33Z</time></trkpt>
+<trkpt lat="45.955902" lon="-66.634947">
+<ele>10</ele>
+<time>2026-05-31T00:07:46Z</time></trkpt>
+<trkpt lat="45.955902" lon="-66.634947">
+<ele>10</ele>
+<time>2026-05-31T00:07:46Z</time></trkpt>
+<trkpt lat="45.955809" lon="-66.635139">
+<ele>10</ele>
+<time>2026-05-31T00:07:52Z</time></trkpt>
+<trkpt lat="45.955809" lon="-66.635139">
+<ele>10</ele>
+<time>2026-05-31T00:07:52Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-05-31T00:07:57Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-05-31T00:08:02Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-05-31T00:08:02Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-05-31T00:08:19Z</time></trkpt>
+<trkpt lat="45.9549" lon="-66.636123">
+<ele>10</ele>
+<time>2026-05-31T00:08:38Z</time></trkpt>
+<trkpt lat="45.9549" lon="-66.636123">
+<ele>10</ele>
+<time>2026-05-31T00:08:38Z</time></trkpt>
+<trkpt lat="45.953965" lon="-66.636905">
+<ele>9</ele>
+<time>2026-05-31T00:09:22Z</time></trkpt>
+<trkpt lat="45.953965" lon="-66.636905">
+<ele>9</ele>
+<time>2026-05-31T00:09:22Z</time></trkpt>
+<trkpt lat="45.953053" lon="-66.637674">
+<ele>8</ele>
+<time>2026-05-31T00:10:04Z</time></trkpt>
+<trkpt lat="45.953053" lon="-66.637674">
+<ele>8</ele>
+<time>2026-05-31T00:10:04Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-05-31T00:10:05Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-05-31T00:10:11Z</time></trkpt>
+<trkpt lat="45.9536" lon="-66.639076">
+<ele>9</ele>
+<time>2026-05-31T00:10:50Z</time></trkpt>
+<trkpt lat="45.953614" lon="-66.639064">
+<ele>9</ele>
+<time>2026-05-31T00:10:51Z</time></trkpt>
+<trkpt lat="45.953614" lon="-66.639064">
+<ele>9</ele>
+<time>2026-05-31T00:10:51Z</time></trkpt>
+<trkpt lat="45.9536" lon="-66.639076">
+<ele>9</ele>
+<time>2026-05-31T00:10:52Z</time></trkpt>
+<trkpt lat="45.954552" lon="-66.641325">
+<ele>10</ele>
+<time>2026-05-31T00:12:05Z</time></trkpt>
+<trkpt lat="45.954552" lon="-66.641325">
+<ele>10</ele>
+<time>2026-05-31T00:12:05Z</time></trkpt>
+<trkpt lat="45.954559" lon="-66.641341">
+<ele>10</ele>
+<time>2026-05-31T00:12:05Z</time></trkpt>
+<trkpt lat="45.953274" lon="-66.642464">
+<ele>9</ele>
+<time>2026-05-31T00:13:06Z</time></trkpt>
+<trkpt lat="45.953274" lon="-66.642464">
+<ele>9</ele>
+<time>2026-05-31T00:13:06Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.642474">
+<ele>9</ele>
+<time>2026-05-31T00:13:06Z</time></trkpt>
+<trkpt lat="45.95313" lon="-66.642248">
+<ele>8</ele>
+<time>2026-05-31T00:13:14Z</time></trkpt>
+<trkpt lat="45.952945" lon="-66.642015">
+<ele>8</ele>
+<time>2026-05-31T00:13:24Z</time></trkpt>
+<trkpt lat="45.952945" lon="-66.642015">
+<ele>8</ele>
+<time>2026-05-31T00:13:24Z</time></trkpt>
+<trkpt lat="45.952837" lon="-66.641845">
+<ele>7</ele>
+<time>2026-05-31T00:13:31Z</time></trkpt>
+<trkpt lat="45.952607" lon="-66.641307">
+<ele>8</ele>
+<time>2026-05-31T00:13:48Z</time></trkpt>
+<trkpt lat="45.952607" lon="-66.641307">
+<ele>8</ele>
+<time>2026-05-31T00:13:48Z</time></trkpt>
+<trkpt lat="45.952272" lon="-66.640526">
+<ele>9</ele>
+<time>2026-05-31T00:14:14Z</time></trkpt>
+<trkpt lat="45.952272" lon="-66.640526">
+<ele>9</ele>
+<time>2026-05-31T00:14:14Z</time></trkpt>
+<trkpt lat="45.952164" lon="-66.640423">
+<ele>9</ele>
+<time>2026-05-31T00:14:19Z</time></trkpt>
+<trkpt lat="45.952078" lon="-66.640406">
+<ele>10</ele>
+<time>2026-05-31T00:14:23Z</time></trkpt>
+<trkpt lat="45.952065" lon="-66.640308">
+<ele>10</ele>
+<time>2026-05-31T00:14:25Z</time></trkpt>
+<trkpt lat="45.952016" lon="-66.640322">
+<ele>10</ele>
+<time>2026-05-31T00:14:27Z</time></trkpt>
+<trkpt lat="45.952016" lon="-66.640322">
+<ele>10</ele>
+<time>2026-05-31T00:14:27Z</time></trkpt>
+<trkpt lat="45.951885" lon="-66.640411">
+<ele>10</ele>
+<time>2026-05-31T00:14:33Z</time></trkpt>
+<trkpt lat="45.951918" lon="-66.640503">
+<ele>10</ele>
+<time>2026-05-31T00:14:36Z</time></trkpt>
+<trkpt lat="45.951799" lon="-66.640615">
+<ele>10</ele>
+<time>2026-05-31T00:14:42Z</time></trkpt>
+<trkpt lat="45.951752" lon="-66.640682">
+<ele>10</ele>
+<time>2026-05-31T00:14:44Z</time></trkpt>
+<trkpt lat="45.951752" lon="-66.640682">
+<ele>10</ele>
+<time>2026-05-31T00:14:44Z</time></trkpt>
+<trkpt lat="45.95166" lon="-66.640814">
+<ele>10</ele>
+<time>2026-05-31T00:14:50Z</time></trkpt>
+<trkpt lat="45.95163" lon="-66.640884">
+<ele>10</ele>
+<time>2026-05-31T00:14:52Z</time></trkpt>
+<trkpt lat="45.951567" lon="-66.640825">
+<ele>10</ele>
+<time>2026-05-31T00:14:55Z</time></trkpt>
+<trkpt lat="45.951482" lon="-66.641095">
+<ele>9</ele>
+<time>2026-05-31T00:15:03Z</time></trkpt>
+<trkpt lat="45.951482" lon="-66.641095">
+<ele>9</ele>
+<time>2026-05-31T00:15:03Z</time></trkpt>
+<trkpt lat="45.951476" lon="-66.641114">
+<ele>9</ele>
+<time>2026-05-31T00:15:04Z</time></trkpt>
+<trkpt lat="45.951308" lon="-66.641177">
+<ele>9</ele>
+<time>2026-05-31T00:15:11Z</time></trkpt>
+<trkpt lat="45.951308" lon="-66.641177">
+<ele>9</ele>
+<time>2026-05-31T00:15:11Z</time></trkpt>
+<trkpt lat="45.951244" lon="-66.64119">
+<ele>10</ele>
+<time>2026-05-31T00:15:13Z</time></trkpt>
+<trkpt lat="45.951091" lon="-66.641168">
+<ele>10</ele>
+<time>2026-05-31T00:15:19Z</time></trkpt>
+<trkpt lat="45.950944" lon="-66.64109">
+<ele>11</ele>
+<time>2026-05-31T00:15:26Z</time></trkpt>
+<trkpt lat="45.951036" lon="-66.64123">
+<ele>11</ele>
+<time>2026-05-31T00:15:31Z</time></trkpt>
+<trkpt lat="45.951036" lon="-66.64123">
+<ele>11</ele>
+<time>2026-05-31T00:15:31Z</time></trkpt>
+<trkpt lat="45.95021" lon="-66.640061">
+<ele>11</ele>
+<time>2026-05-31T00:16:18Z</time></trkpt>
+<trkpt lat="45.950211" lon="-66.64005">
+<ele>11</ele>
+<time>2026-05-31T00:16:18Z</time></trkpt>
+<trkpt lat="45.950211" lon="-66.64005">
+<ele>11</ele>
+<time>2026-05-31T00:16:18Z</time></trkpt>
+<trkpt lat="45.95024" lon="-66.639638">
+<ele>10</ele>
+<time>2026-05-31T00:16:29Z</time></trkpt>
+<trkpt lat="45.950231" lon="-66.639635">
+<ele>10</ele>
+<time>2026-05-31T00:16:30Z</time></trkpt>
+<trkpt lat="45.950231" lon="-66.639635">
+<ele>10</ele>
+<time>2026-05-31T00:16:30Z</time></trkpt>
+<trkpt lat="45.950589" lon="-66.639644">
+<ele>10</ele>
+<time>2026-05-31T00:16:44Z</time></trkpt>
+<trkpt lat="45.950737" lon="-66.639597">
+<ele>10</ele>
+<time>2026-05-31T00:16:50Z</time></trkpt>
+<trkpt lat="45.950737" lon="-66.639597">
+<ele>10</ele>
+<time>2026-05-31T00:16:50Z</time></trkpt>
+<trkpt lat="45.951004" lon="-66.639437">
+<ele>10</ele>
+<time>2026-05-31T00:17:02Z</time></trkpt>
+<trkpt lat="45.951181" lon="-66.639287">
+<ele>9</ele>
+<time>2026-05-31T00:17:10Z</time></trkpt>
+<trkpt lat="45.951181" lon="-66.639287">
+<ele>9</ele>
+<time>2026-05-31T00:17:10Z</time></trkpt>
+<trkpt lat="45.951746" lon="-66.638803">
+<ele>8</ele>
+<time>2026-05-31T00:17:36Z</time></trkpt>
+<trkpt lat="45.951743" lon="-66.6388">
+<ele>8</ele>
+<time>2026-05-31T00:17:37Z</time></trkpt>
+<trkpt lat="45.951743" lon="-66.6388">
+<ele>8</ele>
+<time>2026-05-31T00:17:37Z</time></trkpt>
+<trkpt lat="45.951746" lon="-66.638803">
+<ele>8</ele>
+<time>2026-05-31T00:17:37Z</time></trkpt>
+<trkpt lat="45.952965" lon="-66.637749">
+<ele>8</ele>
+<time>2026-05-31T00:18:34Z</time></trkpt>
+<trkpt lat="45.952965" lon="-66.637749">
+<ele>8</ele>
+<time>2026-05-31T00:18:34Z</time></trkpt>
+<trkpt lat="45.953973" lon="-66.636898">
+<ele>9</ele>
+<time>2026-05-31T00:19:20Z</time></trkpt>
+<trkpt lat="45.953973" lon="-66.636898">
+<ele>9</ele>
+<time>2026-05-31T00:19:20Z</time></trkpt>
+<trkpt lat="45.954912" lon="-66.636113">
+<ele>10</ele>
+<time>2026-05-31T00:20:04Z</time></trkpt>
+<trkpt lat="45.954912" lon="-66.636113">
+<ele>10</ele>
+<time>2026-05-31T00:20:04Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-05-31T00:20:23Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-05-31T00:20:40Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-05-31T00:20:44Z</time></trkpt>
+<trkpt lat="45.955794" lon="-66.63517">
+<ele>10</ele>
+<time>2026-05-31T00:20:49Z</time></trkpt>
+<trkpt lat="45.955794" lon="-66.63517">
+<ele>10</ele>
+<time>2026-05-31T00:20:49Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-05-31T00:21:09Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-05-31T00:21:16Z</time></trkpt>
+<trkpt lat="45.956304" lon="-66.633616">
+<ele>8</ele>
+<time>2026-05-31T00:21:37Z</time></trkpt>
+<trkpt lat="45.956304" lon="-66.633616">
+<ele>8</ele>
+<time>2026-05-31T00:21:37Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-05-31T00:22:00Z</time></trkpt>
+<trkpt lat="45.956497" lon="-66.632517">
+<ele>5</ele>
+<time>2026-05-31T00:22:08Z</time></trkpt>
+<trkpt lat="45.956497" lon="-66.632517">
+<ele>5</ele>
+<time>2026-05-31T00:22:08Z</time></trkpt>
+<trkpt lat="45.957091" lon="-66.629159">
+<ele>2</ele>
+<time>2026-05-31T00:23:45Z</time></trkpt>
+<trkpt lat="45.957091" lon="-66.629159">
+<ele>2</ele>
+<time>2026-05-31T00:23:45Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-05-31T00:25:40Z</time></trkpt>
+<trkpt lat="45.957852" lon="-66.624821">
+<ele>4</ele>
+<time>2026-05-31T00:25:50Z</time></trkpt>
+<trkpt lat="45.957852" lon="-66.624821">
+<ele>4</ele>
+<time>2026-05-31T00:25:50Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-05-31T00:25:57Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-05-31T00:26:01Z</time></trkpt>
+<trkpt lat="45.957941" lon="-66.624263">
+<ele>6</ele>
+<time>2026-05-31T00:26:06Z</time></trkpt>
+<trkpt lat="45.958013" lon="-66.623831">
+<ele>7</ele>
+<time>2026-05-31T00:26:18Z</time></trkpt>
+<trkpt lat="45.958013" lon="-66.623831">
+<ele>7</ele>
+<time>2026-05-31T00:26:18Z</time></trkpt>
+<trkpt lat="45.958301" lon="-66.622218">
+<ele>10</ele>
+<time>2026-05-31T00:27:04Z</time></trkpt>
+<trkpt lat="45.958328" lon="-66.622067">
+<ele>10</ele>
+<time>2026-05-31T00:27:09Z</time></trkpt>
+<trkpt lat="45.958328" lon="-66.622067">
+<ele>10</ele>
+<time>2026-05-31T00:27:09Z</time></trkpt>
+<trkpt lat="45.958397" lon="-66.621747">
+<ele>10</ele>
+<time>2026-05-31T00:27:18Z</time></trkpt>
+<trkpt lat="45.958397" lon="-66.621747">
+<ele>10</ele>
+<time>2026-05-31T00:27:18Z</time></trkpt>
+<trkpt lat="45.958433" lon="-66.621584">
+<ele>10</ele>
+<time>2026-05-31T00:27:23Z</time></trkpt>
+<trkpt lat="45.958486" lon="-66.621393">
+<ele>10</ele>
+<time>2026-05-31T00:27:29Z</time></trkpt>
+<trkpt lat="45.958561" lon="-66.621199">
+<ele>10</ele>
+<time>2026-05-31T00:27:35Z</time></trkpt>
+<trkpt lat="45.958561" lon="-66.621199">
+<ele>10</ele>
+<time>2026-05-31T00:27:35Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-05-31T00:27:44Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-05-31T00:27:56Z</time></trkpt>
+<trkpt lat="45.958915" lon="-66.620444">
+<ele>10</ele>
+<time>2026-05-31T00:28:00Z</time></trkpt>
+<trkpt lat="45.958915" lon="-66.620444">
+<ele>10</ele>
+<time>2026-05-31T00:28:00Z</time></trkpt>
+<trkpt lat="45.958962" lon="-66.62037">
+<ele>10</ele>
+<time>2026-05-31T00:28:03Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620304">
+<ele>10</ele>
+<time>2026-05-31T00:28:05Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620304">
+<ele>10</ele>
+<time>2026-05-31T00:28:05Z</time></trkpt>
+<trkpt lat="45.958961" lon="-66.620292">
+<ele>10</ele>
+<time>2026-05-31T00:28:05Z</time></trkpt>
+<trkpt lat="45.95894" lon="-66.620251">
+<ele>10</ele>
+<time>2026-05-31T00:28:07Z</time></trkpt>
+<trkpt lat="45.958898" lon="-66.620214">
+<ele>10</ele>
+<time>2026-05-31T00:28:09Z</time></trkpt>
+<trkpt lat="45.958905" lon="-66.62021">
+<ele>10</ele>
+<time>2026-05-31T00:28:09Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/08_gibsontrail_bridgemill.gpx
+++ b/cursor/plotaroute/08_gibsontrail_bridgemill.gpx
@@ -1,0 +1,513 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.958909" lon="-66.620208">
+<time>2026-05-31T00:00:00Z</time>
+<name>Start on G</name>
+<cmt>Start on Gibson Trail</cmt>
+<desc>Start on Gibson Trail</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-05-31T00:03:44Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953784" lon="-66.617399">
+<time>2026-05-31T00:03:44Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Sentier Gibson Trail</cmt>
+<desc>Turn left onto Sentier Gibson Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.950003" lon="-66.614738">
+<time>2026-05-31T00:06:34Z</time>
+<name>Keep left </name>
+<cmt>Keep left onto Gibson Trail</cmt>
+<desc>Keep left onto Gibson Trail</desc>
+<sym>Left_slight</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.949942" lon="-66.614185">
+<time>2026-05-31T00:06:50Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Gibson Trail</cmt>
+<desc>Turn left onto Gibson Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-05-31T00:07:52Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951078" lon="-66.612801">
+<time>2026-05-31T00:07:53Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-05-31T00:08:45Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.951447" lon="-66.611004">
+<time>2026-05-31T00:08:47Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Gibson Trail</cmt>
+<desc>Turn right onto Gibson Trail</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.976297" lon="-66.589324">
+<time>2026-05-31T00:31:48Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Rue McGloin Street</cmt>
+<desc>Turn left onto Rue McGloin Street</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978815" lon="-66.589547">
+<time>2026-05-31T00:33:31Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978811" lon="-66.589684">
+<time>2026-05-31T00:33:35Z</time>
+<name>Turn right</name>
+<cmt>Turn right</cmt>
+<desc>Turn right</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-05-31T00:34:38Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978756" lon="-66.591914">
+<time>2026-05-31T00:34:39Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>08_gibsontrail_bridgemill</name>
+<trkseg>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.958909" lon="-66.620208">
+<ele>10</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.958625" lon="-66.620306">
+<ele>9</ele>
+<time>2026-05-31T00:00:12Z</time></trkpt>
+<trkpt lat="45.95833" lon="-66.620318">
+<ele>9</ele>
+<time>2026-05-31T00:00:24Z</time></trkpt>
+<trkpt lat="45.958134" lon="-66.620282">
+<ele>9</ele>
+<time>2026-05-31T00:00:31Z</time></trkpt>
+<trkpt lat="45.957933" lon="-66.620207">
+<ele>9</ele>
+<time>2026-05-31T00:00:40Z</time></trkpt>
+<trkpt lat="45.957728" lon="-66.620097">
+<ele>9</ele>
+<time>2026-05-31T00:00:49Z</time></trkpt>
+<trkpt lat="45.95718" lon="-66.619732">
+<ele>6</ele>
+<time>2026-05-31T00:01:13Z</time></trkpt>
+<trkpt lat="45.956327" lon="-66.619138">
+<ele>3</ele>
+<time>2026-05-31T00:01:51Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-05-31T00:02:23Z</time></trkpt>
+<trkpt lat="45.955599" lon="-66.618631">
+<ele>9</ele>
+<time>2026-05-31T00:02:23Z</time></trkpt>
+<trkpt lat="45.953955" lon="-66.617486">
+<ele>10</ele>
+<time>2026-05-31T00:03:36Z</time></trkpt>
+<trkpt lat="45.953846" lon="-66.617411">
+<ele>10</ele>
+<time>2026-05-31T00:03:41Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-05-31T00:03:44Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-05-31T00:03:44Z</time></trkpt>
+<trkpt lat="45.953785" lon="-66.617392">
+<ele>10</ele>
+<time>2026-05-31T00:03:44Z</time></trkpt>
+<trkpt lat="45.953784" lon="-66.617399">
+<ele>10</ele>
+<time>2026-05-31T00:03:44Z</time></trkpt>
+<trkpt lat="45.953661" lon="-66.617407">
+<ele>9</ele>
+<time>2026-05-31T00:03:49Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-05-31T00:03:59Z</time></trkpt>
+<trkpt lat="45.953486" lon="-66.617174">
+<ele>9</ele>
+<time>2026-05-31T00:03:59Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-05-31T00:05:06Z</time></trkpt>
+<trkpt lat="45.951978" lon="-66.616125">
+<ele>10</ele>
+<time>2026-05-31T00:05:06Z</time></trkpt>
+<trkpt lat="45.95177" lon="-66.615978">
+<ele>10</ele>
+<time>2026-05-31T00:05:15Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-05-31T00:05:43Z</time></trkpt>
+<trkpt lat="45.951133" lon="-66.61553">
+<ele>10</ele>
+<time>2026-05-31T00:05:43Z</time></trkpt>
+<trkpt lat="45.950773" lon="-66.615278">
+<ele>9</ele>
+<time>2026-05-31T00:05:59Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-05-31T00:06:32Z</time></trkpt>
+<trkpt lat="45.950039" lon="-66.614763">
+<ele>9</ele>
+<time>2026-05-31T00:06:32Z</time></trkpt>
+<trkpt lat="45.950003" lon="-66.614738">
+<ele>9</ele>
+<time>2026-05-31T00:06:34Z</time></trkpt>
+<trkpt lat="45.949917" lon="-66.614497">
+<ele>9</ele>
+<time>2026-05-31T00:06:41Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-05-31T00:06:43Z</time></trkpt>
+<trkpt lat="45.949912" lon="-66.614422">
+<ele>9</ele>
+<time>2026-05-31T00:06:43Z</time></trkpt>
+<trkpt lat="45.949908" lon="-66.614348">
+<ele>9</ele>
+<time>2026-05-31T00:06:45Z</time></trkpt>
+<trkpt lat="45.949942" lon="-66.614185">
+<ele>9</ele>
+<time>2026-05-31T00:06:50Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-05-31T00:06:54Z</time></trkpt>
+<trkpt lat="45.950037" lon="-66.61414">
+<ele>9</ele>
+<time>2026-05-31T00:06:54Z</time></trkpt>
+<trkpt lat="45.950333" lon="-66.613966">
+<ele>9</ele>
+<time>2026-05-31T00:07:07Z</time></trkpt>
+<trkpt lat="45.950635" lon="-66.613663">
+<ele>10</ele>
+<time>2026-05-31T00:07:22Z</time></trkpt>
+<trkpt lat="45.950902" lon="-66.61323">
+<ele>10</ele>
+<time>2026-05-31T00:07:38Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-05-31T00:07:52Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-05-31T00:07:52Z</time></trkpt>
+<trkpt lat="45.951065" lon="-66.612802">
+<ele>10</ele>
+<time>2026-05-31T00:07:52Z</time></trkpt>
+<trkpt lat="45.951078" lon="-66.612801">
+<ele>10</ele>
+<time>2026-05-31T00:07:53Z</time></trkpt>
+<trkpt lat="45.951176" lon="-66.612384">
+<ele>10</ele>
+<time>2026-05-31T00:08:05Z</time></trkpt>
+<trkpt lat="45.951354" lon="-66.611746">
+<ele>10</ele>
+<time>2026-05-31T00:08:24Z</time></trkpt>
+<trkpt lat="45.95143" lon="-66.61128">
+<ele>10</ele>
+<time>2026-05-31T00:08:38Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-05-31T00:08:45Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-05-31T00:08:46Z</time></trkpt>
+<trkpt lat="45.951431" lon="-66.611006">
+<ele>10</ele>
+<time>2026-05-31T00:08:46Z</time></trkpt>
+<trkpt lat="45.951447" lon="-66.611004">
+<ele>10</ele>
+<time>2026-05-31T00:08:47Z</time></trkpt>
+<trkpt lat="45.951461" lon="-66.610792">
+<ele>10</ele>
+<time>2026-05-31T00:08:53Z</time></trkpt>
+<trkpt lat="45.951556" lon="-66.610483">
+<ele>10</ele>
+<time>2026-05-31T00:09:02Z</time></trkpt>
+<trkpt lat="45.951635" lon="-66.610362">
+<ele>10</ele>
+<time>2026-05-31T00:09:07Z</time></trkpt>
+<trkpt lat="45.951716" lon="-66.610289">
+<ele>10</ele>
+<time>2026-05-31T00:09:10Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-05-31T00:09:13Z</time></trkpt>
+<trkpt lat="45.951765" lon="-66.610215">
+<ele>10</ele>
+<time>2026-05-31T00:09:13Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-05-31T00:10:16Z</time></trkpt>
+<trkpt lat="45.952338" lon="-66.608112">
+<ele>10</ele>
+<time>2026-05-31T00:10:16Z</time></trkpt>
+<trkpt lat="45.952532" lon="-66.607543">
+<ele>12</ele>
+<time>2026-05-31T00:10:34Z</time></trkpt>
+<trkpt lat="45.952784" lon="-66.607017">
+<ele>10</ele>
+<time>2026-05-31T00:10:52Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-05-31T00:11:17Z</time></trkpt>
+<trkpt lat="45.953262" lon="-66.606405">
+<ele>10</ele>
+<time>2026-05-31T00:11:17Z</time></trkpt>
+<trkpt lat="45.953282" lon="-66.606382">
+<ele>10</ele>
+<time>2026-05-31T00:11:18Z</time></trkpt>
+<trkpt lat="45.953384" lon="-66.606251">
+<ele>10</ele>
+<time>2026-05-31T00:11:24Z</time></trkpt>
+<trkpt lat="45.953925" lon="-66.605723">
+<ele>10</ele>
+<time>2026-05-31T00:11:50Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-05-31T00:12:05Z</time></trkpt>
+<trkpt lat="45.954233" lon="-66.605395">
+<ele>10</ele>
+<time>2026-05-31T00:12:05Z</time></trkpt>
+<trkpt lat="45.954387" lon="-66.605232">
+<ele>10</ele>
+<time>2026-05-31T00:12:13Z</time></trkpt>
+<trkpt lat="45.954745" lon="-66.60476">
+<ele>10</ele>
+<time>2026-05-31T00:12:33Z</time></trkpt>
+<trkpt lat="45.955223" lon="-66.603919">
+<ele>10</ele>
+<time>2026-05-31T00:13:03Z</time></trkpt>
+<trkpt lat="45.955571" lon="-66.603154">
+<ele>12</ele>
+<time>2026-05-31T00:13:28Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-05-31T00:14:57Z</time></trkpt>
+<trkpt lat="45.956822" lon="-66.600529">
+<ele>12</ele>
+<time>2026-05-31T00:14:57Z</time></trkpt>
+<trkpt lat="45.958914" lon="-66.596075">
+<ele>15</ele>
+<time>2026-05-31T00:17:27Z</time></trkpt>
+<trkpt lat="45.959408" lon="-66.595054">
+<ele>12</ele>
+<time>2026-05-31T00:18:01Z</time></trkpt>
+<trkpt lat="45.959986" lon="-66.593886">
+<ele>9</ele>
+<time>2026-05-31T00:18:41Z</time></trkpt>
+<trkpt lat="45.960677" lon="-66.592592">
+<ele>10</ele>
+<time>2026-05-31T00:19:27Z</time></trkpt>
+<trkpt lat="45.960883" lon="-66.592242">
+<ele>11</ele>
+<time>2026-05-31T00:19:39Z</time></trkpt>
+<trkpt lat="45.96131" lon="-66.591631">
+<ele>11</ele>
+<time>2026-05-31T00:20:04Z</time></trkpt>
+<trkpt lat="45.963861" lon="-66.588577">
+<ele>12</ele>
+<time>2026-05-31T00:22:17Z</time></trkpt>
+<trkpt lat="45.964377" lon="-66.587911">
+<ele>11</ele>
+<time>2026-05-31T00:22:44Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-05-31T00:22:58Z</time></trkpt>
+<trkpt lat="45.964614" lon="-66.587565">
+<ele>10</ele>
+<time>2026-05-31T00:22:58Z</time></trkpt>
+<trkpt lat="45.965429" lon="-66.586262">
+<ele>7</ele>
+<time>2026-05-31T00:23:47Z</time></trkpt>
+<trkpt lat="45.966107" lon="-66.585312">
+<ele>8</ele>
+<time>2026-05-31T00:24:25Z</time></trkpt>
+<trkpt lat="45.966364" lon="-66.585057">
+<ele>8</ele>
+<time>2026-05-31T00:24:37Z</time></trkpt>
+<trkpt lat="45.966634" lon="-66.584828">
+<ele>8</ele>
+<time>2026-05-31T00:24:50Z</time></trkpt>
+<trkpt lat="45.96688" lon="-66.584676">
+<ele>8</ele>
+<time>2026-05-31T00:25:00Z</time></trkpt>
+<trkpt lat="45.96727" lon="-66.584548">
+<ele>8</ele>
+<time>2026-05-31T00:25:17Z</time></trkpt>
+<trkpt lat="45.967399" lon="-66.584523">
+<ele>8</ele>
+<time>2026-05-31T00:25:22Z</time></trkpt>
+<trkpt lat="45.967658" lon="-66.584517">
+<ele>8</ele>
+<time>2026-05-31T00:25:32Z</time></trkpt>
+<trkpt lat="45.967891" lon="-66.584555">
+<ele>9</ele>
+<time>2026-05-31T00:25:42Z</time></trkpt>
+<trkpt lat="45.968123" lon="-66.584619">
+<ele>8</ele>
+<time>2026-05-31T00:25:51Z</time></trkpt>
+<trkpt lat="45.96836" lon="-66.584715">
+<ele>8</ele>
+<time>2026-05-31T00:26:01Z</time></trkpt>
+<trkpt lat="45.968593" lon="-66.584857">
+<ele>8</ele>
+<time>2026-05-31T00:26:11Z</time></trkpt>
+<trkpt lat="45.972289" lon="-66.587553">
+<ele>10</ele>
+<time>2026-05-31T00:28:57Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-05-31T00:29:25Z</time></trkpt>
+<trkpt lat="45.972907" lon="-66.58804">
+<ele>9</ele>
+<time>2026-05-31T00:29:25Z</time></trkpt>
+<trkpt lat="45.973398" lon="-66.588427">
+<ele>9</ele>
+<time>2026-05-31T00:29:48Z</time></trkpt>
+<trkpt lat="45.973712" lon="-66.588627">
+<ele>8</ele>
+<time>2026-05-31T00:30:01Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-05-31T00:30:13Z</time></trkpt>
+<trkpt lat="45.973971" lon="-66.588764">
+<ele>8</ele>
+<time>2026-05-31T00:30:13Z</time></trkpt>
+<trkpt lat="45.974595" lon="-66.589095">
+<ele>8</ele>
+<time>2026-05-31T00:30:39Z</time></trkpt>
+<trkpt lat="45.974902" lon="-66.589197">
+<ele>9</ele>
+<time>2026-05-31T00:30:52Z</time></trkpt>
+<trkpt lat="45.97523" lon="-66.589266">
+<ele>9</ele>
+<time>2026-05-31T00:31:05Z</time></trkpt>
+<trkpt lat="45.975815" lon="-66.589324">
+<ele>9</ele>
+<time>2026-05-31T00:31:29Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-05-31T00:31:45Z</time></trkpt>
+<trkpt lat="45.976219" lon="-66.589322">
+<ele>10</ele>
+<time>2026-05-31T00:31:45Z</time></trkpt>
+<trkpt lat="45.976297" lon="-66.589324">
+<ele>10</ele>
+<time>2026-05-31T00:31:48Z</time></trkpt>
+<trkpt lat="45.976388" lon="-66.589479">
+<ele>10</ele>
+<time>2026-05-31T00:31:54Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-05-31T00:31:55Z</time></trkpt>
+<trkpt lat="45.976412" lon="-66.589494">
+<ele>10</ele>
+<time>2026-05-31T00:31:55Z</time></trkpt>
+<trkpt lat="45.97647" lon="-66.58953">
+<ele>10</ele>
+<time>2026-05-31T00:31:57Z</time></trkpt>
+<trkpt lat="45.976864" lon="-66.589543">
+<ele>11</ele>
+<time>2026-05-31T00:32:13Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-05-31T00:33:07Z</time></trkpt>
+<trkpt lat="45.978204" lon="-66.589547">
+<ele>11</ele>
+<time>2026-05-31T00:33:07Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-05-31T00:33:30Z</time></trkpt>
+<trkpt lat="45.978794" lon="-66.589547">
+<ele>11</ele>
+<time>2026-05-31T00:33:30Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.589547">
+<ele>11</ele>
+<time>2026-05-31T00:33:31Z</time></trkpt>
+<trkpt lat="45.978813" lon="-66.589615">
+<ele>10</ele>
+<time>2026-05-31T00:33:33Z</time></trkpt>
+<trkpt lat="45.978811" lon="-66.589684">
+<ele>10</ele>
+<time>2026-05-31T00:33:35Z</time></trkpt>
+<trkpt lat="45.978846" lon="-66.589722">
+<ele>10</ele>
+<time>2026-05-31T00:33:37Z</time></trkpt>
+<trkpt lat="45.978852" lon="-66.589755">
+<ele>10</ele>
+<time>2026-05-31T00:33:38Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-05-31T00:33:39Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.589812">
+<ele>10</ele>
+<time>2026-05-31T00:33:39Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-05-31T00:34:17Z</time></trkpt>
+<trkpt lat="45.978826" lon="-66.59118">
+<ele>5</ele>
+<time>2026-05-31T00:34:17Z</time></trkpt>
+<trkpt lat="45.978815" lon="-66.591785">
+<ele>11</ele>
+<time>2026-05-31T00:34:34Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-05-31T00:34:38Z</time></trkpt>
+<trkpt lat="45.978756" lon="-66.591914">
+<ele>12</ele>
+<time>2026-05-31T00:34:39Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/09_bridgemill_fullturn.gpx
+++ b/cursor/plotaroute/09_bridgemill_fullturn.gpx
@@ -1,0 +1,282 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="46.003025" lon="-66.57611">
+<time>2026-05-31T00:20:25Z</time>
+<name>Make a U-t</name>
+<cmt>Make a U-turn onto Nashwaak Trail</cmt>
+<desc>Make a U-turn onto Nashwaak Trail</desc>
+<sym>U-turn</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978791" lon="-66.591908">
+<time>2026-05-31T00:40:50Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>09_bridgemill_fullturn</name>
+<trkseg>
+<trkpt lat="45.978791" lon="-66.591908">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-05-31T00:00:05Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-05-31T00:00:15Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-05-31T00:00:39Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-05-31T00:01:15Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-05-31T00:01:41Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-05-31T00:02:42Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-05-31T00:03:04Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-05-31T00:03:59Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-05-31T00:04:20Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-05-31T00:04:39Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-05-31T00:04:53Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-05-31T00:05:09Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-05-31T00:05:31Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-05-31T00:05:54Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-05-31T00:06:33Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-05-31T00:07:02Z</time></trkpt>
+<trkpt lat="45.987819" lon="-66.586563">
+<ele>11</ele>
+<time>2026-05-31T00:07:22Z</time></trkpt>
+<trkpt lat="45.987851" lon="-66.586415">
+<ele>11</ele>
+<time>2026-05-31T00:07:26Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-05-31T00:07:46Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-05-31T00:08:34Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-05-31T00:08:43Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-05-31T00:08:51Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-05-31T00:09:33Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-05-31T00:11:04Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-05-31T00:11:23Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-05-31T00:11:35Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-05-31T00:11:42Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-05-31T00:14:47Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-05-31T00:15:03Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-05-31T00:15:27Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-05-31T00:15:28Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-05-31T00:15:30Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-05-31T00:16:19Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-05-31T00:16:32Z</time></trkpt>
+<trkpt lat="45.99783" lon="-66.573644">
+<ele>12</ele>
+<time>2026-05-31T00:16:44Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-05-31T00:16:51Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-05-31T00:16:58Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-05-31T00:17:13Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-05-31T00:17:35Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-05-31T00:18:16Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-05-31T00:18:41Z</time></trkpt>
+<trkpt lat="46.003025" lon="-66.57611">
+<ele>14</ele>
+<time>2026-05-31T00:20:25Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-05-31T00:22:09Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-05-31T00:22:34Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-05-31T00:23:15Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-05-31T00:23:38Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-05-31T00:23:52Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-05-31T00:23:59Z</time></trkpt>
+<trkpt lat="45.99783" lon="-66.573644">
+<ele>12</ele>
+<time>2026-05-31T00:24:06Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-05-31T00:24:18Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-05-31T00:24:31Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-05-31T00:25:21Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-05-31T00:25:22Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-05-31T00:25:23Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-05-31T00:25:48Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-05-31T00:26:03Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-05-31T00:29:08Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-05-31T00:29:15Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-05-31T00:29:27Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-05-31T00:29:46Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-05-31T00:31:17Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-05-31T00:31:59Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-05-31T00:32:07Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-05-31T00:32:16Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-05-31T00:33:04Z</time></trkpt>
+<trkpt lat="45.987851" lon="-66.586415">
+<ele>11</ele>
+<time>2026-05-31T00:33:24Z</time></trkpt>
+<trkpt lat="45.987819" lon="-66.586563">
+<ele>11</ele>
+<time>2026-05-31T00:33:29Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-05-31T00:33:48Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-05-31T00:34:18Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-05-31T00:34:56Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-05-31T00:35:20Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-05-31T00:35:41Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-05-31T00:35:57Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-05-31T00:36:11Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-05-31T00:36:30Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-05-31T00:36:51Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-05-31T00:37:47Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-05-31T00:38:08Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-05-31T00:39:10Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-05-31T00:39:36Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-05-31T00:40:11Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-05-31T00:40:35Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-05-31T00:40:45Z</time></trkpt>
+<trkpt lat="45.978791" lon="-66.591908">
+<ele>12</ele>
+<time>2026-05-31T00:40:50Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/10_bridgemill_halfturn.gpx
+++ b/cursor/plotaroute/10_bridgemill_halfturn.gpx
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.978812" lon="-66.591904">
+<time>2026-05-31T00:00:00Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.979101" lon="-66.59187">
+<time>2026-05-31T00:31:03Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9959704" lon="-66.574451">
+<time>2026-05-31T00:00:00Z</time>
+<name>Half Turn</name>
+<cmt>Half Turn</cmt>
+<desc>Half Turn</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9950158" lon="-66.5751376">
+<time>2026-05-31T00:00:00Z</time>
+<name>Water Stop</name>
+<cmt>Water Stop</cmt>
+<desc>Water Stop</desc>
+<sym>Drinking Water</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9789484" lon="-66.5918793">
+<time>2026-05-31T00:00:00Z</time>
+<name>Water Stop</name>
+<cmt>Water Stop</cmt>
+<desc>Water Stop</desc>
+<sym>Drinking Water</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.9790637" lon="-66.5918739">
+<time>2026-05-31T00:00:00Z</time>
+<name>First Aid</name>
+<cmt>First Aid</cmt>
+<desc>First Aid</desc>
+<sym>Medical Facility</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>10_bridgemill_halfturn</name>
+<trkseg>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-05-31T00:00:05Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-05-31T00:00:15Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-05-31T00:00:38Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-05-31T00:00:50Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-05-31T00:00:50Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-05-31T00:01:14Z</time></trkpt>
+<trkpt lat="45.980922" lon="-66.592016">
+<ele>15</ele>
+<time>2026-05-31T00:01:25Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-05-31T00:01:40Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-05-31T00:01:55Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-05-31T00:01:55Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-05-31T00:02:41Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-05-31T00:03:03Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-05-31T00:03:58Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-05-31T00:04:19Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-05-31T00:04:38Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-05-31T00:04:52Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-05-31T00:05:08Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-05-31T00:05:30Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-05-31T00:05:32Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-05-31T00:05:32Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-05-31T00:05:53Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-05-31T00:06:32Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-05-31T00:07:02Z</time></trkpt>
+<trkpt lat="45.987926" lon="-66.586193">
+<ele>11</ele>
+<time>2026-05-31T00:07:32Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-05-31T00:07:45Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-05-31T00:08:33Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-05-31T00:08:43Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-05-31T00:08:51Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-05-31T00:09:32Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-05-31T00:11:03Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-05-31T00:11:22Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-05-31T00:11:34Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-05-31T00:11:42Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-05-31T00:14:46Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-05-31T00:15:02Z</time></trkpt>
+<trkpt lat="45.995963" lon="-66.574401">
+<ele>4</ele>
+<time>2026-05-31T00:15:25Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-05-31T00:15:49Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-05-31T00:16:05Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-05-31T00:19:09Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-05-31T00:19:17Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-05-31T00:19:29Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-05-31T00:19:47Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-05-31T00:21:19Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-05-31T00:22:00Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-05-31T00:22:08Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-05-31T00:22:17Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-05-31T00:23:06Z</time></trkpt>
+<trkpt lat="45.987926" lon="-66.586193">
+<ele>11</ele>
+<time>2026-05-31T00:23:19Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-05-31T00:23:49Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-05-31T00:24:19Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-05-31T00:24:58Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-05-31T00:25:19Z</time></trkpt>
+<trkpt lat="45.986747" lon="-66.590134">
+<ele>12</ele>
+<time>2026-05-31T00:25:19Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-05-31T00:25:21Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-05-31T00:25:43Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-05-31T00:25:59Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-05-31T00:26:13Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-05-31T00:26:32Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-05-31T00:26:53Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-05-31T00:27:48Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-05-31T00:28:09Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-05-31T00:28:56Z</time></trkpt>
+<trkpt lat="45.981676" lon="-66.591945">
+<ele>20</ele>
+<time>2026-05-31T00:28:56Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-05-31T00:29:11Z</time></trkpt>
+<trkpt lat="45.980922" lon="-66.592016">
+<ele>15</ele>
+<time>2026-05-31T00:29:26Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-05-31T00:29:37Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-05-31T00:30:01Z</time></trkpt>
+<trkpt lat="45.980046" lon="-66.591924">
+<ele>12</ele>
+<time>2026-05-31T00:30:01Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-05-31T00:30:13Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-05-31T00:30:36Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-05-31T00:30:46Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-05-31T00:30:51Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-05-31T00:30:51Z</time></trkpt>
+<trkpt lat="45.978812" lon="-66.591904">
+<ele>12</ele>
+<time>2026-05-31T00:30:51Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-05-31T00:30:56Z</time></trkpt>
+<trkpt lat="45.979101" lon="-66.59187">
+<ele>11</ele>
+<time>2026-05-31T00:31:03Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/11_bridgemill_finish.gpx
+++ b/cursor/plotaroute/11_bridgemill_finish.gpx
@@ -1,0 +1,376 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.97879" lon="-66.591898">
+<time>2026-05-31T00:00:00Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978788" lon="-66.591908">
+<time>2026-05-31T00:00:00Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.975623" lon="-66.592254">
+<time>2026-05-31T00:02:11Z</time>
+<name>Turn left </name>
+<cmt>Turn left onto Nashwaak Trail</cmt>
+<desc>Turn left onto Nashwaak Trail</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.966115" lon="-66.603295">
+<time>2026-05-31T00:11:14Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp right</cmt>
+<desc>Turn sharp right</desc>
+<sym>Right_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953071" lon="-66.637658">
+<time>2026-05-31T00:30:10Z</time>
+<name>Turn sharp</name>
+<cmt>Turn sharp left onto Lincoln Trail</cmt>
+<desc>Turn sharp left onto Lincoln Trail</desc>
+<sym>Left_sharp</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953944" lon="-66.639888">
+<time>2026-05-31T00:31:21Z</time>
+<name>Turn left</name>
+<cmt>Turn left</cmt>
+<desc>Turn left</desc>
+<sym>Left</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.953933" lon="-66.639899">
+<time>2026-05-31T00:31:22Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>11_bridgemill_finish</name>
+<trkseg>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.97879" lon="-66.591898">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.978788" lon="-66.591908">
+<ele>12</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.978099" lon="-66.592014">
+<ele>13</ele>
+<time>2026-05-31T00:00:28Z</time></trkpt>
+<trkpt lat="45.97754" lon="-66.592055">
+<ele>15</ele>
+<time>2026-05-31T00:00:50Z</time></trkpt>
+<trkpt lat="45.976207" lon="-66.592051">
+<ele>11</ele>
+<time>2026-05-31T00:01:44Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-05-31T00:02:03Z</time></trkpt>
+<trkpt lat="45.975733" lon="-66.592086">
+<ele>9</ele>
+<time>2026-05-31T00:02:03Z</time></trkpt>
+<trkpt lat="45.975632" lon="-66.592094">
+<ele>9</ele>
+<time>2026-05-31T00:02:07Z</time></trkpt>
+<trkpt lat="45.975623" lon="-66.592254">
+<ele>14</ele>
+<time>2026-05-31T00:02:11Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-05-31T00:02:13Z</time></trkpt>
+<trkpt lat="45.975579" lon="-66.592247">
+<ele>14</ele>
+<time>2026-05-31T00:02:13Z</time></trkpt>
+<trkpt lat="45.975214" lon="-66.592189">
+<ele>12</ele>
+<time>2026-05-31T00:02:28Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-05-31T00:02:29Z</time></trkpt>
+<trkpt lat="45.975184" lon="-66.592197">
+<ele>12</ele>
+<time>2026-05-31T00:02:29Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592442">
+<ele>15</ele>
+<time>2026-05-31T00:03:01Z</time></trkpt>
+<trkpt lat="45.974404" lon="-66.592443">
+<ele>15</ele>
+<time>2026-05-31T00:03:01Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-05-31T00:03:52Z</time></trkpt>
+<trkpt lat="45.973169" lon="-66.592813">
+<ele>17</ele>
+<time>2026-05-31T00:03:52Z</time></trkpt>
+<trkpt lat="45.97213" lon="-66.593132">
+<ele>17</ele>
+<time>2026-05-31T00:04:34Z</time></trkpt>
+<trkpt lat="45.971525" lon="-66.593357">
+<ele>21</ele>
+<time>2026-05-31T00:04:59Z</time></trkpt>
+<trkpt lat="45.969886" lon="-66.594119">
+<ele>22</ele>
+<time>2026-05-31T00:06:08Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-05-31T00:06:21Z</time></trkpt>
+<trkpt lat="45.9696" lon="-66.594281">
+<ele>22</ele>
+<time>2026-05-31T00:06:21Z</time></trkpt>
+<trkpt lat="45.969415" lon="-66.594422">
+<ele>21</ele>
+<time>2026-05-31T00:06:29Z</time></trkpt>
+<trkpt lat="45.969227" lon="-66.594605">
+<ele>21</ele>
+<time>2026-05-31T00:06:38Z</time></trkpt>
+<trkpt lat="45.968963" lon="-66.59493">
+<ele>21</ele>
+<time>2026-05-31T00:06:52Z</time></trkpt>
+<trkpt lat="45.968815" lon="-66.595151">
+<ele>21</ele>
+<time>2026-05-31T00:07:01Z</time></trkpt>
+<trkpt lat="45.9686" lon="-66.595546">
+<ele>21</ele>
+<time>2026-05-31T00:07:15Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-05-31T00:07:23Z</time></trkpt>
+<trkpt lat="45.968498" lon="-66.595789">
+<ele>21</ele>
+<time>2026-05-31T00:07:23Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-05-31T00:09:31Z</time></trkpt>
+<trkpt lat="45.967143" lon="-66.599983">
+<ele>19</ele>
+<time>2026-05-31T00:09:31Z</time></trkpt>
+<trkpt lat="45.966112" lon="-66.603183">
+<ele>17</ele>
+<time>2026-05-31T00:11:10Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-05-31T00:11:13Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-05-31T00:11:13Z</time></trkpt>
+<trkpt lat="45.966116" lon="-66.603312">
+<ele>18</ele>
+<time>2026-05-31T00:11:13Z</time></trkpt>
+<trkpt lat="45.966115" lon="-66.603295">
+<ele>18</ele>
+<time>2026-05-31T00:11:14Z</time></trkpt>
+<trkpt lat="45.96605" lon="-66.603353">
+<ele>17</ele>
+<time>2026-05-31T00:11:17Z</time></trkpt>
+<trkpt lat="45.965996" lon="-66.603402">
+<ele>17</ele>
+<time>2026-05-31T00:11:19Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-05-31T00:11:20Z</time></trkpt>
+<trkpt lat="45.965985" lon="-66.603422">
+<ele>17</ele>
+<time>2026-05-31T00:11:20Z</time></trkpt>
+<trkpt lat="45.965942" lon="-66.603501">
+<ele>17</ele>
+<time>2026-05-31T00:11:23Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-05-31T00:11:30Z</time></trkpt>
+<trkpt lat="45.965908" lon="-66.60375">
+<ele>17</ele>
+<time>2026-05-31T00:11:30Z</time></trkpt>
+<trkpt lat="45.965665" lon="-66.604843">
+<ele>16</ele>
+<time>2026-05-31T00:12:02Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-05-31T00:12:37Z</time></trkpt>
+<trkpt lat="45.96549" lon="-66.60608">
+<ele>16</ele>
+<time>2026-05-31T00:12:37Z</time></trkpt>
+<trkpt lat="45.965181" lon="-66.608383">
+<ele>11</ele>
+<time>2026-05-31T00:13:42Z</time></trkpt>
+<trkpt lat="45.965033" lon="-66.609132">
+<ele>12</ele>
+<time>2026-05-31T00:14:04Z</time></trkpt>
+<trkpt lat="45.964803" lon="-66.609859">
+<ele>12</ele>
+<time>2026-05-31T00:14:26Z</time></trkpt>
+<trkpt lat="45.964626" lon="-66.610341">
+<ele>11</ele>
+<time>2026-05-31T00:14:41Z</time></trkpt>
+<trkpt lat="45.964553" lon="-66.610469">
+<ele>11</ele>
+<time>2026-05-31T00:14:46Z</time></trkpt>
+<trkpt lat="45.963882" lon="-66.611228">
+<ele>11</ele>
+<time>2026-05-31T00:15:20Z</time></trkpt>
+<trkpt lat="45.963738" lon="-66.611445">
+<ele>12</ele>
+<time>2026-05-31T00:15:29Z</time></trkpt>
+<trkpt lat="45.963251" lon="-66.612346">
+<ele>11</ele>
+<time>2026-05-31T00:16:00Z</time></trkpt>
+<trkpt lat="45.963102" lon="-66.612555">
+<ele>10</ele>
+<time>2026-05-31T00:16:09Z</time></trkpt>
+<trkpt lat="45.962888" lon="-66.6132">
+<ele>9</ele>
+<time>2026-05-31T00:16:29Z</time></trkpt>
+<trkpt lat="45.962803" lon="-66.613403">
+<ele>8</ele>
+<time>2026-05-31T00:16:35Z</time></trkpt>
+<trkpt lat="45.962527" lon="-66.613859">
+<ele>9</ele>
+<time>2026-05-31T00:16:52Z</time></trkpt>
+<trkpt lat="45.962084" lon="-66.614756">
+<ele>10</ele>
+<time>2026-05-31T00:17:23Z</time></trkpt>
+<trkpt lat="45.96169" lon="-66.615396">
+<ele>10</ele>
+<time>2026-05-31T00:17:47Z</time></trkpt>
+<trkpt lat="45.961234" lon="-66.615961">
+<ele>11</ele>
+<time>2026-05-31T00:18:11Z</time></trkpt>
+<trkpt lat="45.961024" lon="-66.616296">
+<ele>11</ele>
+<time>2026-05-31T00:18:23Z</time></trkpt>
+<trkpt lat="45.960565" lon="-66.617191">
+<ele>11</ele>
+<time>2026-05-31T00:18:54Z</time></trkpt>
+<trkpt lat="45.959944" lon="-66.618459">
+<ele>10</ele>
+<time>2026-05-31T00:19:37Z</time></trkpt>
+<trkpt lat="45.959573" lon="-66.61926">
+<ele>10</ele>
+<time>2026-05-31T00:20:04Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-05-31T00:20:12Z</time></trkpt>
+<trkpt lat="45.959472" lon="-66.619489">
+<ele>10</ele>
+<time>2026-05-31T00:20:12Z</time></trkpt>
+<trkpt lat="45.959154" lon="-66.620054">
+<ele>9</ele>
+<time>2026-05-31T00:20:32Z</time></trkpt>
+<trkpt lat="45.958838" lon="-66.620567">
+<ele>10</ele>
+<time>2026-05-31T00:20:51Z</time></trkpt>
+<trkpt lat="45.958678" lon="-66.620897">
+<ele>9</ele>
+<time>2026-05-31T00:21:02Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-05-31T00:21:18Z</time></trkpt>
+<trkpt lat="45.958488" lon="-66.62139">
+<ele>10</ele>
+<time>2026-05-31T00:21:18Z</time></trkpt>
+<trkpt lat="45.958337" lon="-66.622017">
+<ele>10</ele>
+<time>2026-05-31T00:21:37Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-05-31T00:22:24Z</time></trkpt>
+<trkpt lat="45.958043" lon="-66.623654">
+<ele>7</ele>
+<time>2026-05-31T00:22:24Z</time></trkpt>
+<trkpt lat="45.957917" lon="-66.624415">
+<ele>5</ele>
+<time>2026-05-31T00:22:46Z</time></trkpt>
+<trkpt lat="45.957894" lon="-66.624562">
+<ele>5</ele>
+<time>2026-05-31T00:22:50Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-05-31T00:23:07Z</time></trkpt>
+<trkpt lat="45.957797" lon="-66.625161">
+<ele>3</ele>
+<time>2026-05-31T00:23:07Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-05-31T00:26:38Z</time></trkpt>
+<trkpt lat="45.956498" lon="-66.632511">
+<ele>5</ele>
+<time>2026-05-31T00:26:38Z</time></trkpt>
+<trkpt lat="45.956443" lon="-66.632825">
+<ele>7</ele>
+<time>2026-05-31T00:26:47Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-05-31T00:27:15Z</time></trkpt>
+<trkpt lat="45.956273" lon="-66.633777">
+<ele>9</ele>
+<time>2026-05-31T00:27:15Z</time></trkpt>
+<trkpt lat="45.956155" lon="-66.634335">
+<ele>9</ele>
+<time>2026-05-31T00:27:31Z</time></trkpt>
+<trkpt lat="45.956079" lon="-66.634562">
+<ele>9</ele>
+<time>2026-05-31T00:27:38Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-05-31T00:27:57Z</time></trkpt>
+<trkpt lat="45.955807" lon="-66.635144">
+<ele>10</ele>
+<time>2026-05-31T00:27:57Z</time></trkpt>
+<trkpt lat="45.955747" lon="-66.635302">
+<ele>10</ele>
+<time>2026-05-31T00:28:02Z</time></trkpt>
+<trkpt lat="45.955664" lon="-66.635399">
+<ele>10</ele>
+<time>2026-05-31T00:28:07Z</time></trkpt>
+<trkpt lat="45.955313" lon="-66.635755">
+<ele>10</ele>
+<time>2026-05-31T00:28:24Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-05-31T00:28:41Z</time></trkpt>
+<trkpt lat="45.954944" lon="-66.636086">
+<ele>10</ele>
+<time>2026-05-31T00:28:41Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-05-31T00:29:25Z</time></trkpt>
+<trkpt lat="45.953997" lon="-66.636878">
+<ele>9</ele>
+<time>2026-05-31T00:29:25Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-05-31T00:30:09Z</time></trkpt>
+<trkpt lat="45.953056" lon="-66.637671">
+<ele>8</ele>
+<time>2026-05-31T00:30:09Z</time></trkpt>
+<trkpt lat="45.953071" lon="-66.637658">
+<ele>8</ele>
+<time>2026-05-31T00:30:10Z</time></trkpt>
+<trkpt lat="45.953087" lon="-66.637863">
+<ele>8</ele>
+<time>2026-05-31T00:30:15Z</time></trkpt>
+<trkpt lat="45.953944" lon="-66.639888">
+<ele>9</ele>
+<time>2026-05-31T00:31:21Z</time></trkpt>
+<trkpt lat="45.953933" lon="-66.639899">
+<ele>9</ele>
+<time>2026-05-31T00:31:22Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/12_station_finish.gpx
+++ b/cursor/plotaroute/12_station_finish.gpx
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.9539395" lon="-66.6399014">
+<time>2026-05-31T00:11:15Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>12_station_finish</name>
+<trkseg>
+<trkpt lat="45.9595734" lon="-66.6192701">
+<ele>10</ele>
+<time>2026-05-31T00:00:00Z</time></trkpt>
+<trkpt lat="45.9592053" lon="-66.6199726">
+<ele>9</ele>
+<time>2026-05-31T00:00:25Z</time></trkpt>
+<trkpt lat="45.9589182" lon="-66.6204447">
+<ele>10</ele>
+<time>2026-05-31T00:00:42Z</time></trkpt>
+<trkpt lat="45.9588771" lon="-66.6204983">
+<ele>10</ele>
+<time>2026-05-31T00:00:44Z</time></trkpt>
+<trkpt lat="45.95881" lon="-66.6206163">
+<ele>10</ele>
+<time>2026-05-31T00:00:48Z</time></trkpt>
+<trkpt lat="45.958728" lon="-66.6208094">
+<ele>9</ele>
+<time>2026-05-31T00:00:55Z</time></trkpt>
+<trkpt lat="45.9585042" lon="-66.6213566">
+<ele>10</ele>
+<time>2026-05-31T00:01:12Z</time></trkpt>
+<trkpt lat="45.9584446" lon="-66.6215658">
+<ele>10</ele>
+<time>2026-05-31T00:01:19Z</time></trkpt>
+<trkpt lat="45.9583401" lon="-66.6220111">
+<ele>10</ele>
+<time>2026-05-31T00:01:32Z</time></trkpt>
+<trkpt lat="45.9580642" lon="-66.6235507">
+<ele>7</ele>
+<time>2026-05-31T00:02:16Z</time></trkpt>
+<trkpt lat="45.957806" lon="-66.6251547">
+<ele>3</ele>
+<time>2026-05-31T00:03:02Z</time></trkpt>
+<trkpt lat="45.9573966" lon="-66.6274559">
+<ele>2</ele>
+<time>2026-05-31T00:04:08Z</time></trkpt>
+<trkpt lat="45.9564308" lon="-66.6329193">
+<ele>8</ele>
+<time>2026-05-31T00:06:45Z</time></trkpt>
+<trkpt lat="45.9562927" lon="-66.6336787">
+<ele>8</ele>
+<time>2026-05-31T00:07:07Z</time></trkpt>
+<trkpt lat="45.9561622" lon="-66.6343224">
+<ele>9</ele>
+<time>2026-05-31T00:07:26Z</time></trkpt>
+<trkpt lat="45.9560914" lon="-66.6345102">
+<ele>9</ele>
+<time>2026-05-31T00:07:32Z</time></trkpt>
+<trkpt lat="45.9559981" lon="-66.6347516">
+<ele>10</ele>
+<time>2026-05-31T00:07:39Z</time></trkpt>
+<trkpt lat="45.9558788" lon="-66.6349822">
+<ele>10</ele>
+<time>2026-05-31T00:07:47Z</time></trkpt>
+<trkpt lat="45.9558042" lon="-66.63517">
+<ele>10</ele>
+<time>2026-05-31T00:07:53Z</time></trkpt>
+<trkpt lat="45.9557557" lon="-66.635288">
+<ele>10</ele>
+<time>2026-05-31T00:07:57Z</time></trkpt>
+<trkpt lat="45.9556662" lon="-66.635406">
+<ele>10</ele>
+<time>2026-05-31T00:08:02Z</time></trkpt>
+<trkpt lat="45.9553716" lon="-66.6357011">
+<ele>10</ele>
+<time>2026-05-31T00:08:17Z</time></trkpt>
+<trkpt lat="45.9550956" lon="-66.6359586">
+<ele>10</ele>
+<time>2026-05-31T00:08:30Z</time></trkpt>
+<trkpt lat="45.9547711" lon="-66.6362321">
+<ele>10</ele>
+<time>2026-05-31T00:08:45Z</time></trkpt>
+<trkpt lat="45.9530784" lon="-66.6376535">
+<ele>8</ele>
+<time>2026-05-31T00:10:03Z</time></trkpt>
+<trkpt lat="45.9530928" lon="-66.6378307">
+<ele>8</ele>
+<time>2026-05-31T00:10:08Z</time></trkpt>
+<trkpt lat="45.9536224" lon="-66.6391021">
+<ele>9</ele>
+<time>2026-05-31T00:10:50Z</time></trkpt>
+<trkpt lat="45.9539395" lon="-66.6399014">
+<ele>9</ele>
+<time>2026-05-31T00:11:15Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/13_halfturn_to_fullturn.gpx
+++ b/cursor/plotaroute/13_halfturn_to_fullturn.gpx
@@ -1,0 +1,136 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.9959839" lon="-66.5744058">
+<time>2026-06-01T00:09:28Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>13_halfturn_to_fullturn</name>
+<trkseg>
+<trkpt lat="45.9959839" lon="-66.5744058">
+<ele>4</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.995981" lon="-66.574392">
+<ele>4</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T00:00:01Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T00:00:02Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T00:00:03Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-06-01T00:00:52Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-06-01T00:01:05Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T00:01:13Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T00:01:13Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-06-01T00:01:24Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-06-01T00:01:31Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-06-01T00:01:46Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T00:02:02Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T00:02:02Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-06-01T00:02:09Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-06-01T00:02:49Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-06-01T00:03:14Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T00:03:23Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T00:03:23Z</time></trkpt>
+<trkpt lat="46.002683" lon="-66.575951">
+<ele>14</ele>
+<time>2026-06-01T00:04:44Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T00:06:05Z</time></trkpt>
+<trkpt lat="46.000754" lon="-66.575046">
+<ele>15</ele>
+<time>2026-06-01T00:06:05Z</time></trkpt>
+<trkpt lat="46.000557" lon="-66.574954">
+<ele>15</ele>
+<time>2026-06-01T00:06:14Z</time></trkpt>
+<trkpt lat="45.999978" lon="-66.574611">
+<ele>17</ele>
+<time>2026-06-01T00:06:39Z</time></trkpt>
+<trkpt lat="45.999073" lon="-66.573949">
+<ele>15</ele>
+<time>2026-06-01T00:07:19Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T00:07:26Z</time></trkpt>
+<trkpt lat="45.998921" lon="-66.573882">
+<ele>15</ele>
+<time>2026-06-01T00:07:26Z</time></trkpt>
+<trkpt lat="45.998532" lon="-66.57371">
+<ele>14</ele>
+<time>2026-06-01T00:07:42Z</time></trkpt>
+<trkpt lat="45.998173" lon="-66.573642">
+<ele>13</ele>
+<time>2026-06-01T00:07:57Z</time></trkpt>
+<trkpt lat="45.997993" lon="-66.573634">
+<ele>13</ele>
+<time>2026-06-01T00:08:04Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T00:08:15Z</time></trkpt>
+<trkpt lat="45.997718" lon="-66.573667">
+<ele>12</ele>
+<time>2026-06-01T00:08:15Z</time></trkpt>
+<trkpt lat="45.997521" lon="-66.573707">
+<ele>11</ele>
+<time>2026-06-01T00:08:23Z</time></trkpt>
+<trkpt lat="45.997205" lon="-66.573822">
+<ele>10</ele>
+<time>2026-06-01T00:08:36Z</time></trkpt>
+<trkpt lat="45.996038" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T00:09:25Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T00:09:26Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T00:09:27Z</time></trkpt>
+<trkpt lat="45.995981" lon="-66.574392">
+<ele>4</ele>
+<time>2026-06-01T00:09:28Z</time></trkpt>
+<trkpt lat="45.9959839" lon="-66.5744058">
+<ele>4</ele>
+<time>2026-06-01T00:09:28Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/14_bridgemill_to_halfturn.gpx
+++ b/cursor/plotaroute/14_bridgemill_to_halfturn.gpx
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.978817" lon="-66.591903">
+<time>2026-06-01T00:00:00Z</time>
+<name>Start on </name>
+<cmt>Start on </cmt>
+<desc>Start on </desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.995971" lon="-66.574397">
+<time>2026-06-01T00:15:26Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>14_bridgemill_to_halfturn</name>
+<trkseg>
+<trkpt lat="45.978817" lon="-66.591903">
+<ele>12</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.978817" lon="-66.591903">
+<ele>12</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-06-01T00:00:04Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-06-01T00:00:14Z</time></trkpt>
+<trkpt lat="45.979505" lon="-66.591875">
+<ele>12</ele>
+<time>2026-06-01T00:00:28Z</time></trkpt>
+<trkpt lat="45.979505" lon="-66.591875">
+<ele>12</ele>
+<time>2026-06-01T00:00:28Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-06-01T00:00:38Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-06-01T00:01:14Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-06-01T00:01:40Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-06-01T00:02:41Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-06-01T00:03:03Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-06-01T00:03:58Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-06-01T00:04:19Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-06-01T00:04:38Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-06-01T00:04:52Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-06-01T00:05:08Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-06-01T00:05:30Z</time></trkpt>
+<trkpt lat="45.986955" lon="-66.589677">
+<ele>12</ele>
+<time>2026-06-01T00:05:47Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-06-01T00:05:53Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-06-01T00:06:31Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-06-01T00:07:01Z</time></trkpt>
+<trkpt lat="45.987926" lon="-66.586193">
+<ele>11</ele>
+<time>2026-06-01T00:07:32Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-06-01T00:07:45Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-06-01T00:08:33Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-06-01T00:08:42Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-06-01T00:08:50Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-06-01T00:09:32Z</time></trkpt>
+<trkpt lat="45.990072" lon="-66.581083">
+<ele>13</ele>
+<time>2026-06-01T00:10:18Z</time></trkpt>
+<trkpt lat="45.990072" lon="-66.581083">
+<ele>13</ele>
+<time>2026-06-01T00:10:18Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-06-01T00:11:03Z</time></trkpt>
+<trkpt lat="45.9908" lon="-66.579277">
+<ele>13</ele>
+<time>2026-06-01T00:11:16Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-06-01T00:11:22Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-06-01T00:11:34Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-06-01T00:11:41Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-06-01T00:14:46Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-06-01T00:15:02Z</time></trkpt>
+<trkpt lat="45.995971" lon="-66.574397">
+<ele>4</ele>
+<time>2026-06-01T00:15:26Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/15_halfturn_to_bridgemill.gpx
+++ b/cursor/plotaroute/15_halfturn_to_bridgemill.gpx
@@ -1,0 +1,140 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1" creator="www.plotaroute.com" version="1.1"  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata>
+<desc>Route created on plotaroute.com</desc>
+</metadata>
+<wpt lat="45.996057" lon="-66.574357">
+<time>2026-06-01T00:00:00Z</time>
+<name>Start on N</name>
+<cmt>Start on Nashwaak Trail</cmt>
+<desc>Start on Nashwaak Trail</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978851" lon="-66.591896">
+<time>2026-06-01T00:15:28Z</time>
+<name>Turn right</name>
+<cmt>Turn right onto Rue Bridge Street</cmt>
+<desc>Turn right onto Rue Bridge Street</desc>
+<sym>Right</sym>
+<type>Waypoint</type>
+</wpt>
+<wpt lat="45.978851" lon="-66.591931">
+<time>2026-06-01T00:15:29Z</time>
+<name>FINISH</name>
+<cmt>FINISH</cmt>
+<desc>FINISH</desc>
+<sym>Flag, Blue</sym>
+<type>Waypoint</type>
+</wpt>
+<trk>
+<name>15_halfturn_to_bridgemill</name>
+<trkseg>
+<trkpt lat="45.996057" lon="-66.574357">
+<ele>4</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.996057" lon="-66.574357">
+<ele>4</ele>
+<time>2026-06-01T00:00:00Z</time></trkpt>
+<trkpt lat="45.996007" lon="-66.574365">
+<ele>4</ele>
+<time>2026-06-01T00:00:02Z</time></trkpt>
+<trkpt lat="45.995984" lon="-66.574391">
+<ele>4</ele>
+<time>2026-06-01T00:00:03Z</time></trkpt>
+<trkpt lat="45.995404" lon="-66.574686">
+<ele>10</ele>
+<time>2026-06-01T00:00:28Z</time></trkpt>
+<trkpt lat="45.995066" lon="-66.574953">
+<ele>10</ele>
+<time>2026-06-01T00:00:43Z</time></trkpt>
+<trkpt lat="45.991238" lon="-66.578647">
+<ele>13</ele>
+<time>2026-06-01T00:03:48Z</time></trkpt>
+<trkpt lat="45.991099" lon="-66.578811">
+<ele>12</ele>
+<time>2026-06-01T00:03:55Z</time></trkpt>
+<trkpt lat="45.990882" lon="-66.579114">
+<ele>13</ele>
+<time>2026-06-01T00:04:07Z</time></trkpt>
+<trkpt lat="45.990625" lon="-66.579677">
+<ele>13</ele>
+<time>2026-06-01T00:04:26Z</time></trkpt>
+<trkpt lat="45.989504" lon="-66.582529">
+<ele>15</ele>
+<time>2026-06-01T00:05:57Z</time></trkpt>
+<trkpt lat="45.989032" lon="-66.583864">
+<ele>12</ele>
+<time>2026-06-01T00:06:39Z</time></trkpt>
+<trkpt lat="45.988931" lon="-66.58411">
+<ele>12</ele>
+<time>2026-06-01T00:06:47Z</time></trkpt>
+<trkpt lat="45.988805" lon="-66.584382">
+<ele>11</ele>
+<time>2026-06-01T00:06:56Z</time></trkpt>
+<trkpt lat="45.988087" lon="-66.585774">
+<ele>12</ele>
+<time>2026-06-01T00:07:44Z</time></trkpt>
+<trkpt lat="45.987851" lon="-66.586415">
+<ele>11</ele>
+<time>2026-06-01T00:08:05Z</time></trkpt>
+<trkpt lat="45.987819" lon="-66.586563">
+<ele>11</ele>
+<time>2026-06-01T00:08:09Z</time></trkpt>
+<trkpt lat="45.987621" lon="-66.587191">
+<ele>10</ele>
+<time>2026-06-01T00:08:28Z</time></trkpt>
+<trkpt lat="45.987372" lon="-66.588201">
+<ele>9</ele>
+<time>2026-06-01T00:08:58Z</time></trkpt>
+<trkpt lat="45.987026" lon="-66.589492">
+<ele>12</ele>
+<time>2026-06-01T00:09:36Z</time></trkpt>
+<trkpt lat="45.986715" lon="-66.590203">
+<ele>12</ele>
+<time>2026-06-01T00:10:00Z</time></trkpt>
+<trkpt lat="45.986348" lon="-66.590762">
+<ele>13</ele>
+<time>2026-06-01T00:10:21Z</time></trkpt>
+<trkpt lat="45.986009" lon="-66.591097">
+<ele>13</ele>
+<time>2026-06-01T00:10:38Z</time></trkpt>
+<trkpt lat="45.98571" lon="-66.591319">
+<ele>14</ele>
+<time>2026-06-01T00:10:51Z</time></trkpt>
+<trkpt lat="45.985251" lon="-66.591525">
+<ele>12</ele>
+<time>2026-06-01T00:11:10Z</time></trkpt>
+<trkpt lat="45.984739" lon="-66.591659">
+<ele>14</ele>
+<time>2026-06-01T00:11:31Z</time></trkpt>
+<trkpt lat="45.983354" lon="-66.591705">
+<ele>13</ele>
+<time>2026-06-01T00:12:27Z</time></trkpt>
+<trkpt lat="45.982824" lon="-66.591745">
+<ele>15</ele>
+<time>2026-06-01T00:12:48Z</time></trkpt>
+<trkpt lat="45.981295" lon="-66.592012">
+<ele>18</ele>
+<time>2026-06-01T00:13:50Z</time></trkpt>
+<trkpt lat="45.980648" lon="-66.592009">
+<ele>13</ele>
+<time>2026-06-01T00:14:16Z</time></trkpt>
+<trkpt lat="45.979756" lon="-66.591883">
+<ele>12</ele>
+<time>2026-06-01T00:14:52Z</time></trkpt>
+<trkpt lat="45.979174" lon="-66.591865">
+<ele>11</ele>
+<time>2026-06-01T00:15:15Z</time></trkpt>
+<trkpt lat="45.978925" lon="-66.591881">
+<ele>12</ele>
+<time>2026-06-01T00:15:25Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.591896">
+<ele>12</ele>
+<time>2026-06-01T00:15:28Z</time></trkpt>
+<trkpt lat="45.978851" lon="-66.591931">
+<ele>12</ele>
+<time>2026-06-01T00:15:29Z</time></trkpt>
+</trkseg>
+</trk>
+</gpx>

--- a/cursor/plotaroute/README.md
+++ b/cursor/plotaroute/README.md
@@ -1,0 +1,76 @@
+# PlotARoute segment library (reference)
+
+GPX **routes** in this folder are reusable course **segments**. Event courses are built by **combining** routes in order (PlotARoute “Combine Route”), or—in the app—by assigning **order numbers** per event in a table.
+
+## Files
+
+| Prefix | Meaning |
+|--------|---------|
+| `01`–`15` | Individual segments |
+| `00_full_new.gpx` | Combined **Full** (authoritative check for full recipe) |
+| `00_half.gpx`, `00_10k.gpx` | Combined Half / 10K |
+
+## Full marathon (corrected Marysville legs)
+
+**Do not** combine route `10` (out-and-back) before route `13` — the return strand leaves the course disconnected.
+
+**Use:**
+
+`01 → 02 → 03 → 04 → 05 → 06 → 07 → 08 → 14 → 13 → 15 → 11`
+
+Matches `00_full_new.gpx` (~41.9 km).
+
+| Id | File | ~km | Full order |
+|----|------|-----|------------|
+| 01 | `01_start_friel.gpx` | 2.71 | 1 |
+| 02 | `02_friel_10kturn.gpx` | 1.59 | 2 |
+| 03 | `03_10kturn_fullturn.gpx` | 11.14 | 3 |
+| 04 | `04_10kturn_friel.gpx` | 1.59 | 4 |
+| 05 | `05_friel_station.gpx` | 2.24 | 5 |
+| 06 | `06_station_gibsontrail.gpx` | 0.11 | 6 |
+| 07 | `07_station_qsloop.gpx` | 4.69 | 7 |
+| 08 | `08_gibsontrail_bridgemill.gpx` | 5.77 | 8 |
+| 14 | `14_bridgemill_to_halfturn.gpx` | 2.57 | 9 |
+| 13 | `13_halfturn_to_fullturn.gpx` | 1.58 | 10 |
+| 15 | `15_halfturn_to_bridgemill.gpx` | 2.58 | 11 |
+| 11 | `11_bridgemill_finish.gpx` | 5.22 | 12 |
+
+## Half marathon
+
+`00_half.gpx` in this folder still uses legacy route **10** (out-and-back). For runflow, use this recipe instead (~**21.20 km**, matches distance target; all stitches &lt; 15 m):
+
+`01 → 05 → 06 → 08 → 14 → 15 → 11`
+
+| Id | File | ~km | half order |
+|----|------|-----|------------|
+| 01 | `01_start_friel.gpx` | 2.71 | 1 |
+| 05 | `05_friel_station.gpx` | 2.24 | 2 |
+| 06 | `06_station_gibsontrail.gpx` | 0.11 | 3 |
+| 08 | `08_gibsontrail_bridgemill.gpx` | 5.77 | 4 |
+| 14 | `14_bridgemill_to_halfturn.gpx` | 2.57 | 5 |
+| 15 | `15_halfturn_to_bridgemill.gpx` | 2.58 | 6 |
+| 11 | `11_bridgemill_finish.gpx` | 5.22 | 7 |
+
+No route **10**, **12**, or **13** on Half.
+
+## 10K
+
+Unchanged (~**10.00 km** vs `00_10k.gpx` 10.02 km):
+
+`01 → 02 → 04 → 05 → 12`
+
+| Id | File | ~km | 10k order |
+|----|------|-----|-----------|
+| 01 | `01_start_friel.gpx` | 2.71 | 1 |
+| 02 | `02_friel_10kturn.gpx` | 1.59 | 2 |
+| 04 | `04_10kturn_friel.gpx` | 1.59 | 3 |
+| 05 | `05_friel_station.gpx` | 2.24 | 4 |
+| 12 | `12_station_finish.gpx` | 1.87 | 5 |
+
+## Stitch gaps
+
+Small endpoint gaps (&lt;10 m) are normal. ~105 m between `06` and `07` exists in PlotARoute too—fix in PlotARoute or add a connector segment later if needed.
+
+## App direction
+
+Organizers will **not** edit this YAML. Phase 1 UI: import GPX → recipe table (order per event) → **Save** → `segments.csv`.

--- a/cursor/plotaroute/generated_segments.csv
+++ b/cursor/plotaroute/generated_segments.csv
@@ -1,0 +1,16 @@
+seg_id,seg_label,width_m,schema,direction,full,half,10k,elite,open,full_from_km,full_to_km,half_from_km,half_to_km,10k_from_km,10k_to_km,elite_from_km,elite_to_km,open_from_km,open_to_km,full_length,half_length,10k_length,elite_length,open_length,description
+A1,Start to Northside Trail at Friel,5,on_course_open,uni,y,y,y,n,n,0,2.71,0,2.71,0,2.71,0,0,0,0,2.71,2.71,2.71,0,0,
+B1,Friel to 10K Turn (Out),1.5,on_course_narrow,bi,y,n,y,n,n,2.71,4.3,0,0,2.71,4.3,0,0,0,0,1.59,0,1.59,0,0,
+C1,10K Turn to Full Turn at Blake (Out),1.5,on_course_narrow,bi,y,n,n,n,n,4.3,15.44,0,0,0,0,0,0,0,0,11.14,0,0,0,0,
+B2,10K Turn to Friel (Back),1.5,on_course_narrow,bi,y,n,y,n,n,15.44,17.03,0,0,4.3,5.89,0,0,0,0,1.59,0,1.59,0,0,
+E1,Friel to Station Rd,3,on_course_open,uni,y,y,y,n,n,17.03,19.27,2.71,4.95,5.89,8.13,0,0,0,0,2.24,2.24,2.24,0,0,
+E2,Station connector (Gibson),3,on_course_open,uni,y,y,n,n,n,19.27,19.38,4.95,5.06,0,0,0,0,0,0,0.11,0.11,0,0,0,
+G1,Station to QS loop,3,on_course_open,uni,y,n,n,n,n,19.38,24.07,0,0,0,0,0,0,0,0,4.69,0,0,0,0,
+I1,Gibson Trail to Bridge/Mill,3,on_course_open,uni,y,y,n,n,n,24.07,29.84,5.06,10.83,0,0,0,0,0,0,5.77,5.77,0,0,0,
+J2,Bridge/Mill to Full Turn (legacy),1.5,on_course_narrow,uni,n,n,n,n,n,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Superseded for Full by 13–15; kept for reference.
+J1,Bridge/Mill to Half Turn (legacy out-and-back),1.5,on_course_narrow,bi,n,n,n,n,n,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,Do not use on Full combine (stranded runner with 13). Half may still use.
+K2,Bridge/Mill to QS finish leg,1.5,on_course_narrow,uni,y,y,n,n,n,29.84,35.06,10.83,16.05,0,0,0,0,0,0,5.22,5.22,0,0,0,
+M1,Station to Finish,3,on_course_open,uni,n,n,y,n,n,0,0,0,0,8.13,10,0,0,0,0,0,0,1.87,0,0,
+J3,Half Turn to Full Turn (Out and back),1.5,on_course_narrow,bi,y,n,n,n,n,35.06,36.64,0,0,0,0,0,0,0,0,1.58,0,0,0,0,Full only — Chase tree farm / full turn.
+J4,Bridge/Mill to Half Turn,1.5,on_course_narrow,uni,y,y,n,n,n,36.64,39.21,16.05,18.62,0,0,0,0,0,0,2.57,2.57,0,0,0,One-way to half turn; Full and Half.
+J5,Half Turn to Bridge/Mill,1.5,on_course_narrow,uni,y,y,n,n,n,39.21,41.79,18.62,21.2,0,0,0,0,0,0,2.58,2.58,0,0,0,One-way Half Turn to Bridge/Mill; Full and Half (replaces legacy 10 out-and-back).

--- a/cursor/plotaroute/manifest.yaml
+++ b/cursor/plotaroute/manifest.yaml
@@ -1,0 +1,157 @@
+# Segment library (PlotARoute GPX chunks) — developer import only.
+# End users will edit a recipe table in the app; this file backs import/tests until then.
+#
+# Full 2026 fix: routes 09/10 (out-and-back) replaced by 14 → 13 → 15 → 11 for Marysville.
+
+version: 2
+label: "Fredericton Marathon (PlotARoute library)"
+
+chunks:
+  - id: "01"
+    file: "01_start_friel.gpx"
+    seg_id: "A1"
+    seg_label: "Start to Northside Trail at Friel"
+    width_m: 5
+    schema: on_course_open
+    direction: uni
+  - id: "02"
+    file: "02_friel_10kturn.gpx"
+    seg_id: "B1"
+    seg_label: "Friel to 10K Turn (Out)"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: bi
+  - id: "03"
+    file: "03_10kturn_fullturn.gpx"
+    seg_id: "C1"
+    seg_label: "10K Turn to Full Turn at Blake (Out)"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: bi
+  - id: "04"
+    file: "04_10kturn_friel.gpx"
+    seg_id: "B2"
+    seg_label: "10K Turn to Friel (Back)"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: bi
+  - id: "05"
+    file: "05_friel_station.gpx"
+    seg_id: "E1"
+    seg_label: "Friel to Station Rd"
+    width_m: 3
+    schema: on_course_open
+    direction: uni
+  - id: "06"
+    file: "06_station_gibsontrail.gpx"
+    seg_id: "E2"
+    seg_label: "Station connector (Gibson)"
+    width_m: 3
+    schema: on_course_open
+    direction: uni
+  - id: "07"
+    file: "07_station_qsloop.gpx"
+    seg_id: "G1"
+    seg_label: "Station to QS loop"
+    width_m: 3
+    schema: on_course_open
+    direction: uni
+  - id: "08"
+    file: "08_gibsontrail_bridgemill.gpx"
+    seg_id: "I1"
+    seg_label: "Gibson Trail to Bridge/Mill"
+    width_m: 3
+    schema: on_course_open
+    direction: uni
+  - id: "09"
+    file: "09_bridgemill_fullturn.gpx"
+    seg_id: "J2"
+    seg_label: "Bridge/Mill to Full Turn (legacy)"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: uni
+    description: "Superseded for Full by 13–15; kept for reference."
+  - id: "10"
+    file: "10_bridgemill_halfturn.gpx"
+    seg_id: "J1"
+    seg_label: "Bridge/Mill to Half Turn (legacy out-and-back)"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: bi
+    description: "Do not use on Full combine (stranded runner with 13). Half may still use."
+  - id: "11"
+    file: "11_bridgemill_finish.gpx"
+    seg_id: "K2"
+    seg_label: "Bridge/Mill to QS finish leg"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: uni
+  - id: "12"
+    file: "12_station_finish.gpx"
+    seg_id: "M1"
+    seg_label: "Station to Finish"
+    width_m: 3
+    schema: on_course_open
+    direction: uni
+  - id: "13"
+    file: "13_halfturn_to_fullturn.gpx"
+    seg_id: "J3"
+    seg_label: "Half Turn to Full Turn (Out and back)"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: bi
+    description: "Full only — Chase tree farm / full turn."
+  - id: "14"
+    file: "14_bridgemill_to_halfturn.gpx"
+    seg_id: "J4"
+    seg_label: "Bridge/Mill to Half Turn"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: uni
+    description: "One-way to half turn; Full and Half."
+  - id: "15"
+    file: "15_halfturn_to_bridgemill.gpx"
+    seg_id: "J5"
+    seg_label: "Half Turn to Bridge/Mill"
+    width_m: 1.5
+    schema: on_course_narrow
+    direction: uni
+    description: "One-way Half Turn to Bridge/Mill; Full and Half (replaces legacy 10 out-and-back)."
+
+# Recipe order = event column numbers in the end-user table (Phase 1 UI).
+recipes:
+  "10k":
+    - "01"
+    - "02"
+    - "04"
+    - "05"
+    - "12"
+  "half":
+    - "01"
+    - "05"
+    - "06"
+    - "08"
+    - "14"
+    - "15"
+    - "11"
+  "full":
+    - "01"
+    - "02"
+    - "03"
+    - "04"
+    - "05"
+    - "06"
+    - "07"
+    - "08"
+    - "14"
+    - "13"
+    - "15"
+    - "11"
+
+reference_combined:
+  full: "00_full_new.gpx"
+  half: "00_half.gpx"
+  "10k": "00_10k.gpx"
+  # half: 00_half.gpx uses orphaned route 10; use recipe below (~21.2 km), not 00_half combine
+
+flow_overrides: []

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       - ./config:/app/config
       # Issue #694: Mount docs directory for AI analysis templates
       - ./docs:/app/docs
+      # Segment library reference GPX (PlotARoute chunks for recipe UI)
+      - ./cursor:/app/cursor
       # Issue #470: Legacy artifacts/ and reports/ mounts removed - using runflow/ structure exclusively
       # Issue #465: GCS keys mount disabled during Phase 0 (local-only mode)
       # - ./keys:/tmp/keys:ro

--- a/docs/dev-guides/segment-library-2027.md
+++ b/docs/dev-guides/segment-library-2027.md
@@ -1,0 +1,160 @@
+# Segment library & event recipes (2027 planning)
+
+**Status:** Prototype in `app/core/course/segment_library.py`  
+**Reference data:** `cursor/plotaroute/` (PlotARoute chunks + combined `00_*.gpx`)  
+**Epic:** #755 · Related: #767 (planner), #759 (flow review)
+
+---
+
+## Goal
+
+Use a **map/GPX workflow** to produce analysis-ready config **without hand-editing** `segments.csv`, `flow.csv`, or `locations.csv` for each new year (e.g. 2027).
+
+| Output | Role in analysis |
+|--------|------------------|
+| **segments.csv** | **Multi-event rows** — one row per *shared* course chunk; `full`/`half`/`10k` flags; per-event `*_from_km` / `*_to_km` for density |
+| **flow.csv** | **Event pairs** on shared chunks; uses *each event’s* km on that chunk (can differ on same `seg_id` in advanced cases) |
+| **locations.csv** | Points with **per-event** flags and km; first/last runner times pool arrivals across all flagged events |
+| **`{event}.gpx`** | Per-event geometry for GPX projection and location distance |
+
+---
+
+## Model (PlotARoute-aligned)
+
+### 1. Segment library
+
+- Each file `01_start_friel.gpx`, `02_friel_10kturn.gpx`, … is one **chunk**.
+- Chunks stitch end-to-end (endpoint tolerance ~80 m).
+- Metadata in `cursor/plotaroute/manifest.yaml`: `seg_id`, `seg_label`, width, schema, direction.
+
+### 2. Event recipes
+
+Ordered list of chunk ids per event:
+
+```yaml
+recipes:
+  10k: [01, 02, 04, 05, 06, 12]
+  half: [01, 05, 08, 10, 11, 12]
+  full: [01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12]
+```
+
+- **Combine** = concatenate chunk GPX (same idea as PlotARoute “Combine Route”).
+- Verify `recipe_lengths_km` against `00_{event}.gpx` after edits.
+
+### 3. Export `segments.csv` (multi-event — required)
+
+**One row per chunk**, not per event:
+
+| Column | Source |
+|--------|--------|
+| `seg_id`, `seg_label`, … | Chunk metadata |
+| `full`, `half`, `10k`, … | `y` if chunk appears in that event’s recipe |
+| `full_from_km`, `full_to_km`, … | Cumulative distance along **that event’s recipe only** |
+| `0` / `n` | Events that skip the chunk |
+
+This matches **2026_final** (e.g. A1 used by Full+Half+10K with aligned early km; B1 Full+10K only with `half` = n).
+
+Density (`get_shared_segments`, bins) uses these flags — **shared segments must stay on one row**.
+
+### 4. Export `flow.csv` (re-planned)
+
+**Generator:** `build_flow_csv_from_segments()` in `segment_library.py`.
+
+For each segment row where **2+ events** are active:
+
+- Emit rows for event pairs `(A, B)` (and same-event pairs where needed, e.g. 10k/10k on B3-style legs).
+- `from_km_a` / `to_km_a` = segment’s `{event_a}_from_km` / `{event_a}_to_km`.
+- `from_km_b` / `to_km_b` = same for event B.
+- Default `flow_type`: `overtake`; overrides in manifest `flow_overrides` or future UI.
+
+**Not** the old stub in `build_flow_csv()` (one row per segment, same event A/B).
+
+**Pipeline:** `app/core/v2/flow.py` — `flow.csv` is authoritative; pairs must exist for requested events or analysis fails (#553).
+
+**Follow-up (#759):** Review grid for exceptions (e.g. 2026 `B1a` — same `seg_label`, different km windows for late overlaps). Auto-generate baseline; human adds override rows.
+
+### 5. Locations (re-planned)
+
+Locations are **like segments + flow**: multi-event, analysis uses **all** eligible events at a point.
+
+**Current analysis** (`app/location_report.py`):
+
+1. Read `locations.csv` flags (`full`, `half`, `10k`, …).
+2. For each eligible event, compute arrival times from:
+   - Listed `seg_id`(s) on the location, **or**
+   - Nearest segment + GPX projection using `{event}.gpx`.
+3. Uses `{event}_from_km` / distance on segment for `pace × distance + start`.
+4. **`first_runner` / `last_runner`** = min/max over **combined** arrival list across events (cross-event staffing window).
+
+**Planned authoring (no hand km):**
+
+| Step | Action |
+|------|--------|
+| 1 | Place location on map (or import lat/lon). |
+| 2 | System projects point onto each **recipe-built** `{event}.gpx` → event km at location. |
+| 3 | Set event flags from segment membership (suggest API exists: `suggest_location_events`). |
+| 4 | Export `locations.csv` with `full_from_km`, `half_from_km`, `10k_from_km`, … |
+
+**Dependency:** Per-event GPX from recipes must exist before location export (same as analysis).
+
+**Not** tied to single `course.json` LineString.
+
+---
+
+## What’s implemented now
+
+```bash
+# In repo root (Docker or venv with app deps):
+python3 -c "
+from pathlib import Path
+from app.core.course.segment_library import export_library_to_course, write_package_exports
+b = export_library_to_course(Path('cursor/plotaroute'))
+print('10k km', b['recipe_lengths_km'])
+print('flow rows', b['flow_csv'].count(chr(10)))
+write_package_exports(Path('/tmp/fm_plotaroute_test'), Path('cursor/plotaroute'))
+"
+```
+
+```bash
+pytest tests/unit/test_segment_library.py -q
+```
+
+Files:
+
+- `cursor/plotaroute/manifest.yaml` — chunks + recipes (edit recipes here)
+- `app/core/course/segment_library.py` — load, stitch, segments, flow, package write
+- `tests/unit/test_segment_library.py`
+
+---
+
+## UI roadmap (after library API stable)
+
+| Tab | Purpose |
+|-----|---------|
+| **Library** | Import GPX chunks; endpoint validation |
+| **Recipes** | Order chunks per event; length vs `00_*` check |
+| **Segments & flow** | Preview tables; export |
+| **Locations** | Pins + auto km + event flags |
+| **Publish** | Write package + `analyze_ready` |
+
+Deprecate single-line-only planner as **primary** 2027 path; keep for simple races.
+
+---
+
+## Open issues
+
+1. **Full recipe tuning** — manifest `full` recipe ~40–44 km; validate against `00_full.gpx` (41.76 km).
+2. **Flow exceptions** — `B1a`-style rows need override UI or manifest entries.
+3. **Package API** — `POST /api/config/packages/{id}/import-library` (not wired yet).
+4. **#767** — Align waypoint planner with chunk ids instead of vertex indices.
+
+---
+
+## Related code
+
+| Module | Use |
+|--------|-----|
+| `app/core/course/export.py` | `build_segments_csv`, `_event_cumulative_distances` |
+| `app/core/v2/flow.py` | Consumes `flow.csv` + `segments.csv` |
+| `app/location_report.py` | Consumes `locations.csv` + GPX + segments |
+| `app/core/config_package/storage.py` | `package_readiness` needs all three CSVs |

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -4126,9 +4126,19 @@ document.addEventListener('DOMContentLoaded', function () {
             syncHeaderFromMeta: syncCourseHeaderFromPackageMeta
         };
 
+        document.addEventListener('segment-recipes-applied', function (ev) {
+            if (!isConfigPackageMode() || !ev.detail || !ev.detail.course) return;
+            currentCourse = ev.detail.course;
+            updateCourseUI();
+            renderSegmentsList();
+        });
+
         if (isConfigPackageMode()) {
             applyConfigPackageUIMode();
             loadConfigPackageCourse();
+            if (window.segmentRecipes && window.segmentRecipes.load) {
+                window.segmentRecipes.load();
+            }
         } else {
             setCourse(null, blankCourse());
             loadCourseList();

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -137,10 +137,10 @@
         tbody.innerHTML = '';
         libraryState.chunks.forEach(function (ch) {
             var tr = document.createElement('tr');
+            var label = (ch.leg_label || ch.seg_label || '').slice(0, 48);
             var cells = [
                 ch.id,
-                ch.seg_id || '',
-                (ch.seg_label || '').slice(0, 48),
+                label,
                 (ch.length_km != null ? Number(ch.length_km).toFixed(2) : '—')
             ];
             cells.forEach(function (text) {
@@ -214,7 +214,7 @@
                 renderTable();
                 renderTotals(data.recipe_lengths_km);
                 renderWarnings(data.stitch_warnings);
-                setStatus('Reference library loaded (' + (data.chunks || []).length + ' chunks).');
+                setStatus('Reference library loaded (' + (data.chunks || []).length + ' legs).');
             })
             .catch(function (err) {
                 setStatus(err.message || String(err), true);
@@ -246,8 +246,8 @@
                 var n = (data.chunks || []).length;
                 setStatus(
                     n
-                        ? 'Imported ' + n + ' segment(s). Set order numbers, then Save recipes & export.'
-                        : 'GPX saved but no segments detected. Use Load reference library or name files like 01_start.gpx.'
+                        ? 'Imported ' + n + ' leg(s). Set order numbers, then Save recipes & export.'
+                        : 'GPX saved but no legs detected. Use Load reference library or name files like 01_start.gpx.'
                 );
             })
             .catch(function (err) {

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -1,0 +1,305 @@
+/**
+ * Segment library + event recipes UI (config packages).
+ * Issue #755 / #769
+ */
+(function () {
+    'use strict';
+
+    var EVENTS = ['full', 'half', '10k'];
+    var libraryState = null;
+    var orderGrid = {};
+
+    function resolveConfigPackageId() {
+        var params = new URLSearchParams(window.location.search);
+        var raw = params.get('config_id');
+        return raw ? raw.trim() : '';
+    }
+
+    function isConfigPackageWorkspace() {
+        return !!resolveConfigPackageId() && !!document.getElementById('race-config-workspace');
+    }
+
+    function apiBase() {
+        return '/api/config/packages/' + encodeURIComponent(resolveConfigPackageId());
+    }
+
+    function showCard(visible) {
+        var card = document.getElementById('segment-recipes-card');
+        if (!card) return;
+        card.style.display = visible && isConfigPackageWorkspace() ? 'block' : 'none';
+    }
+
+    function setStatus(msg, isError) {
+        var el = document.getElementById('segment-recipes-status');
+        if (!el) return;
+        if (!msg) {
+            el.style.display = 'none';
+            el.textContent = '';
+            return;
+        }
+        el.style.display = 'block';
+        el.style.color = isError ? '#c0392b' : '#27ae60';
+        el.textContent = msg;
+    }
+
+    function renderTotals(lengths) {
+        var wrap = document.getElementById('segment-recipes-totals');
+        if (!wrap || !lengths) return;
+        wrap.style.display = 'block';
+        var full = document.getElementById('recipe-total-full');
+        var half = document.getElementById('recipe-total-half');
+        var ten = document.getElementById('recipe-total-10k');
+        if (full) full.textContent = ' Full ' + (lengths.full != null ? lengths.full.toFixed(2) : '—') + ' km';
+        if (half) half.textContent = ' · Half ' + (lengths.half != null ? lengths.half.toFixed(2) : '—') + ' km';
+        if (ten) ten.textContent = ' · 10K ' + (lengths['10k'] != null ? lengths['10k'].toFixed(2) : '—') + ' km';
+    }
+
+    function renderWarnings(warnings) {
+        var el = document.getElementById('segment-recipes-warnings');
+        if (!el) return;
+        if (!warnings || !warnings.length) {
+            el.style.display = 'none';
+            el.textContent = '';
+            return;
+        }
+        el.style.display = 'block';
+        el.textContent = 'Stitch warnings: ' + warnings.join(' · ');
+    }
+
+    function getOrder(chunkId, eventId) {
+        var row = orderGrid[eventId] || {};
+        var v = row[chunkId];
+        return v == null || v === '' ? '' : String(v);
+    }
+
+    function setOrder(chunkId, eventId, value) {
+        if (!orderGrid[eventId]) orderGrid[eventId] = {};
+        var trimmed = String(value || '').trim();
+        if (!trimmed) {
+            orderGrid[eventId][chunkId] = null;
+        } else {
+            var n = parseInt(trimmed, 10);
+            orderGrid[eventId][chunkId] = isNaN(n) || n < 1 ? null : n;
+        }
+        if (libraryState && libraryState.recipe_lengths_km) {
+            recomputeTotalsLocal();
+        }
+    }
+
+    function recomputeTotalsLocal() {
+        if (!libraryState || !libraryState.chunks) return;
+        var lengths = { full: 0, half: 0, '10k': 0 };
+        EVENTS.forEach(function (ev) {
+            var pairs = [];
+            libraryState.chunks.forEach(function (ch) {
+                var o = getOrder(ch.id, ev);
+                if (o) pairs.push({ order: parseInt(o, 10), km: ch.length_km || 0 });
+            });
+            pairs.sort(function (a, b) { return a.order - b.order; });
+            lengths[ev] = pairs.reduce(function (sum, p) { return sum + p.km; }, 0);
+            lengths[ev] = Math.round(lengths[ev] * 100) / 100;
+        });
+        renderTotals(lengths);
+    }
+
+    function renderTable() {
+        var tbody = document.getElementById('segment-recipes-tbody');
+        var wrap = document.getElementById('segment-recipes-table-wrap');
+        var empty = document.getElementById('segment-recipes-empty');
+        var applyBtn = document.getElementById('btn-segment-recipes-apply');
+        if (!tbody) return;
+
+        if (!libraryState || !libraryState.has_library || !libraryState.chunks.length) {
+            if (wrap) wrap.style.display = 'none';
+            if (empty) empty.style.display = 'block';
+            if (applyBtn) applyBtn.disabled = true;
+            return;
+        }
+
+        if (empty) empty.style.display = 'none';
+        if (wrap) wrap.style.display = 'block';
+        if (applyBtn) applyBtn.disabled = false;
+
+        orderGrid = libraryState.order_grid || orderGrid;
+        tbody.innerHTML = '';
+        libraryState.chunks.forEach(function (ch) {
+            var tr = document.createElement('tr');
+            var cells = [
+                ch.id,
+                ch.seg_id || '',
+                (ch.seg_label || '').slice(0, 48),
+                (ch.length_km != null ? Number(ch.length_km).toFixed(2) : '—')
+            ];
+            cells.forEach(function (text) {
+                var td = document.createElement('td');
+                td.textContent = text;
+                tr.appendChild(td);
+            });
+            EVENTS.forEach(function (ev) {
+                var td = document.createElement('td');
+                var inp = document.createElement('input');
+                inp.type = 'number';
+                inp.min = '1';
+                inp.max = '99';
+                inp.step = '1';
+                inp.className = 'segment-recipe-order-input';
+                inp.style.width = '3rem';
+                inp.dataset.chunkId = ch.id;
+                inp.dataset.eventId = ev;
+                inp.value = getOrder(ch.id, ev);
+                inp.title = 'Order on ' + ev + ' course (leave empty if unused)';
+                inp.addEventListener('input', function () {
+                    setOrder(ch.id, ev, inp.value);
+                });
+                td.appendChild(inp);
+                tr.appendChild(td);
+            });
+            tbody.appendChild(tr);
+        });
+    }
+
+    function loadLibrary() {
+        if (!isConfigPackageWorkspace()) {
+            showCard(false);
+            return Promise.resolve();
+        }
+        showCard(true);
+        return fetch(apiBase() + '/segment-library', { credentials: 'same-origin' })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data.ok) throw new Error(data.detail || 'Failed to load library');
+                libraryState = data;
+                orderGrid = data.order_grid || {};
+                renderTable();
+                renderTotals(data.recipe_lengths_km);
+                renderWarnings(data.stitch_warnings);
+                setStatus('');
+            })
+            .catch(function (err) {
+                setStatus(err.message || String(err), true);
+            });
+    }
+
+    function seedReference() {
+        setStatus('Loading reference library…');
+        return fetch(apiBase() + '/segment-library/seed-reference', {
+            method: 'POST',
+            credentials: 'same-origin'
+        })
+            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (res) {
+                if (!res.ok) throw new Error(res.data.detail || 'Seed failed');
+                libraryState = res.data;
+                orderGrid = res.data.order_grid || {};
+                renderTable();
+                renderTotals(res.data.recipe_lengths_km);
+                renderWarnings(res.data.stitch_warnings);
+                setStatus('Reference library loaded (' + (res.data.chunks || []).length + ' chunks).');
+            })
+            .catch(function (err) {
+                setStatus(err.message || String(err), true);
+            });
+    }
+
+    function uploadGpx(files) {
+        if (!files || !files.length) return Promise.resolve();
+        var fd = new FormData();
+        for (var i = 0; i < files.length; i++) {
+            fd.append('files', files[i]);
+        }
+        setStatus('Uploading GPX…');
+        return fetch(apiBase() + '/segment-library/upload', {
+            method: 'POST',
+            credentials: 'same-origin',
+            body: fd
+        })
+            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (res) {
+                if (!res.ok) throw new Error(res.data.detail || 'Upload failed');
+                libraryState = res.data;
+                orderGrid = res.data.order_grid || {};
+                renderTable();
+                renderTotals(res.data.recipe_lengths_km);
+                renderWarnings(res.data.stitch_warnings);
+                setStatus('Uploaded GPX files.');
+            })
+            .catch(function (err) {
+                setStatus(err.message || String(err), true);
+            });
+    }
+
+    function saveRecipes() {
+        setStatus('Saving recipes and exporting segments.csv…');
+        return fetch(apiBase() + '/segment-library/recipes', {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ order_by_event: orderGrid, export_csv: true })
+        })
+            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (res) {
+                if (!res.ok) throw new Error(res.data.detail || 'Save failed');
+                var data = res.data;
+                if (data.library) {
+                    libraryState = data.library;
+                    orderGrid = data.library.order_grid || orderGrid;
+                }
+                if (data.apply) {
+                    renderTotals(data.apply.recipe_lengths_km);
+                    renderWarnings(data.apply.stitch_warnings);
+                    setStatus(
+                        'Saved — ' + (data.apply.segment_count || 0) + ' segments exported to segments.csv.'
+                    );
+                } else {
+                    setStatus('Recipes saved.');
+                }
+                renderTable();
+                if (data.course) {
+                    document.dispatchEvent(new CustomEvent('segment-recipes-applied', {
+                        detail: { course: data.course }
+                    }));
+                }
+            })
+            .catch(function (err) {
+                setStatus(err.message || String(err), true);
+            });
+    }
+
+    function bindUi() {
+        var seedBtn = document.getElementById('btn-segment-library-seed');
+        var applyBtn = document.getElementById('btn-segment-recipes-apply');
+        var fileInput = document.getElementById('segment-library-gpx-input');
+        if (seedBtn) {
+            seedBtn.addEventListener('click', function () {
+                if (!window.confirm('Replace this package segment library with the built-in reference chunks?')) return;
+                seedReference();
+            });
+        }
+        if (applyBtn) {
+            applyBtn.addEventListener('click', function () { saveRecipes(); });
+        }
+        if (fileInput) {
+            fileInput.addEventListener('change', function () {
+                uploadGpx(fileInput.files);
+                fileInput.value = '';
+            });
+        }
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        bindUi();
+        if (isConfigPackageWorkspace()) {
+            loadLibrary();
+        }
+    });
+
+    window.addEventListener('popstate', function () {
+        if (isConfigPackageWorkspace()) loadLibrary();
+        else showCard(false);
+    });
+
+    window.segmentRecipes = {
+        load: loadLibrary,
+        refresh: loadLibrary
+    };
+})();

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -29,6 +29,19 @@
         card.style.display = visible && isConfigPackageWorkspace() ? 'block' : 'none';
     }
 
+    function formatApiError(res, data) {
+        if (data && data.detail) {
+            if (typeof data.detail === 'string') return data.detail;
+            if (Array.isArray(data.detail)) {
+                return data.detail.map(function (d) { return d.msg || JSON.stringify(d); }).join('; ');
+            }
+        }
+        if (res && res.status === 404 && data && data.detail === 'Not Found') {
+            return 'Segment library API is unavailable. Restart the app (make stop && make dev) and try again.';
+        }
+        return (res && res.status ? 'HTTP ' + res.status + ': ' : '') + 'Request failed';
+    }
+
     function setStatus(msg, isError) {
         var el = document.getElementById('segment-recipes-status');
         if (!el) return;
@@ -165,9 +178,14 @@
         }
         showCard(true);
         return fetch(apiBase() + '/segment-library', { credentials: 'same-origin' })
-            .then(function (r) { return r.json(); })
-            .then(function (data) {
-                if (!data.ok) throw new Error(data.detail || 'Failed to load library');
+            .then(function (r) {
+                return r.json().then(function (data) { return { res: r, data: data }; });
+            })
+            .then(function (payload) {
+                var r = payload.res;
+                var data = payload.data;
+                if (!r.ok) throw new Error(formatApiError(r, data));
+                if (!data.ok) throw new Error(formatApiError(r, data));
                 libraryState = data;
                 orderGrid = data.order_grid || {};
                 renderTable();
@@ -186,15 +204,17 @@
             method: 'POST',
             credentials: 'same-origin'
         })
-            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (r) { return r.json().then(function (d) { return { res: r, ok: r.ok, data: d }; }); })
             .then(function (res) {
-                if (!res.ok) throw new Error(res.data.detail || 'Seed failed');
-                libraryState = res.data;
-                orderGrid = res.data.order_grid || {};
+                if (!res.ok) throw new Error(formatApiError(res.res, res.data));
+                var data = res.data;
+                if (!data.ok) throw new Error(formatApiError(res.res, data));
+                libraryState = data;
+                orderGrid = data.order_grid || {};
                 renderTable();
-                renderTotals(res.data.recipe_lengths_km);
-                renderWarnings(res.data.stitch_warnings);
-                setStatus('Reference library loaded (' + (res.data.chunks || []).length + ' chunks).');
+                renderTotals(data.recipe_lengths_km);
+                renderWarnings(data.stitch_warnings);
+                setStatus('Reference library loaded (' + (data.chunks || []).length + ' chunks).');
             })
             .catch(function (err) {
                 setStatus(err.message || String(err), true);
@@ -213,15 +233,22 @@
             credentials: 'same-origin',
             body: fd
         })
-            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (r) { return r.json().then(function (d) { return { res: r, ok: r.ok, data: d }; }); })
             .then(function (res) {
-                if (!res.ok) throw new Error(res.data.detail || 'Upload failed');
-                libraryState = res.data;
-                orderGrid = res.data.order_grid || {};
+                if (!res.ok) throw new Error(formatApiError(res.res, res.data));
+                var data = res.data;
+                if (!data.ok) throw new Error(formatApiError(res.res, data));
+                libraryState = data;
+                orderGrid = data.order_grid || {};
                 renderTable();
-                renderTotals(res.data.recipe_lengths_km);
-                renderWarnings(res.data.stitch_warnings);
-                setStatus('Uploaded GPX files.');
+                renderTotals(data.recipe_lengths_km);
+                renderWarnings(data.stitch_warnings);
+                var n = (data.chunks || []).length;
+                setStatus(
+                    n
+                        ? 'Imported ' + n + ' segment(s). Set order numbers, then Save recipes & export.'
+                        : 'GPX saved but no segments detected. Use Load reference library or name files like 01_start.gpx.'
+                );
             })
             .catch(function (err) {
                 setStatus(err.message || String(err), true);
@@ -236,10 +263,11 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ order_by_event: orderGrid, export_csv: true })
         })
-            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, data: d }; }); })
+            .then(function (r) { return r.json().then(function (d) { return { res: r, ok: r.ok, data: d }; }); })
             .then(function (res) {
-                if (!res.ok) throw new Error(res.data.detail || 'Save failed');
+                if (!res.ok) throw new Error(formatApiError(res.res, res.data));
                 var data = res.data;
+                if (!data.ok) throw new Error(formatApiError(res.res, data));
                 if (data.library) {
                     libraryState = data.library;
                     orderGrid = data.library.order_grid || orderGrid;

--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -105,6 +105,9 @@
                 window.courseMappingMap.invalidateSize();
             }, 150);
         }
+        if (getTab() === 'course' && window.segmentRecipes && window.segmentRecipes.load) {
+            window.segmentRecipes.load();
+        }
     }
 
     function setActiveTab(tab) {

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -157,7 +157,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
 <script src="/static/js/map/course_mapping.js?v=769a"></script>
-<script src="/static/js/map/segment_recipes.js?v=769b"></script>
+<script src="/static/js/map/segment_recipes.js?v=769c"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=758a"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -156,7 +156,8 @@
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/course_mapping.js?v=766m"></script>
+<script src="/static/js/map/course_mapping.js?v=769a"></script>
+<script src="/static/js/map/segment_recipes.js?v=769a"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=758a"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -157,7 +157,7 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
 <script src="/static/js/map/course_mapping.js?v=769a"></script>
-<script src="/static/js/map/segment_recipes.js?v=769a"></script>
+<script src="/static/js/map/segment_recipes.js?v=769b"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=758a"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -1,5 +1,25 @@
 <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
 <style>
+    .segment-recipes-upload-label .btn-like {
+        display: inline-block;
+        padding: 0.4rem 0.75rem;
+        border: 1px solid #bdc3c7;
+        border-radius: 4px;
+        background: #fff;
+        font-size: 0.875rem;
+        cursor: pointer;
+    }
+    .segment-recipes-upload-label .btn-like:hover {
+        background: #f8f9fa;
+    }
+    #segment-recipes-card .course-planner-toolbar button.primary,
+    #btn-segment-recipes-apply.primary {
+        background: #3498db;
+        color: #fff;
+        border-color: #2980b9;
+        font-weight: 600;
+    }
+
     #course-mapping-map {
         height: 750px;
         border-radius: 4px;

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -72,9 +72,49 @@
         </div>
     </div>
 
+    <section class="course-derived-section" id="segment-recipes-card" style="display: none;">
+        <h4 class="course-derived-heading">Event recipes</h4>
+        <p class="course-derived-empty" style="margin-bottom: 0.5rem;">Build each event from reusable GPX segments. Enter <strong>order numbers</strong> (1, 2, 3…) per event; leave blank if a segment is not used. Save applies recipes and writes <code>segments.csv</code>.</p>
+        <div class="course-planner-toolbar" style="margin-bottom: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+            <button type="button" id="btn-segment-library-seed" title="Load Fredericton reference chunks (PlotARoute library)">Load reference library</button>
+            <label class="segment-recipes-upload-label">
+                <span class="btn-like">Import GPX chunks</span>
+                <input type="file" id="segment-library-gpx-input" accept=".gpx" multiple style="display: none;" />
+            </label>
+            <button type="button" id="btn-segment-recipes-apply" class="primary" disabled>Save recipes &amp; export</button>
+        </div>
+        <p id="segment-recipes-status" class="course-derived-empty" style="display: none;"></p>
+        <div id="segment-recipes-totals" style="display: none; margin-bottom: 0.5rem; font-size: 0.875rem;">
+            <strong>Totals:</strong>
+            <span id="recipe-total-full"></span>
+            <span id="recipe-total-half"></span>
+            <span id="recipe-total-10k"></span>
+        </div>
+        <div id="segment-recipes-warnings" style="display: none; margin-bottom: 0.5rem; font-size: 0.8rem; color: #c0392b;"></div>
+        <div id="segment-recipes-table-wrap" style="display: none;">
+            <div class="scrollable-table-container segments-table-scroll" style="max-height: 28vh;">
+                <table id="segment-recipes-table" class="table-sticky-header course-planner-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
+                    <thead>
+                        <tr>
+                            <th>Chunk</th>
+                            <th>Seg ID</th>
+                            <th>Label</th>
+                            <th>km</th>
+                            <th>Full</th>
+                            <th>Half</th>
+                            <th>10K</th>
+                        </tr>
+                    </thead>
+                    <tbody id="segment-recipes-tbody"></tbody>
+                </table>
+            </div>
+        </div>
+        <p id="segment-recipes-empty" class="course-derived-empty">No segment library yet. Load the reference library or import GPX chunk files.</p>
+    </section>
+
     <section class="course-derived-section" id="segments-card" style="display: none;">
         <h4 class="course-derived-heading">Segments</h4>
-        <p id="segments-empty" class="course-derived-empty">Add segment pins on the course line to split it into segments. Click a row to zoom the map to that leg; use From/To pin links to open a pin.</p>
+        <p id="segments-empty" class="course-derived-empty">Add segment pins on the course line, or use <strong>Event recipes</strong> above. Click a row to zoom the map to that leg.</p>
         <div id="segments-table-wrap" style="display: none;">
             <div class="scrollable-table-container segments-table-scroll" style="max-height: 25vh;">
                 <table id="segments-table" class="table-sticky-header" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -74,9 +74,13 @@
 
     <section class="course-derived-section" id="segment-recipes-card" style="display: none;">
         <h4 class="course-derived-heading">Event recipes</h4>
-        <p class="course-derived-empty" style="margin-bottom: 0.5rem;">Build each event from reusable GPX segments. Enter <strong>order numbers</strong> (1, 2, 3…) per event; leave blank if a segment is not used. Save applies recipes and writes <code>segments.csv</code>.</p>
+        <p class="course-derived-empty" style="margin-bottom: 0.5rem;">
+            <strong>1.</strong> <em>Load reference library</em> (Fredericton chunks + default recipes) <em>or</em> <em>Import GPX chunks</em> (one file per segment, e.g. <code>01_start.gpx</code>).<br>
+            <strong>2.</strong> Enter <strong>order numbers</strong> (1, 2, 3…) for Full / Half / 10K; leave blank if unused.<br>
+            <strong>3.</strong> <em>Save recipes &amp; export</em> writes <code>segments.csv</code> for analysis.
+        </p>
         <div class="course-planner-toolbar" style="margin-bottom: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
-            <button type="button" id="btn-segment-library-seed" title="Load Fredericton reference chunks (PlotARoute library)">Load reference library</button>
+            <button type="button" id="btn-segment-library-seed" title="Copy built-in Fredericton PlotARoute chunks and default recipes into this package">Load reference library</button>
             <label class="segment-recipes-upload-label">
                 <span class="btn-like">Import GPX chunks</span>
                 <input type="file" id="segment-library-gpx-input" accept=".gpx" multiple style="display: none;" />

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -75,14 +75,14 @@
     <section class="course-derived-section" id="segment-recipes-card" style="display: none;">
         <h4 class="course-derived-heading">Event recipes</h4>
         <p class="course-derived-empty" style="margin-bottom: 0.5rem;">
-            <strong>1.</strong> <em>Load reference library</em> (Fredericton chunks + default recipes) <em>or</em> <em>Import GPX chunks</em> (one file per segment, e.g. <code>01_start.gpx</code>).<br>
+            <strong>1.</strong> <em>Load reference library</em> (Fredericton legs + default recipes) <em>or</em> <em>Import GPX legs</em> (one file per leg, e.g. <code>01_start.gpx</code>).<br>
             <strong>2.</strong> Enter <strong>order numbers</strong> (1, 2, 3…) for Full / Half / 10K; leave blank if unused.<br>
             <strong>3.</strong> <em>Save recipes &amp; export</em> writes <code>segments.csv</code> for analysis.
         </p>
         <div class="course-planner-toolbar" style="margin-bottom: 0.5rem; display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
-            <button type="button" id="btn-segment-library-seed" title="Copy built-in Fredericton PlotARoute chunks and default recipes into this package">Load reference library</button>
+            <button type="button" id="btn-segment-library-seed" title="Copy built-in Fredericton PlotARoute legs and default recipes into this package">Load reference library</button>
             <label class="segment-recipes-upload-label">
-                <span class="btn-like">Import GPX chunks</span>
+                <span class="btn-like">Import GPX legs</span>
                 <input type="file" id="segment-library-gpx-input" accept=".gpx" multiple style="display: none;" />
             </label>
             <button type="button" id="btn-segment-recipes-apply" class="primary" disabled>Save recipes &amp; export</button>
@@ -100,8 +100,7 @@
                 <table id="segment-recipes-table" class="table-sticky-header course-planner-table" style="width: 100%; border-collapse: collapse; font-size: 0.875rem;">
                     <thead>
                         <tr>
-                            <th>Chunk</th>
-                            <th>Seg ID</th>
+                            <th>Leg</th>
                             <th>Label</th>
                             <th>km</th>
                             <th>Full</th>
@@ -113,7 +112,7 @@
                 </table>
             </div>
         </div>
-        <p id="segment-recipes-empty" class="course-derived-empty">No segment library yet. Load the reference library or import GPX chunk files.</p>
+        <p id="segment-recipes-empty" class="course-derived-empty">No leg library yet. Load the reference library or import GPX leg files.</p>
     </section>
 
     <section class="course-derived-section" id="segments-card" style="display: none;">

--- a/scripts/bootstrap_config_package_from_gpx.py
+++ b/scripts/bootstrap_config_package_from_gpx.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Create a config package with course geometry loaded from a GPX track."""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import sys
+from pathlib import Path
+
+# Repo root on sys.path when run as scripts/bootstrap_*.py
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.core.config_package.storage import (
+    create_config_package,
+    load_config_course,
+    save_config_course,
+)
+from app.core.gpx.processor import parse_gpx_file
+
+
+def gpx_to_coordinates(gpx_path: Path) -> tuple[list[list[float]], str, float]:
+    gpx = parse_gpx_file(str(gpx_path))
+    coords: list[list[float]] = []
+    for p in gpx.points:
+        c = [round(p.lon, 6), round(p.lat, 6)]
+        if not coords or c[0] != coords[-1][0] or c[1] != coords[-1][1]:
+            coords.append(c)
+    return coords, gpx.name, gpx.total_distance_km
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("gpx", type=Path, help="Source GPX file")
+    parser.add_argument("--label", required=True, help="Package label")
+    parser.add_argument("--description", default="", help="Package description")
+    parser.add_argument(
+        "--copy-gpx",
+        action="store_true",
+        help="Copy GPX into package folder as full.gpx",
+    )
+    args = parser.parse_args()
+    if not args.gpx.is_file():
+        print(f"GPX not found: {args.gpx}", file=sys.stderr)
+        return 1
+
+    coords, track_name, km = gpx_to_coordinates(args.gpx)
+    print(f"Track: {track_name!r}, {len(coords)} vertices, {km:.2f} km")
+
+    result = create_config_package(args.label, args.description)
+    config_id = result["config_id"]
+    package_path = Path(result["path"])
+
+    course = load_config_course(config_id)
+    course["geometry"] = {"type": "LineString", "coordinates": coords}
+    course["segment_breaks"] = []
+    course["segment_break_labels"] = {}
+    course["segment_break_descriptions"] = {}
+    course["segment_break_ids"] = {}
+    course["segments"] = []
+    course["waypoints"] = []
+    course["segment_defs"] = []
+    course["flow_control_points"] = []
+    course["turnaround_indices"] = []
+    course["start_description"] = "Start"
+    course["end_description"] = "Finish"
+
+    save_config_course(config_id, course)
+    if args.copy_gpx:
+        shutil.copy2(args.gpx, package_path / "full.gpx")
+
+    print(f"config_id: {config_id}")
+    print(f"path: {package_path}")
+    print("Open Race Configuration and select this package to add segment pins.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/export_plotaroute_library.py
+++ b/scripts/export_plotaroute_library.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Export segments.csv + flow.csv (+ per-event GPX) from cursor/plotaroute manifest."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from app.core.course.segment_library import export_library_to_course, write_package_exports
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--library",
+        type=Path,
+        default=Path("cursor/plotaroute"),
+        help="Directory with chunk GPX files and manifest.yaml",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help="Config package directory to write CSV/GPX (optional)",
+    )
+    args = parser.parse_args()
+    lib = args.library.resolve()
+    manifest = lib / "manifest.yaml"
+    if not manifest.is_file():
+        print(f"Missing {manifest}", file=sys.stderr)
+        return 1
+
+    bundle = export_library_to_course(lib, manifest)
+    print("Recipe lengths (km):", bundle["recipe_lengths_km"])
+    if bundle["stitch_warnings"]:
+        print("Stitch warnings:")
+        for w in bundle["stitch_warnings"]:
+            print(" ", w)
+    print("Segments:", len(bundle["segments"]))
+    print("Flow CSV lines:", bundle["flow_csv"].count("\n"))
+
+    if args.out:
+        write_package_exports(args.out.resolve(), lib, manifest)
+        print("Wrote:", args.out)
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -1,0 +1,82 @@
+"""Tests for segment library + event recipes export (2027 planning)."""
+
+from pathlib import Path
+
+import pytest
+
+from app.core.course.segment_library import (
+    build_course_segments_from_library,
+    build_flow_csv_from_segments,
+    export_library_to_course,
+    load_chunk_library,
+    load_manifest,
+    parse_chunk_gpx,
+    validate_recipe_stitch,
+)
+
+LIBRARY_DIR = Path(__file__).resolve().parents[2] / "cursor" / "plotaroute"
+MANIFEST = LIBRARY_DIR / "manifest.yaml"
+
+
+@pytest.fixture(scope="module")
+def manifest():
+    if not MANIFEST.is_file():
+        pytest.skip("cursor/plotaroute/manifest.yaml not present")
+    return load_manifest(MANIFEST)
+
+
+@pytest.fixture(scope="module")
+def chunks(manifest):
+    return load_chunk_library(LIBRARY_DIR, manifest)
+
+
+def test_plotaroute_chunks_load(manifest, chunks):
+    assert len(chunks) >= 10
+    assert chunks["01"]["length_km"] == pytest.approx(2.71, abs=0.05)
+    assert chunks["02"]["length_km"] == pytest.approx(1.59, abs=0.05)
+
+
+def test_10k_recipe_stitch(manifest, chunks):
+    warnings = validate_recipe_stitch(
+        LIBRARY_DIR, manifest["recipes"]["10k"], chunks, tolerance_m=120.0
+    )
+    assert not any("01" in w and "02" in w for w in warnings)
+
+
+def test_multi_event_segment_rows(manifest, chunks):
+    segments = build_course_segments_from_library(
+        manifest, chunks, event_ids=["full", "half", "10k"]
+    )
+    assert len(segments) == len(manifest["chunks"])
+    a1 = next(s for s in segments if s["seg_id"] == "A1")
+    assert set(a1["events"]) == {"full", "half", "10k"}
+    assert a1["10k_from_km"] == 0.0
+    assert a1["10k_to_km"] == pytest.approx(2.71, abs=0.05)
+    b1 = next(s for s in segments if s["seg_id"] == "B1")
+    assert "half" not in b1["events"]
+    assert b1["full_from_km"] == pytest.approx(2.71, abs=0.05)
+    assert b1["10k_from_km"] == pytest.approx(2.71, abs=0.05)
+
+
+def test_10k_recipe_length(manifest, chunks):
+    bundle = export_library_to_course(LIBRARY_DIR, MANIFEST, event_ids=["10k"])
+    assert bundle["recipe_lengths_km"]["10k"] == pytest.approx(10.02, abs=0.2)
+
+
+def test_flow_pairs_on_shared_segment(manifest, chunks):
+    segments = build_course_segments_from_library(
+        manifest, chunks, event_ids=["full", "half", "10k"]
+    )
+    csv_text = build_flow_csv_from_segments(segments, ["full", "half", "10k"])
+    lines = [ln for ln in csv_text.strip().splitlines() if ln]
+    assert lines[0].startswith("seg_id,")
+    assert any(",10k,half," in ln or ",half,10k," in ln for ln in lines)
+    assert any(ln.startswith("A1,") for ln in lines[1:])
+
+
+def test_export_bundle_writes_csv():
+    if not MANIFEST.is_file():
+        pytest.skip("plotaroute library missing")
+    bundle = export_library_to_course(LIBRARY_DIR, MANIFEST)
+    assert "full,half,10k" in bundle["segments_csv"].splitlines()[0]
+    assert "event_a" in bundle["flow_csv"]

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -48,14 +48,15 @@ def test_multi_event_segment_rows(manifest, chunks):
         manifest, chunks, event_ids=["full", "half", "10k"]
     )
     assert len(segments) == len(manifest["chunks"])
-    a1 = next(s for s in segments if s["seg_id"] == "A1")
-    assert set(a1["events"]) == {"full", "half", "10k"}
-    assert a1["10k_from_km"] == 0.0
-    assert a1["10k_to_km"] == pytest.approx(2.71, abs=0.05)
-    b1 = next(s for s in segments if s["seg_id"] == "B1")
-    assert "half" not in b1["events"]
-    assert b1["full_from_km"] == pytest.approx(2.71, abs=0.05)
-    assert b1["10k_from_km"] == pytest.approx(2.71, abs=0.05)
+    s1 = next(s for s in segments if s["seg_id"] == "S1")
+    assert set(s1["events"]) == {"full", "half", "10k"}
+    assert s1["10k_from_km"] == 0.0
+    assert s1["10k_to_km"] == pytest.approx(2.71, abs=0.05)
+    s2 = next(s for s in segments if s["seg_id"] == "S2")
+    assert "half" not in s2["events"]
+    assert s2["full_from_km"] == pytest.approx(2.71, abs=0.05)
+    assert s2["10k_from_km"] == pytest.approx(2.71, abs=0.05)
+    assert [s["seg_id"] for s in segments] == [f"S{i}" for i in range(1, len(segments) + 1)]
 
 
 def test_10k_recipe_length(manifest, chunks):
@@ -71,7 +72,7 @@ def test_flow_pairs_on_shared_segment(manifest, chunks):
     lines = [ln for ln in csv_text.strip().splitlines() if ln]
     assert lines[0].startswith("seg_id,")
     assert any(",10k,half," in ln or ",half,10k," in ln for ln in lines)
-    assert any(ln.startswith("A1,") for ln in lines[1:])
+    assert any(ln.startswith("S1,") for ln in lines[1:])
 
 
 def test_export_bundle_writes_csv():

--- a/tests/unit/test_segment_recipes_package.py
+++ b/tests/unit/test_segment_recipes_package.py
@@ -3,8 +3,10 @@
 import pytest
 
 from app.core.config_package.segment_recipes import (
+    _chunk_id_from_filename,
     order_grid_from_recipes,
     recipes_from_order_grid,
+    sync_manifest_chunks_from_gpx,
 )
 
 
@@ -19,6 +21,11 @@ def test_recipes_from_order_grid():
     assert recipes["full"] == ["01", "02"]
     assert recipes["half"] == ["01", "05"]
     assert recipes["10k"] == ["01", "02"]
+
+
+def test_chunk_id_from_filename():
+    assert _chunk_id_from_filename("01_start_friel.gpx") == "01"
+    assert _chunk_id_from_filename("00_full.gpx") == ""
 
 
 def test_order_grid_roundtrip():

--- a/tests/unit/test_segment_recipes_package.py
+++ b/tests/unit/test_segment_recipes_package.py
@@ -1,0 +1,33 @@
+"""Tests for config package segment recipes (#769)."""
+
+import pytest
+
+from app.core.config_package.segment_recipes import (
+    order_grid_from_recipes,
+    recipes_from_order_grid,
+)
+
+
+def test_recipes_from_order_grid():
+    chunks = [{"id": "01"}, {"id": "02"}, {"id": "05"}]
+    grid = {
+        "full": {"01": 1, "02": 2, "05": None},
+        "half": {"01": 1, "05": 2, "02": None},
+        "10k": {"01": 1, "02": 2},
+    }
+    recipes = recipes_from_order_grid(chunks, grid)
+    assert recipes["full"] == ["01", "02"]
+    assert recipes["half"] == ["01", "05"]
+    assert recipes["10k"] == ["01", "02"]
+
+
+def test_order_grid_roundtrip():
+    chunks = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+    recipes = {"full": ["a", "c"], "half": ["b"], "10k": ["a", "b", "c"]}
+    grid = order_grid_from_recipes(chunks, recipes)
+    assert grid["full"]["a"] == 1
+    assert grid["full"]["c"] == 2
+    assert grid["full"]["b"] is None
+    assert grid["half"]["b"] == 1
+    back = recipes_from_order_grid(chunks, grid)
+    assert back == recipes


### PR DESCRIPTION
## Summary

Delivers **Phase 1** of #769 (epic #755): configure a race package from reusable GPX **legs** and per-event **recipes**, without YAML/scripts.

- PlotARoute reference library (`cursor/plotaroute/`) + export engine
- Config package `segment_library/` + recipe APIs
- Event recipes UI: load reference, import GPX, order grid, save → `segments.csv` (S1…Sn), `course.json` segments, per-event `.gpx`
- Docker dev mount for `cursor/plotaroute`

Phases 2–7 remain on #769 (package events, leg endpoints, preview map, flow, locations, UX pass).

## Test plan

- [ ] `make dev` (restart if needed for `cursor/` mount)
- [ ] Race Configuration → new package → Course tab
- [ ] **Load reference library** → 15 legs, default recipes, km totals
- [ ] **Save recipes & export** → `runflow/config/{id}/segments.csv` with S1…Sn
- [ ] Verify `full.gpx`, `half.gpx`, `10k.gpx` in package folder
- [ ] `docker exec run-density-dev python -m pytest tests/unit/test_segment_library.py tests/unit/test_segment_recipes_package.py -q`

Part of #769. Does not close #769 (later phases on same issue).


Made with [Cursor](https://cursor.com)