### PR TITLE
Refresh seg_id on recipe apply; proxy timing dropdown (#774, #775)

### DIFF
--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -44,6 +44,7 @@ from app.utils.constants import (
     COURSE_EVENT_IDS,
     LOCATION_PLACEMENT_CHOICES,
     LOCATION_TYPE_CHOICES,
+    OFF_COURSE_LOCATION_TYPES,
     ON_COURSE_LOCATION_TYPES,
     SEGMENT_DIRECTION_CHOICES,
     SEGMENT_DIRECTION_VALUES,
@@ -586,6 +587,196 @@ def _segment_for_leg(
     return None
 
 
+def _parse_location_seg_ids(seg_id_value: Any) -> List[str]:
+    """Parse comma-separated seg_id(s) on a location row."""
+    if seg_id_value is None:
+        return []
+    raw = str(seg_id_value).strip()
+    if not raw:
+        return []
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
+def _valid_segment_ids(segments: Sequence[Dict[str, Any]]) -> set[str]:
+    return {
+        str(seg.get("seg_id", "")).strip()
+        for seg in segments
+        if isinstance(seg, dict) and str(seg.get("seg_id", "")).strip()
+    }
+
+
+def _leg_id_for_location(loc: Dict[str, Any]) -> str:
+    leg_id = str(loc.get("leg_id") or "").strip()
+    if leg_id:
+        return leg_id
+    key = str(loc.get("leg_loc_key") or "").strip()
+    if ":" in key:
+        return key.partition(":")[0].strip()
+    return ""
+
+
+def _proxy_loc_id_is_set(proxy_val: Any) -> bool:
+    if proxy_val is None:
+        return False
+    if isinstance(proxy_val, str) and not proxy_val.strip():
+        return False
+    return str(proxy_val).strip().lower() not in ("nan", "none")
+
+
+def refresh_location_seg_ids_from_segments(
+    locations: Sequence[Dict[str, Any]],
+    segments: Sequence[Dict[str, Any]],
+    *,
+    unmapped: Optional[List[Dict[str, Any]]] = None,
+) -> int:
+    """
+    Issue #774: Align on-course ``seg_id`` with current segments via ``leg_id``.
+
+    Off-course types (traffic, extract) get empty ``seg_id``. Returns count of
+    locations whose ``seg_id`` field changed.
+    """
+    valid_seg_ids = _valid_segment_ids(segments)
+    updated = 0
+    off_course = set(OFF_COURSE_LOCATION_TYPES)
+
+    for loc in locations:
+        if not isinstance(loc, dict):
+            continue
+        loc_type = str(loc.get("loc_type") or "").strip().lower()
+        old_seg = str(loc.get("seg_id") or "").strip()
+
+        if loc_type in off_course:
+            if old_seg:
+                loc["seg_id"] = ""
+                updated += 1
+            continue
+
+        if loc_type not in ON_COURSE_LOCATION_TYPES:
+            continue
+
+        leg_id = _leg_id_for_location(loc)
+        if leg_id:
+            seg = _segment_for_leg(segments, leg_id)
+            new_seg = str(seg.get("seg_id", "")).strip() if seg else ""
+            if new_seg != old_seg:
+                loc["seg_id"] = new_seg
+                updated += 1
+            if not new_seg and unmapped is not None:
+                unmapped.append(
+                    {
+                        "id": loc.get("id"),
+                        "loc_label": loc.get("loc_label"),
+                        "leg_id": leg_id,
+                        "reason": "no_segment_for_leg",
+                    }
+                )
+            continue
+
+        parsed = _parse_location_seg_ids(loc.get("seg_id"))
+        if not parsed:
+            continue
+        kept = [sid for sid in parsed if sid in valid_seg_ids]
+        new_val = ",".join(kept)
+        if new_val != old_seg:
+            loc["seg_id"] = new_val
+            updated += 1
+            if not kept and unmapped is not None:
+                unmapped.append(
+                    {
+                        "id": loc.get("id"),
+                        "loc_label": loc.get("loc_label"),
+                        "seg_id": old_seg,
+                        "reason": "stale_seg_id",
+                    }
+                )
+
+    return updated
+
+
+def validate_locations_for_export(course: Dict[str, Any]) -> List[str]:
+    """
+    Issue #774 / #775: Fail-fast checks before writing locations.csv.
+
+    Validates segment references and proxy_loc_id targets.
+    """
+    segments = [
+        s for s in (course.get("segments") or []) if isinstance(s, dict)
+    ]
+    valid_seg_ids = _valid_segment_ids(segments)
+    locations = [
+        loc for loc in (course.get("locations") or []) if isinstance(loc, dict)
+    ]
+    by_id: Dict[int, Dict[str, Any]] = {}
+    for loc in locations:
+        lid = parse_location_id(loc.get("id", loc.get("loc_id")))
+        if lid is not None and lid > 0:
+            by_id[lid] = loc
+
+    errors: List[str] = []
+    for loc in locations:
+        lid = parse_location_id(loc.get("id", loc.get("loc_id")))
+        label = str(loc.get("loc_label") or lid or "location").strip()
+        loc_type = str(loc.get("loc_type") or "").strip().lower()
+
+        for sid in _parse_location_seg_ids(loc.get("seg_id")):
+            if sid not in valid_seg_ids:
+                errors.append(
+                    f'Location "{label}" (id={lid}): seg_id "{sid}" not in segments.csv'
+                )
+
+        proxy_val = loc.get("proxy_loc_id")
+        if not _proxy_loc_id_is_set(proxy_val):
+            continue
+        try:
+            proxy_id = int(proxy_val)
+        except (TypeError, ValueError):
+            errors.append(
+                f'Location "{label}" (id={lid}): proxy_loc_id must be a numeric loc_id'
+            )
+            continue
+        if lid is not None and proxy_id == lid:
+            errors.append(
+                f'Location "{label}" (id={lid}): proxy_loc_id cannot reference itself'
+            )
+        elif proxy_id not in by_id:
+            errors.append(
+                f'Location "{label}" (id={lid}): proxy_loc_id {proxy_id} not found'
+            )
+        if _proxy_loc_id_is_set(proxy_val) and _parse_location_seg_ids(loc.get("seg_id")):
+            errors.append(
+                f'Location "{label}" (id={lid}): set only proxy_loc_id or seg_id, not both (Issue #751)'
+            )
+        if loc_type in OFF_COURSE_LOCATION_TYPES and _parse_location_seg_ids(
+            loc.get("seg_id")
+        ):
+            errors.append(
+                f'Location "{label}" (id={lid}): {loc_type} locations should have empty seg_id when using proxy timing'
+            )
+
+    return errors
+
+
+def refresh_course_location_seg_ids(config_id: str) -> Dict[str, Any]:
+    """Refresh all location seg_ids from course segments; persist course.json."""
+    cid = validate_config_id(config_id)
+    course = load_config_course(cid)
+    segments = [
+        s for s in (course.get("segments") or []) if isinstance(s, dict)
+    ]
+    locations = course.get("locations") or []
+    unmapped: List[Dict[str, Any]] = []
+    updated = refresh_location_seg_ids_from_segments(
+        locations, segments, unmapped=unmapped
+    )
+    if updated:
+        course["locations"] = locations
+        save_config_course(cid, course)
+    return {
+        "seg_id_refresh_count": updated,
+        "seg_id_unmapped": unmapped,
+    }
+
+
 def _event_flags_for_segment(
     seg: Optional[Dict[str, Any]], event_ids: Sequence[str]
 ) -> Dict[str, str]:
@@ -679,8 +870,6 @@ def merge_leg_locations_into_course(config_id: str) -> None:
                     used_ids.add(prev_id)
                 else:
                     row["id"] = allocate_location_id(used_ids)
-                if (prev.get("seg_id") or "").strip():
-                    row["seg_id"] = str(prev["seg_id"]).strip()
                 for field in _LEG_LOC_PRESERVE_FIELDS:
                     if field not in prev:
                         continue

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -562,9 +562,13 @@ def apply_package_recipes(
     course["segment_library_applied"] = True
     save_config_course(cid, course)
 
-    from app.core.config_package.legs import merge_leg_locations_into_course
+    from app.core.config_package.legs import (
+        merge_leg_locations_into_course,
+        refresh_course_location_seg_ids,
+    )
 
     merge_leg_locations_into_course(cid)
+    seg_refresh = refresh_course_location_seg_ids(cid)
 
     export_result: Optional[Dict[str, Any]] = None
     flow_gpx_result: Optional[Dict[str, Any]] = None
@@ -578,6 +582,8 @@ def apply_package_recipes(
         "segment_count": len(segments),
         "recipe_lengths_km": bundle["recipe_lengths_km"],
         "stitch_warnings": bundle["stitch_warnings"],
+        "seg_id_refresh_count": seg_refresh.get("seg_id_refresh_count", 0),
+        "seg_id_unmapped": seg_refresh.get("seg_id_unmapped") or [],
         "segments_csv_path": export_result.get("path") if export_result else None,
         "flow_csv_path": (flow_gpx_result or {}).get("flow_path"),
         "gpx_files": (flow_gpx_result or {}).get("gpx_files") or [],

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -727,6 +727,24 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
         raise ValueError("Course has no segments; add segment pins before export")
 
     enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
+
+    from app.core.config_package.legs import (
+        refresh_location_seg_ids_from_segments,
+        validate_locations_for_export,
+    )
+
+    locations = course.get("locations") or []
+    if refresh_location_seg_ids_from_segments(locations, segments):
+        course["locations"] = locations
+        save_config_course(cid, course)
+
+    loc_errors = validate_locations_for_export(course)
+    if loc_errors:
+        detail = "; ".join(loc_errors[:8])
+        if len(loc_errors) > 8:
+            detail += f" (+{len(loc_errors) - 8} more)"
+        raise ValueError(f"Cannot export locations.csv: {detail}")
+
     csv_content = build_segments_csv(course, fmt="pipeline")
 
     target = package_path / "segments.csv"

--- a/docs/dev-guides/data-sources.md
+++ b/docs/dev-guides/data-sources.md
@@ -402,8 +402,8 @@ runner_id,event,pace,distance,start_offset,day
 - `loc_id`: Location identifier
 - `loc_label`: Human-readable label
 - `loc_type`: Location category; allowed values are **`LOCATION_TYPE_CHOICES`** in `app/utils/constants.py` (SSOT for Course Mapping and Locations UI).
-- `seg_id`: Associated segment ID(s); may be empty for off-course or proxy-only timing rows
-- `proxy_loc_id`: Optional; when set with **empty** `seg_id`, the locations report copies **operational** timing (`loc_end`, `duration`) from that `loc_id` for **all** `loc_type` values (`timing_source` becomes `proxy:<id>` in output). Issue #751.
+- `seg_id`: Associated segment ID(s); may be empty for off-course or proxy-only timing rows. After leg recipe changes, re-apply recipes so segment IDs stay aligned with `segments.csv` (Issue #774).
+- `proxy_loc_id`: Optional **integer** `loc_id` of another location (timing source). In config package authoring (#775), operators pick the source from a dropdown; export writes the numeric id at snapshot time. When set with **empty** `seg_id`, the locations report copies **operational** timing (`loc_end`, `duration`) from that `loc_id` for **all** `loc_type` values (`timing_source` becomes `proxy:<id>` in output). Issue #751. Alphanumeric proxy values are not supported in the analysis pipeline.
 - `timing_source`: Optional advanced override (e.g. `proxy:n`) when present in input
 
 **Issue #751 — `proxy_loc_id` vs `seg_id` (locations report)**:

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -1034,6 +1034,57 @@ document.addEventListener('DOMContentLoaded', function () {
             .catch(function (e) { alert('Failed to save resources: ' + (e.message || String(e))); });
     }
 
+    function offCourseUsesProxyTiming(locType) {
+        var t = (locType || '').toString().toLowerCase();
+        return t === 'traffic' || t === 'extract';
+    }
+
+    function locationNumericId(loc) {
+        if (!loc) return 0;
+        var raw = loc.id != null ? loc.id : loc.loc_id;
+        var n = parseInt(raw, 10);
+        return isNaN(n) ? 0 : n;
+    }
+
+    function buildProxyTimingSelect(loc, editable) {
+        var sel = document.createElement('select');
+        sel.disabled = !editable;
+        var none = document.createElement('option');
+        none.value = '';
+        none.textContent = '— None —';
+        sel.appendChild(none);
+        var selfId = locationNumericId(loc);
+        var others = getCourseLocations().slice();
+        others.sort(function (a, b) {
+            return locationNumericId(a) - locationNumericId(b);
+        });
+        others.forEach(function (other) {
+            var oid = locationNumericId(other);
+            if (!oid || (selfId && oid === selfId)) return;
+            var opt = document.createElement('option');
+            opt.value = String(oid);
+            var typeHint = other.loc_type ? ' (' + other.loc_type + ')' : '';
+            opt.textContent =
+                oid + ' — ' + (other.loc_label || 'Untitled') + typeHint;
+            sel.appendChild(opt);
+        });
+        var pv =
+            loc.proxy_loc_id != null && loc.proxy_loc_id !== ''
+                ? String(loc.proxy_loc_id).trim()
+                : '';
+        if (pv) {
+            sel.value = pv;
+            if (sel.value !== pv) {
+                var missing = document.createElement('option');
+                missing.value = pv;
+                missing.textContent = pv + ' — (location not found)';
+                sel.appendChild(missing);
+                sel.value = pv;
+            }
+        }
+        return sel;
+    }
+
     function openLocationEditorModal(idx, readOnly) {
         if (!currentCourse || !currentCourse.locations || idx < 0 || idx >= currentCourse.locations.length) return;
         destroyLocationEditorMap();
@@ -1173,11 +1224,8 @@ document.addEventListener('DOMContentLoaded', function () {
         inpInterval.value = loc.interval != null ? loc.interval : 5;
         inpInterval.disabled = !editable;
         addField(secTiming, 'Interval (min)', inpInterval);
-        var inpProxy = document.createElement('input');
-        inpProxy.type = 'text';
-        inpProxy.value = loc.proxy_loc_id != null ? String(loc.proxy_loc_id) : '';
-        inpProxy.disabled = !editable;
-        addField(secTiming, 'Proxy loc ID', inpProxy);
+        var selProxy = buildProxyTimingSelect(loc, editable);
+        addField(secTiming, 'Proxy timing source', selProxy);
 
         var secRes = addSection('Resources scheduled');
         var resGrid = document.createElement('div');
@@ -1259,7 +1307,33 @@ document.addEventListener('DOMContentLoaded', function () {
                 applySuggestedEventsToLocation(loc);
                 loc.buffer = parseInt(inpBuffer.value, 10) || 10;
                 loc.interval = parseInt(inpInterval.value, 10) || 5;
-                loc.proxy_loc_id = inpProxy.value.trim();
+                var proxyRaw = selProxy.value.trim();
+                if (proxyRaw) {
+                    var proxyNum = parseInt(proxyRaw, 10);
+                    if (isNaN(proxyNum)) {
+                        alert('Select a valid timing source location.');
+                        btnSave.disabled = false;
+                        return;
+                    }
+                    if (proxyNum === locationNumericId(loc)) {
+                        alert('A location cannot use itself as the proxy timing source.');
+                        btnSave.disabled = false;
+                        return;
+                    }
+                    loc.proxy_loc_id = proxyNum;
+                } else {
+                    loc.proxy_loc_id = '';
+                }
+                if (loc.proxy_loc_id && (loc.seg_id || '').trim()) {
+                    alert(
+                        'Use either Proxy timing source or Segment ID, not both (Issue #751).'
+                    );
+                    btnSave.disabled = false;
+                    return;
+                }
+                if (loc.proxy_loc_id && offCourseUsesProxyTiming(loc.loc_type)) {
+                    loc.seg_id = '';
+                }
                 loc.onepage = inpOnepage.checked ? 'y' : 'n';
                 loc.equipment = inpEquip.value.trim();
                 loc.contact = inpContact.value.trim();

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -2439,6 +2439,17 @@
                     if (data.apply.flow_csv_path) status += ', flow.csv';
                     var gpxCount = (data.apply.gpx_files || []).length;
                     if (gpxCount) status += ', ' + gpxCount + ' GPX file(s)';
+                    var segRefresh = data.apply.seg_id_refresh_count || 0;
+                    if (segRefresh > 0) {
+                        status += '; segment IDs updated on ' + segRefresh + ' location(s)';
+                    }
+                    var unmapped = data.apply.seg_id_unmapped || [];
+                    if (unmapped.length) {
+                        status +=
+                            '; ' +
+                            unmapped.length +
+                            ' location(s) could not be mapped to a segment (Course tab)';
+                    }
                     setRecipeStatus(status + '.');
                 }
                 if (data.course) {

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -205,8 +205,8 @@
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
 <script src="/static/js/table_actions.js?v=775b"></script>
-<script src="/static/js/map/course_mapping.js?v=775a"></script>
-<script src="/static/js/map/segment_recipes.js?v=778b"></script>
+<script src="/static/js/map/course_mapping.js?v=775b"></script>
+<script src="/static/js/map/segment_recipes.js?v=778c"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=771a"></script>
 {% endblock %}

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -836,3 +836,135 @@ def test_update_package_leg_geometry(tmp_path, monkeypatch):
     parsed = parse_leg_gpx(lib_dir / "01_leg.gpx")
     assert len(parsed["coordinates"]) == 3
     assert parsed["coordinates"][1][0] == -66.638
+
+
+def test_refresh_location_seg_ids_updates_stale_leg_seg_id():
+    from app.core.config_package.legs import refresh_location_seg_ids_from_segments
+
+    segments = [
+        {"seg_id": "S1", "leg_id": "01"},
+        {"seg_id": "S2", "leg_id": "02"},
+    ]
+    locations = [
+        {
+            "id": 1,
+            "loc_label": "Aid",
+            "loc_type": "course",
+            "leg_id": "01",
+            "seg_id": "S2",
+            "source": "leg",
+        }
+    ]
+    updated = refresh_location_seg_ids_from_segments(locations, segments)
+    assert updated == 1
+    assert locations[0]["seg_id"] == "S1"
+
+
+def test_refresh_location_seg_ids_clears_traffic_seg_id():
+    from app.core.config_package.legs import refresh_location_seg_ids_from_segments
+
+    segments = [{"seg_id": "S1", "leg_id": "01"}]
+    locations = [
+        {
+            "id": 2,
+            "loc_label": "Barricade",
+            "loc_type": "traffic",
+            "seg_id": "S1",
+            "proxy_loc_id": 1,
+        }
+    ]
+    updated = refresh_location_seg_ids_from_segments(locations, segments)
+    assert updated == 1
+    assert locations[0]["seg_id"] == ""
+
+
+def test_validate_locations_for_export_rejects_stale_seg_id():
+    from app.core.config_package.legs import validate_locations_for_export
+
+    course = {
+        "segments": [{"seg_id": "S1", "leg_id": "01"}],
+        "locations": [
+            {
+                "id": 1,
+                "loc_label": "Stale",
+                "loc_type": "course",
+                "seg_id": "S99",
+            }
+        ],
+    }
+    errors = validate_locations_for_export(course)
+    assert any("S99" in e for e in errors)
+
+
+def test_validate_locations_for_export_rejects_missing_proxy():
+    from app.core.config_package.legs import validate_locations_for_export
+
+    course = {
+        "segments": [{"seg_id": "S1", "leg_id": "01"}],
+        "locations": [
+            {
+                "id": 5,
+                "loc_label": "Traffic",
+                "loc_type": "traffic",
+                "seg_id": "",
+                "proxy_loc_id": 99,
+            }
+        ],
+    }
+    errors = validate_locations_for_export(course)
+    assert any("proxy_loc_id 99" in e for e in errors)
+
+
+def test_export_config_package_segments_fails_on_invalid_proxy(
+    tmp_path, monkeypatch
+):
+    from app.core.config_package.storage import (
+        export_config_package_segments,
+        save_config_course,
+    )
+
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Export guard", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    course = load_config_course(config_id)
+    course["segments"] = [
+        {
+            "seg_id": "S1",
+            "seg_label": "Only",
+            "width_m": 3,
+            "schema": "on_course_open",
+            "direction": "uni",
+            "full": "y",
+            "full_from_km": 0,
+            "full_to_km": 1,
+        }
+    ]
+    course["locations"] = [
+        {
+            "id": 1,
+            "loc_label": "Aid",
+            "loc_type": "course",
+            "lat": 45.96,
+            "lon": -66.64,
+            "seg_id": "S1",
+            "full": "y",
+        },
+        {
+            "id": 2,
+            "loc_label": "Traffic",
+            "loc_type": "traffic",
+            "lat": 45.97,
+            "lon": -66.63,
+            "seg_id": "",
+            "proxy_loc_id": 42,
+            "full": "y",
+        },
+    ]
+    save_config_course(config_id, course)
+    with pytest.raises(ValueError, match="Cannot export locations.csv"):
+        export_config_package_segments(config_id)


### PR DESCRIPTION
## Summary

- **#774:** After Apply recipes, refresh on-course location `seg_id` from current segments via `leg_id`; stop preserving stale `seg_id` on leg merge. Re-sync again at export; fail export when `seg_id` or `proxy_loc_id` references are invalid.
- **#775:** Course location editor uses a **Proxy timing source** dropdown (locations sorted by ID, id + label). Export validation ensures integer `proxy_loc_id` targets exist; Issue #751 conflicts surfaced at export.

## Test plan

- [x] `pytest tests/unit/test_package_legs.py` (24 passed)
- [ ] Apply recipes after reordering legs → status shows segment ID refresh count
- [ ] Traffic location: pick proxy from dropdown, save, export package
- [ ] Export fails with clear error when proxy points at missing loc_id

Closes #774
Closes #775


Made with [Cursor](https://cursor.com)