### PR TITLE
Race Configuration: map viewport filters tables (Legs + Course)

### DIFF
--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -223,11 +223,20 @@ document.addEventListener('DOMContentLoaded', function () {
         return e ? e.charAt(0).toUpperCase() + e.slice(1) : '';
     }
 
+    function formatPackageIdDisplay(pkgId) {
+        var id = String(pkgId || '').trim();
+        if (id.length <= 16) return id;
+        return id.slice(0, 4) + '...' + id.slice(-4);
+    }
+
     /** Populate read-only package details card (does not require course.json loaded). */
     function syncConfigPackageDetailsCard(label, description, eventDay, packageEvents) {
         var pkgId = resolveConfigPackageId() || '';
         var idEl = document.getElementById('course-map-id');
-        if (idEl) idEl.textContent = pkgId;
+        if (idEl) {
+            idEl.textContent = formatPackageIdDisplay(pkgId);
+            idEl.title = pkgId;
+        }
         var nameText = document.getElementById('course-map-name-text');
         var descText = document.getElementById('course-map-description-text');
         var dayText = document.getElementById('course-map-event-day-text');
@@ -244,6 +253,8 @@ document.addEventListener('DOMContentLoaded', function () {
         if (nameText) nameText.textContent = nameVal || '(no name)';
         if (descText) descText.textContent = descVal || '(none)';
         if (dayText) dayText.textContent = dayVal || '(not set)';
+        var pageTitle = document.getElementById('race-config-page-title');
+        if (pageTitle && nameVal) pageTitle.textContent = nameVal;
         if (packageEvents != null) {
             window.CONFIG_PACKAGE_EVENTS = Array.isArray(packageEvents)
                 ? packageEvents.slice()
@@ -254,7 +265,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var eventsText = document.getElementById('course-map-package-events-text');
         if (eventsField && eventsText) {
             if (events.length) {
-                eventsField.style.display = '';
+                eventsField.style.display = 'flex';
                 eventsText.textContent = events.map(formatPackageEventLabel).join(', ');
             } else {
                 eventsField.style.display = 'none';

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -3315,7 +3315,18 @@ document.addEventListener('DOMContentLoaded', function () {
         thead.appendChild(lenTh);
     }
 
-    function renderSegmentsList() {
+    function visibleIndexSet(visibleIndices) {
+        if (visibleIndices == null) return null;
+        if (visibleIndices instanceof Set) return visibleIndices;
+        var s = new Set();
+        (visibleIndices || []).forEach(function (i) {
+            s.add(i);
+        });
+        return s;
+    }
+
+    function renderSegmentsList(visibleIndices) {
+        var indexFilter = visibleIndexSet(visibleIndices);
         var card = document.getElementById('segments-card');
         var empty = document.getElementById('segments-empty');
         var wrap = document.getElementById('segments-table-wrap');
@@ -3337,6 +3348,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var eventIds = segmentsTableEventIds();
         var computedEventDistances = computeEventDistancesForSegments(currentCourse.segments, eventIds);
         currentCourse.segments.forEach(function (seg, segIdx) {
+            if (indexFilter && !indexFilter.has(segIdx)) return;
             var len = (seg.to_km - seg.from_km);
             var startIdx = seg.start_index != null ? seg.start_index : 0;
             var endIdx = seg.end_index != null ? seg.end_index : (coordsLen ? coordsLen - 1 : 0);
@@ -3460,6 +3472,10 @@ document.addEventListener('DOMContentLoaded', function () {
             });
             tbody.appendChild(tr);
         });
+        if (!indexFilter && isConfigPackageMode() && window.segmentRecipes &&
+            window.segmentRecipes.syncCoursePreviewBoundsFilterItems) {
+            window.segmentRecipes.syncCoursePreviewBoundsFilterItems();
+        }
     }
 
     function getLocationTypeLabel(locType) {
@@ -3658,7 +3674,8 @@ document.addEventListener('DOMContentLoaded', function () {
             });
     }
 
-    function renderLocationsList() {
+    function renderLocationsList(visibleIndices) {
+        var indexFilter = visibleIndexSet(visibleIndices);
         var card = document.getElementById('locations-card');
         var empty = document.getElementById('locations-empty');
         var wrap = document.getElementById('locations-table-wrap');
@@ -3678,6 +3695,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var resourceTotals = {};
         getPackageResources().forEach(function (res) { resourceTotals[res.code] = 0; });
         currentCourse.locations.forEach(function (loc, i) {
+            if (indexFilter && !indexFilter.has(i)) return;
             syncLocationResourceCounts(loc);
             var tr = document.createElement('tr');
             var typeLabel = getLocationTypeLabel(loc.loc_type);
@@ -3772,6 +3790,10 @@ document.addEventListener('DOMContentLoaded', function () {
                     currentCourse.locations.length > 0
                 )
             );
+        }
+        if (!indexFilter && isConfigPackageMode() && window.segmentRecipes &&
+            window.segmentRecipes.syncCoursePreviewBoundsFilterItems) {
+            window.segmentRecipes.syncCoursePreviewBoundsFilterItems();
         }
     }
 
@@ -4763,6 +4785,15 @@ document.addEventListener('DOMContentLoaded', function () {
                 );
             },
             renderSegmentsList: renderSegmentsList,
+            renderSegmentsListFiltered: function (indices) {
+                renderSegmentsList(indices);
+            },
+            renderLocationsListFiltered: function (indices) {
+                renderLocationsList(indices);
+            },
+            getCourse: function () {
+                return currentCourse;
+            },
             getCourseLocations: getCourseLocations,
             buildLocationTooltipHtml: buildConfigLocationTooltipHtml,
             getLocationPinColor: getLocationPinColor,

--- a/frontend/static/js/map/map_bounds_table_filter.js
+++ b/frontend/static/js/map/map_bounds_table_filter.js
@@ -1,0 +1,99 @@
+/**
+ * Map viewport → table row filter (Issue #634 pattern used on Segments / Locations pages).
+ */
+(function () {
+    'use strict';
+
+    function create(options) {
+        var debounceMs = options.debounceMs || 150;
+        var programmaticDelay = options.programmaticDelay || 600;
+        var isProgrammatic = false;
+        var timeout = null;
+        var allItems = [];
+        var attachedMap = null;
+        var debouncedHandler = null;
+
+        function getMap() {
+            return options.getMap ? options.getMap() : null;
+        }
+
+        function filterNow() {
+            if (isProgrammatic) return;
+            var map = getMap();
+            if (!map) {
+                if (options.onFilter) options.onFilter(allItems.slice(), { total: allItems.length, visible: allItems.length });
+                return;
+            }
+            var bounds = map.getBounds();
+            if (!bounds || !bounds.isValid()) return;
+            var visible = allItems.filter(function (item) {
+                try {
+                    return options.isItemInBounds(item, bounds);
+                } catch (e) {
+                    return true;
+                }
+            });
+            if (options.onFilter) {
+                options.onFilter(visible, {
+                    total: allItems.length,
+                    visible: visible.length
+                });
+            }
+        }
+
+        function debouncedFilter() {
+            if (timeout) clearTimeout(timeout);
+            timeout = setTimeout(filterNow, debounceMs);
+        }
+
+        function setAllItems(items) {
+            allItems = items || [];
+            filterNow();
+        }
+
+        function setProgrammatic(flag) {
+            isProgrammatic = !!flag;
+        }
+
+        function runProgrammatic(fn) {
+            isProgrammatic = true;
+            try {
+                if (typeof fn === 'function') fn();
+            } finally {
+                setTimeout(function () {
+                    isProgrammatic = false;
+                    filterNow();
+                }, programmaticDelay);
+            }
+        }
+
+        function attach(map) {
+            if (!map) return;
+            if (attachedMap && attachedMap !== map) detach(attachedMap);
+            if (attachedMap === map) return;
+            debouncedHandler = debouncedFilter;
+            map.on('moveend', debouncedHandler);
+            map.on('zoomend', debouncedHandler);
+            attachedMap = map;
+        }
+
+        function detach(map) {
+            var target = map || attachedMap;
+            if (!target || !debouncedHandler) return;
+            target.off('moveend', debouncedHandler);
+            target.off('zoomend', debouncedHandler);
+            if (attachedMap === target) attachedMap = null;
+        }
+
+        return {
+            setAllItems: setAllItems,
+            filterNow: filterNow,
+            attach: attach,
+            detach: detach,
+            setProgrammatic: setProgrammatic,
+            runProgrammatic: runProgrammatic
+        };
+    }
+
+    window.MapBoundsTableFilter = { create: create };
+})();

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -358,23 +358,118 @@
         }
     }
 
-    function segmentIntersectsBounds(seg, bounds) {
+    function resolveLegIdForSegment(seg, segIdx) {
+        if (!libraryState || !libraryState.legs || !libraryState.legs.length) return '';
+        var legId = seg && (seg.leg_id != null || seg.chunk_id != null)
+            ? String(seg.leg_id != null ? seg.leg_id : seg.chunk_id).trim()
+            : '';
+        if (!legId) {
+            var segId = seg && seg.seg_id != null ? String(seg.seg_id) : '';
+            var m = /^S(\d+)$/i.exec(segId);
+            if (m) {
+                var ord = parseInt(m[1], 10) - 1;
+                if (ord >= 0 && ord < libraryState.legs.length) {
+                    legId = libraryState.legs[ord].id;
+                }
+            } else if (segIdx >= 0 && segIdx < libraryState.legs.length) {
+                legId = libraryState.legs[segIdx].id;
+            }
+        }
+        return legId;
+    }
+
+    function activePreviewEventId() {
+        if (coursePreviewSelectedEvent) return coursePreviewSelectedEvent;
+        var evs = packageEvents();
+        return evs.length ? evs[0] : null;
+    }
+
+    function flattenPreviewLatLngs(layer) {
+        if (!layer) return [];
+        var latlngs = layer.getLatLngs();
+        if (!latlngs || !latlngs.length) return [];
+        if (latlngs[0] && latlngs[0].lat != null) return latlngs;
+        var flat = [];
+        latlngs.forEach(function (part) {
+            if (Array.isArray(part)) {
+                part.forEach(function (ll) {
+                    flat.push(ll);
+                });
+            }
+        });
+        return flat;
+    }
+
+    function haversineKm(a, b) {
+        var R = 6371;
+        var dLat = ((b.lat - a.lat) * Math.PI) / 180;
+        var dLon = ((b.lng - a.lng) * Math.PI) / 180;
+        var lat1 = (a.lat * Math.PI) / 180;
+        var lat2 = (b.lat * Math.PI) / 180;
+        var x =
+            Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+            Math.cos(lat1) * Math.cos(lat2) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+        return R * 2 * Math.atan2(Math.sqrt(x), Math.sqrt(1 - x));
+    }
+
+    function buildRouteKmTable(latlngs) {
+        var cum = [0];
+        for (var i = 1; i < latlngs.length; i++) {
+            cum.push(cum[i - 1] + haversineKm(latlngs[i - 1], latlngs[i]));
+        }
+        return cum;
+    }
+
+    function latLngAtRouteKm(latlngs, cum, km) {
+        if (!latlngs.length) return null;
+        if (km <= 0) return latlngs[0];
+        var total = cum[cum.length - 1];
+        if (km >= total) return latlngs[latlngs.length - 1];
+        for (var i = 1; i < cum.length; i++) {
+            if (cum[i] >= km) {
+                var segLen = cum[i] - cum[i - 1];
+                var t = segLen > 0 ? (km - cum[i - 1]) / segLen : 0;
+                var a = latlngs[i - 1];
+                var b = latlngs[i];
+                return L.latLng(a.lat + (b.lat - a.lat) * t, a.lng + (b.lng - a.lng) * t);
+            }
+        }
+        return latlngs[latlngs.length - 1];
+    }
+
+    function segmentIntersectsPreviewRoute(seg, bounds) {
+        if (!coursePreviewLineLayer || !seg || !bounds || !bounds.isValid()) return false;
+        var eventId = activePreviewEventId();
+        if (!eventId) return false;
+        var el = String(eventId).toLowerCase();
+        var fromKm = parseFloat(seg[el + '_from_km']);
+        var toKm = parseFloat(seg[el + '_to_km']);
+        if (isNaN(fromKm) || isNaN(toKm) || toKm <= fromKm) return false;
+        var latlngs = flattenPreviewLatLngs(coursePreviewLineLayer);
+        if (latlngs.length < 2) return false;
+        var cum = buildRouteKmTable(latlngs);
+        var span = toKm - fromKm;
+        var steps = Math.max(2, Math.min(20, Math.ceil(span * 5)));
+        for (var s = 0; s <= steps; s++) {
+            var km = fromKm + (span * s) / steps;
+            var ll = latLngAtRouteKm(latlngs, cum, km);
+            if (ll && bounds.contains(ll)) return true;
+        }
+        return false;
+    }
+
+    function segmentIntersectsBounds(seg, bounds, segIdx) {
         if (!seg || !bounds || !bounds.isValid()) return false;
-        if (seg.leg_id && libraryState && libraryState.legs) {
+        if (segmentIntersectsPreviewRoute(seg, bounds)) return true;
+        var legId = resolveLegIdForSegment(seg, segIdx != null ? segIdx : -1);
+        if (legId && libraryState && libraryState.legs) {
             var leg = libraryState.legs.find(function (c) {
-                return c.id === seg.leg_id;
+                return c.id === legId;
             });
             if (leg && legIntersectsBounds(leg, bounds)) return true;
         }
         if (coursePreviewLineLayer && seg.start_index != null && seg.end_index != null) {
-            var latlngs = coursePreviewLineLayer.getLatLngs();
-            var flat = latlngs;
-            if (latlngs.length && latlngs[0] && Array.isArray(latlngs[0])) {
-                flat = [];
-                latlngs.forEach(function (part) {
-                    part.forEach(function (ll) { flat.push(ll); });
-                });
-            }
+            var flat = flattenPreviewLatLngs(coursePreviewLineLayer);
             var lo = Math.min(seg.start_index, seg.end_index);
             var hi = Math.max(seg.start_index, seg.end_index);
             for (var i = lo; i <= hi && i < flat.length; i++) {
@@ -433,7 +528,7 @@
                     var lon = parseFloat(item.data.lon);
                     return !isNaN(lat) && !isNaN(lon) && bounds.contains([lat, lon]);
                 }
-                return segmentIntersectsBounds(item.data, bounds);
+                return segmentIntersectsBounds(item.data, bounds, item.index);
             },
             onFilter: function (visible, stats) {
                 applyCoursePreviewBoundsToTables(visible, stats);
@@ -2110,20 +2205,7 @@
         if (!libraryState || !libraryState.legs || !libraryState.legs.length) {
             return null;
         }
-        var legId = seg && (seg.leg_id != null || seg.chunk_id != null)
-            ? String(seg.leg_id != null ? seg.leg_id : seg.chunk_id).trim() : '';
-        if (!legId) {
-            var segId = seg && seg.seg_id != null ? String(seg.seg_id) : '';
-            var m = /^S(\d+)$/i.exec(segId);
-            if (m) {
-                var ord = parseInt(m[1], 10) - 1;
-                if (ord >= 0 && ord < libraryState.legs.length) {
-                    legId = libraryState.legs[ord].id;
-                }
-            } else if (segIdx >= 0 && segIdx < libraryState.legs.length) {
-                legId = libraryState.legs[segIdx].id;
-            }
-        }
+        var legId = resolveLegIdForSegment(seg, segIdx);
         var ch = libraryState.legs.find(function (c) { return c.id === legId; });
         if (!ch) return null;
         return {
@@ -2157,7 +2239,9 @@
             btn.addEventListener('click', function () {
                 coursePreviewSelectedEvent = eid;
                 renderCoursePreviewToolbar();
-                loadCoursePreviewRoute(eid);
+                loadCoursePreviewRoute(eid).then(function () {
+                    syncCoursePreviewBoundsFilterItems();
+                });
             });
             toolbar.appendChild(btn);
         });
@@ -2231,8 +2315,8 @@
         var wrap = document.getElementById('course-preview-map-wrap');
         var meta = document.getElementById('course-preview-meta');
         var empty = document.getElementById('course-preview-empty');
-        if (!eventId || !hasCombinedCourse()) return;
-        fetch(
+        if (!eventId || !hasCombinedCourse()) return Promise.resolve();
+        return fetch(
             apiBase() + '/segment-library/events/' + encodeURIComponent(eventId) + '/preview',
             { credentials: 'same-origin' }
         )

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -34,6 +34,9 @@
     var legTrimEndIdx = 0;
     var legTrimGhostLayer = null;
     var legTrimMarkerLayer = null;
+    var legBoundsCache = {};
+    var legsTableBoundsFilter = null;
+    var coursePreviewBoundsFilter = null;
 
     function schemaLabelForValue(value) {
         var v = String(value || 'on_course_open');
@@ -241,6 +244,219 @@
         });
     }
 
+    function updateLegsMapBoundsStatus(visible, total) {
+        var el = document.getElementById('leg-map-bounds-status');
+        if (!el) return;
+        if (!total) {
+            el.textContent = '';
+            return;
+        }
+        if (visible >= total) {
+            el.textContent = 'Showing all ' + total + ' legs';
+        } else {
+            el.textContent = 'Showing ' + visible + ' of ' + total + ' legs in map view';
+        }
+    }
+
+    function updateCoursePreviewBoundsStatus(segVisible, segTotal, locVisible, locTotal) {
+        var el = document.getElementById('course-preview-bounds-status');
+        if (!el) return;
+        if (!segTotal && !locTotal) {
+            el.textContent = '';
+            return;
+        }
+        var parts = [];
+        if (segTotal) {
+            parts.push(
+                segVisible >= segTotal
+                    ? 'All ' + segTotal + ' segments'
+                    : segVisible + ' of ' + segTotal + ' segments'
+            );
+        }
+        if (locTotal) {
+            parts.push(
+                locVisible >= locTotal
+                    ? 'all ' + locTotal + ' locations'
+                    : locVisible + ' of ' + locTotal + ' locations'
+            );
+        }
+        el.textContent = 'Map view: ' + parts.join(' · ');
+    }
+
+    function legIntersectsBounds(leg, bounds) {
+        if (!leg || !bounds || !bounds.isValid()) return false;
+        var cached = legBoundsCache[leg.id];
+        if (cached && cached.isValid && cached.isValid()) {
+            return bounds.intersects(cached);
+        }
+        function hasPt(lat, lon) {
+            var la = parseFloat(lat);
+            var lo = parseFloat(lon);
+            return !isNaN(la) && !isNaN(lo) && bounds.contains([la, lo]);
+        }
+        if (hasPt(leg.start_lat, leg.start_lon) || hasPt(leg.end_lat, leg.end_lon)) return true;
+        var locs = leg.locations || [];
+        for (var i = 0; i < locs.length; i++) {
+            if (hasPt(locs[i].lat, locs[i].lon)) return true;
+        }
+        return false;
+    }
+
+    function initLegsTableBoundsFilter() {
+        if (!window.MapBoundsTableFilter || legsTableBoundsFilter) return;
+        legsTableBoundsFilter = window.MapBoundsTableFilter.create({
+            getMap: function () { return window.courseMappingMap; },
+            isItemInBounds: function (leg, bounds) {
+                return legIntersectsBounds(leg, bounds);
+            },
+            onFilter: function (visible, stats) {
+                renderLegsTable(visible);
+                updateLegsMapBoundsStatus(stats.visible, stats.total);
+            }
+        });
+    }
+
+    function syncLegsTableBoundsFilterItems() {
+        initLegsTableBoundsFilter();
+        if (!legsTableBoundsFilter) return;
+        legsTableBoundsFilter.setAllItems((libraryState && libraryState.legs) || []);
+    }
+
+    function attachLegsTableBoundsFilter() {
+        initLegsTableBoundsFilter();
+        if (!legsTableBoundsFilter) return;
+        var map = window.courseMappingMap;
+        if (map) {
+            legsTableBoundsFilter.attach(map);
+            syncLegsTableBoundsFilterItems();
+        }
+    }
+
+    function fitLegMapToAllLegs() {
+        var map = window.courseMappingMap;
+        var legs = (libraryState && libraryState.legs) || [];
+        if (!map || !legs.length || selectedLegId) return;
+        var points = [];
+        legs.forEach(function (leg) {
+            if (leg.start_lat != null && leg.start_lon != null) {
+                points.push([leg.start_lat, leg.start_lon]);
+            }
+            if (leg.end_lat != null && leg.end_lon != null) {
+                points.push([leg.end_lat, leg.end_lon]);
+            }
+        });
+        if (points.length < 2) return;
+        function doFit() {
+            try {
+                map.fitBounds(L.latLngBounds(points), { padding: [48, 48], maxZoom: 14 });
+            } catch (e) { /* empty */ }
+        }
+        if (legsTableBoundsFilter) {
+            legsTableBoundsFilter.runProgrammatic(doFit);
+        } else {
+            doFit();
+        }
+    }
+
+    function segmentIntersectsBounds(seg, bounds) {
+        if (!seg || !bounds || !bounds.isValid()) return false;
+        if (seg.leg_id && libraryState && libraryState.legs) {
+            var leg = libraryState.legs.find(function (c) {
+                return c.id === seg.leg_id;
+            });
+            if (leg && legIntersectsBounds(leg, bounds)) return true;
+        }
+        if (coursePreviewLineLayer && seg.start_index != null && seg.end_index != null) {
+            var latlngs = coursePreviewLineLayer.getLatLngs();
+            var flat = latlngs;
+            if (latlngs.length && latlngs[0] && Array.isArray(latlngs[0])) {
+                flat = [];
+                latlngs.forEach(function (part) {
+                    part.forEach(function (ll) { flat.push(ll); });
+                });
+            }
+            var lo = Math.min(seg.start_index, seg.end_index);
+            var hi = Math.max(seg.start_index, seg.end_index);
+            for (var i = lo; i <= hi && i < flat.length; i++) {
+                if (bounds.contains(flat[i])) return true;
+            }
+        }
+        return false;
+    }
+
+    function buildCoursePreviewBoundsItems() {
+        var items = [];
+        var pkg = window.configPackageCourse;
+        if (!pkg || !pkg.getCourse) return items;
+        var course = pkg.getCourse();
+        if (!course) return items;
+        (course.segments || []).forEach(function (seg, i) {
+            items.push({ kind: 'segment', index: i, data: seg });
+        });
+        (course.locations || []).forEach(function (loc, i) {
+            items.push({ kind: 'location', index: i, data: loc });
+        });
+        return items;
+    }
+
+    function applyCoursePreviewBoundsToTables(visibleItems, stats) {
+        var segIndices = [];
+        var locIndices = [];
+        var segTotal = 0;
+        var locTotal = 0;
+        var pkg = window.configPackageCourse;
+        if (pkg && pkg.getCourse) {
+            var course = pkg.getCourse();
+            if (course) {
+                segTotal = (course.segments || []).length;
+                locTotal = (course.locations || []).length;
+            }
+        }
+        (visibleItems || []).forEach(function (item) {
+            if (item.kind === 'segment') segIndices.push(item.index);
+            else if (item.kind === 'location') locIndices.push(item.index);
+        });
+        if (pkg) {
+            if (pkg.renderSegmentsListFiltered) pkg.renderSegmentsListFiltered(segIndices);
+            if (pkg.renderLocationsListFiltered) pkg.renderLocationsListFiltered(locIndices);
+        }
+        updateCoursePreviewBoundsStatus(segIndices.length, segTotal, locIndices.length, locTotal);
+    }
+
+    function initCoursePreviewBoundsFilter() {
+        if (!window.MapBoundsTableFilter || coursePreviewBoundsFilter) return;
+        coursePreviewBoundsFilter = window.MapBoundsTableFilter.create({
+            getMap: function () { return coursePreviewMap; },
+            isItemInBounds: function (item, bounds) {
+                if (item.kind === 'location') {
+                    var lat = parseFloat(item.data.lat);
+                    var lon = parseFloat(item.data.lon);
+                    return !isNaN(lat) && !isNaN(lon) && bounds.contains([lat, lon]);
+                }
+                return segmentIntersectsBounds(item.data, bounds);
+            },
+            onFilter: function (visible, stats) {
+                applyCoursePreviewBoundsToTables(visible, stats);
+            }
+        });
+    }
+
+    function syncCoursePreviewBoundsFilterItems() {
+        initCoursePreviewBoundsFilter();
+        if (!coursePreviewBoundsFilter) return;
+        coursePreviewBoundsFilter.setAllItems(buildCoursePreviewBoundsItems());
+    }
+
+    function attachCoursePreviewBoundsFilter() {
+        initCoursePreviewBoundsFilter();
+        if (!coursePreviewBoundsFilter) return;
+        var map = ensureCoursePreviewMap();
+        if (map) {
+            coursePreviewBoundsFilter.attach(map);
+            syncCoursePreviewBoundsFilterItems();
+        }
+    }
+
     function updateAddLocationButtonLabel() {
         var btn = document.getElementById('btn-leg-add-location');
         if (!btn) return;
@@ -259,6 +475,7 @@
         libraryState = data;
         orderGrid = data.order_grid || {};
         renderLegsTable();
+        syncLegsTableBoundsFilterItems();
         renderRecipeTable();
         renderTotals(data.recipe_lengths_km);
         renderWarnings(data.stitch_warnings);
@@ -1431,33 +1648,40 @@
     function fitLegMapBounds(leg) {
         var map = window.courseMappingMap;
         if (!map) return;
-        var points = [];
-        if (selectedLegLatLngs && selectedLegLatLngs.length >= 2) {
-            points.push(selectedLegLatLngs[0]);
-            points.push(selectedLegLatLngs[selectedLegLatLngs.length - 1]);
-        }
-        if (leg) {
-            if (leg.start_lat != null && leg.start_lon != null) {
-                points.push([leg.start_lat, leg.start_lon]);
+        function doFit() {
+            var points = [];
+            if (selectedLegLatLngs && selectedLegLatLngs.length >= 2) {
+                points.push(selectedLegLatLngs[0]);
+                points.push(selectedLegLatLngs[selectedLegLatLngs.length - 1]);
             }
-            if (leg.end_lat != null && leg.end_lon != null) {
-                points.push([leg.end_lat, leg.end_lon]);
+            if (leg) {
+                if (leg.start_lat != null && leg.start_lon != null) {
+                    points.push([leg.start_lat, leg.start_lon]);
+                }
+                if (leg.end_lat != null && leg.end_lon != null) {
+                    points.push([leg.end_lat, leg.end_lon]);
+                }
+                (leg.locations || []).forEach(function (loc) {
+                    if (loc.lat != null && loc.lon != null) points.push([loc.lat, loc.lon]);
+                });
             }
-            (leg.locations || []).forEach(function (loc) {
+            pendingLegLocations.forEach(function (loc) {
                 if (loc.lat != null && loc.lon != null) points.push([loc.lat, loc.lon]);
             });
+            if (points.length === 0) return;
+            if (points.length === 1) {
+                map.setView(points[0], Math.max(map.getZoom(), 14));
+                return;
+            }
+            try {
+                map.fitBounds(L.latLngBounds(points), { padding: [48, 48] });
+            } catch (e) { /* empty */ }
         }
-        pendingLegLocations.forEach(function (loc) {
-            if (loc.lat != null && loc.lon != null) points.push([loc.lat, loc.lon]);
-        });
-        if (points.length === 0) return;
-        if (points.length === 1) {
-            map.setView(points[0], Math.max(map.getZoom(), 14));
-            return;
+        if (legsTableBoundsFilter) {
+            legsTableBoundsFilter.runProgrammatic(doFit);
+        } else {
+            doFit();
         }
-        try {
-            map.fitBounds(L.latLngBounds(points), { padding: [48, 48] });
-        } catch (e) { /* empty */ }
     }
 
     function refreshSelectedLegMap(options) {
@@ -1637,6 +1861,11 @@
                 var coords = feature.geometry.coordinates;
                 var latlngs = coords.map(function (c) { return [c[1], c[0]]; });
                 selectedLegLatLngs = latlngs;
+                try {
+                    legBoundsCache[legId] = L.latLngBounds(latlngs);
+                } catch (e) {
+                    delete legBoundsCache[legId];
+                }
                 setLegRoutePolyline(latlngs);
                 var props = feature.properties || {};
                 var currentLeg = getSelectedLeg() || leg;
@@ -1740,16 +1969,24 @@
         }
     }
 
-    function renderLegsTable() {
+    function renderLegsTable(legsSubset) {
         var tbody = document.getElementById('course-legs-tbody');
         var wrap = document.getElementById('course-legs-table-wrap');
         var empty = document.getElementById('course-legs-empty');
         if (!tbody) return;
-        var legs = (libraryState && libraryState.legs) || [];
-        if (!legs.length) {
+        var allLegs = (libraryState && libraryState.legs) || [];
+        var legs = legsSubset || allLegs;
+        if (!allLegs.length) {
             if (wrap) wrap.style.display = 'none';
             if (empty) empty.style.display = 'block';
             clearLegMap();
+            updateLegsMapBoundsStatus(0, 0);
+            return;
+        }
+        if (!legs.length) {
+            if (wrap) wrap.style.display = 'block';
+            if (empty) empty.style.display = 'none';
+            tbody.innerHTML = '';
             return;
         }
         if (empty) empty.style.display = 'none';
@@ -2022,20 +2259,32 @@
                 if (coursePreviewLocationsLayer) {
                     bounds = bounds.extend(coursePreviewLocationsLayer.getBounds());
                 }
-                map.fitBounds(bounds, { padding: [28, 28], maxZoom: 15 });
-                if (wrap) wrap.style.display = 'block';
-                if (empty) empty.style.display = 'none';
-                if (meta) {
-                    meta.style.display = 'block';
-                    meta.textContent =
-                        eventColumnLabel(eventId) +
-                        ': ' +
-                        Number(data.length_km).toFixed(2) +
-                        ' km · ' +
-                        (data.leg_count || 0) +
-                        ' legs';
+                function finishPreviewLoad() {
+                    if (wrap) wrap.style.display = 'block';
+                    if (empty) empty.style.display = 'none';
+                    if (meta) {
+                        meta.style.display = 'block';
+                        meta.textContent =
+                            eventColumnLabel(eventId) +
+                            ': ' +
+                            Number(data.length_km).toFixed(2) +
+                            ' km · ' +
+                            (data.leg_count || 0) +
+                            ' legs';
+                    }
+                    attachCoursePreviewBoundsFilter();
+                    syncCoursePreviewBoundsFilterItems();
+                    setTimeout(function () { map.invalidateSize(); }, 120);
                 }
-                setTimeout(function () { map.invalidateSize(); }, 120);
+                if (coursePreviewBoundsFilter) {
+                    coursePreviewBoundsFilter.runProgrammatic(function () {
+                        map.fitBounds(bounds, { padding: [28, 28], maxZoom: 15 });
+                        finishPreviewLoad();
+                    });
+                } else {
+                    map.fitBounds(bounds, { padding: [28, 28], maxZoom: 15 });
+                    finishPreviewLoad();
+                }
             })
             .catch(function (err) {
                 var map = coursePreviewMap;
@@ -2126,6 +2375,8 @@
                 setLegStatus('');
                 setRecipeStatus('');
                 bindLegMapControls();
+                attachLegsTableBoundsFilter();
+                fitLegMapToAllLegs();
             })
             .catch(function (err) {
                 setLegStatus(err.message || String(err), true);
@@ -2143,6 +2394,7 @@
             .then(function () {
                 syncCoursePanelUi({ autoOpen: true });
                 syncCoursePreviewUi();
+                attachCoursePreviewBoundsFilter();
             });
     }
 
@@ -2593,12 +2845,17 @@
         resolveLegLabelsForSegment: resolveLegLabelsForSegment,
         onLegsTabShown: function () {
             bindLegMapControls();
+            attachLegsTableBoundsFilter();
             if (window.courseMappingMap) {
                 setTimeout(function () {
                     window.courseMappingMap.invalidateSize();
                     bindLegMapControls();
+                    attachLegsTableBoundsFilter();
                 }, 100);
             }
-        }
+        },
+        attachLegsTableBoundsFilter: attachLegsTableBoundsFilter,
+        attachCoursePreviewBoundsFilter: attachCoursePreviewBoundsFilter,
+        syncCoursePreviewBoundsFilterItems: syncCoursePreviewBoundsFilterItems
     };
 })();

--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -121,13 +121,19 @@
         }
     }
 
+    function setPageTitle(text) {
+        const el = document.getElementById('race-config-page-title');
+        if (el) el.textContent = text || 'Race Configuration';
+    }
+
     function showEntryOnly() {
         const entry = document.getElementById('race-config-entry');
         const workspace = document.getElementById('race-config-workspace');
-        const pageHeader = document.querySelector('.page-header');
+        const pageHeader = document.querySelector('.race-config-page .page-header');
         if (entry) entry.style.display = 'block';
         if (workspace) workspace.style.display = 'none';
         if (pageHeader) pageHeader.style.display = '';
+        setPageTitle('Race Configuration');
     }
 
     function isPackageWorkspaceDirty() {
@@ -137,7 +143,7 @@
     function showWorkspace(manifest, configId) {
         const entry = document.getElementById('race-config-entry');
         const workspace = document.getElementById('race-config-workspace');
-        const pageHeader = document.querySelector('.page-header');
+        const pageHeader = document.querySelector('.race-config-page .page-header');
 
         currentConfigId = configId;
         if (entry) entry.style.display = 'none';
@@ -145,6 +151,7 @@
         if (pageHeader) pageHeader.style.display = 'none';
 
         const label = (manifest && manifest.label) || configId;
+        setPageTitle(label);
         const description = (manifest && manifest.description) || '';
         const eventDay = (manifest && manifest.event_day) || '';
 
@@ -181,7 +188,7 @@
     }
 
     function setActiveTab(tab) {
-        document.querySelectorAll('.race-config-tab').forEach(function (btn) {
+        document.querySelectorAll('.race-config-page .subnav-tab').forEach(function (btn) {
             const isActive = btn.getAttribute('data-tab') === tab;
             btn.classList.toggle('active', isActive);
             btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
@@ -627,26 +634,12 @@
             });
         }
 
-        const changePkg = document.getElementById('race-config-change-package');
-        if (changePkg) {
-            changePkg.addEventListener('click', function (e) {
-                if (
-                    isPackageWorkspaceDirty() &&
-                    !window.confirm('Discard unsaved changes to this package?')
-                ) {
-                    e.preventDefault();
-                    return;
-                }
-                window.location.href = CONFIG_PATH_PREFIX;
-            });
-        }
-
         function switchWorkspaceTab(tab, cid) {
             window.history.pushState({}, '', buildConfigUrl(cid, tab));
             setActiveTab(tab);
         }
 
-        document.querySelectorAll('.race-config-tab').forEach(function (btn) {
+        document.querySelectorAll('.race-config-page .subnav-tab').forEach(function (btn) {
             btn.addEventListener('click', function (e) {
                 const tab = btn.getAttribute('data-tab');
                 const cid = getConfigId();

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -425,11 +425,12 @@
                 const linkPath = href.split("?")[0];
                 let newHref = href.split("?")[0];
                 if (isConfigRoutePath(linkPath)) {
-                    const configId = localStorage.getItem("selected_config_id");
-                    if (configId) {
-                        newHref = setQueryParam(newHref, "config_id", configId);
-                        if (linkPath === "/config") {
-                            newHref = setQueryParam(newHref, "tab", "course");
+                    if (linkPath === "/config") {
+                        newHref = "/config";
+                    } else {
+                        const configId = localStorage.getItem("selected_config_id");
+                        if (configId) {
+                            newHref = setQueryParam(newHref, "config_id", configId);
                         }
                     }
                     newHref = setQueryParam(newHref, "run_id", null);

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -4,190 +4,139 @@
 
 {% block extra_head %}
 {% include 'partials/course_mapping_styles.html' %}
-<style>
-    /* Map height for config legs layout is in course_mapping_styles (.config-legs-map-region) */
-    .config-package-events-grid {
-        display: flex;
-        flex-wrap: wrap;
-        gap: 0.5rem 1rem;
-        margin-bottom: 1rem;
-    }
-    .config-package-events-grid label {
-        display: inline-flex;
-        align-items: center;
-        gap: 0.35rem;
-        font-size: 0.9rem;
-        cursor: pointer;
-    }
-    .race-config-workspace-nav {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        justify-content: space-between;
-        gap: 0.75rem;
-        margin-bottom: 1rem;
-    }
-    .race-config-workspace-actions {
-        display: flex;
-        flex-wrap: wrap;
-        align-items: center;
-        gap: 0.5rem;
-    }
-    .race-config-workspace-actions button {
-        padding: 0.4rem 0.75rem;
-        border: 1px solid #bdc3c7;
-        border-radius: 4px;
-        background: #fff;
-        font-size: 0.875rem;
-        cursor: pointer;
-    }
-    .race-config-workspace-actions button.primary,
-    .race-config-workspace-actions #btn-save-course {
-        background: #3498db;
-        color: #fff;
-        border-color: #2980b9;
-        font-weight: 600;
-    }
-    .race-config-workspace-nav .race-config-tabs {
-        margin-bottom: 0;
-        border-bottom: none;
-        padding-bottom: 0;
-    }
-    .race-config-tabs {
-        display: flex;
-        gap: 0.5rem;
-        margin-bottom: 1rem;
-        border-bottom: 2px solid #ecf0f1;
-        padding-bottom: 0.5rem;
-    }
-    .race-config-tab {
-        padding: 0.5rem 1.25rem;
-        border: 1px solid #bdc3c7;
-        border-radius: 4px 4px 0 0;
-        background: #fff;
-        cursor: pointer;
-        font-size: 0.95rem;
-    }
-    .race-config-tab.active {
-        background: #3498db;
-        color: #fff;
-        border-color: #2980b9;
-    }
-    #race-config-list-table tbody tr.config-row { cursor: pointer; }
-    #race-config-list-table tbody tr.config-row.selected { background: #e3f2fd; }
-    .race-config-modal {
-        display: none;
-        position: fixed;
-        inset: 0;
-        background: rgba(0, 0, 0, 0.4);
-        z-index: 1000;
-        align-items: center;
-        justify-content: center;
-    }
-    .race-config-modal.open { display: flex; }
-    .race-config-modal .modal-panel {
-        background: #fff;
-        border-radius: 6px;
-        padding: 1.5rem;
-        width: 100%;
-        max-width: 480px;
-        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
-    }
-</style>
+{% include 'partials/race_config_page_styles.html' %}
 {% endblock %}
 
 {% block content %}
-<div class="page-header">
-    <h2>Race Configuration</h2>
-</div>
-
-<div id="race-config-entry" class="card" style="margin-bottom: 2rem;">
-    <div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 1rem;">
-        <h3 style="margin: 0; color: #2c3e50;">Select a configuration</h3>
-        <button type="button" id="race-config-new-btn" style="padding: 0.4rem 0.75rem; border: 1px solid #bdc3c7; border-radius: 4px; background: #fff; cursor: pointer; font-size: 0.875rem;">New configuration</button>
+<div class="race-config-page">
+    <div class="page-header">
+        <h2 id="race-config-page-title">Race Configuration</h2>
     </div>
-    <div class="scrollable-table-container">
-        <table id="race-config-list-table" class="table-sticky-header">
-            <thead>
-                <tr>
-                    <th class="table-sortable" data-sort="label">Name <span class="table-sortable-indicator">↕</span></th>
-                    <th class="table-sortable" data-sort="description">Description <span class="table-sortable-indicator">↕</span></th>
-                    <th class="table-sortable" data-sort="updated">Saved On <span class="table-sortable-indicator">↕</span></th>
-                    <th class="course-map-action-cell" style="width: 5.5rem;">Actions</th>
-                </tr>
-            </thead>
-            <tbody id="race-config-list-tbody">
-                <tr><td colspan="4" class="placeholder">Loading configurations…</td></tr>
-            </tbody>
-        </table>
-    </div>
-    <p style="margin: 1rem 0 0 0; color: #7f8c8d; font-size: 0.875rem;">Click a row to open a package. Use the edit icon to change name, day, or description; the delete icon permanently removes a package (with confirmation). Packages live under <code>runflow/config/{config_id}/</code>.</p>
-</div>
 
-<div id="race-config-edit-package-modal" role="dialog" aria-labelledby="race-config-edit-package-title" aria-modal="true" class="race-config-modal">
-    <div class="modal-panel">
-        <h3 id="race-config-edit-package-title" style="margin: 0 0 1rem 0; color: #2c3e50;">Edit configuration</h3>
-        <label for="race-config-edit-label" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Name</label>
-        <input type="text" id="race-config-edit-label" maxlength="120" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
-        <label for="race-config-edit-day" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Day</label>
-        <select id="race-config-edit-day" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
-            <option value="">(not set)</option>
-            {% for day in day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true) %}
-            <option value="{{ day }}">{{ day | upper }}</option>
-            {% endfor %}
-        </select>
-        <p id="race-config-edit-events-note" style="font-size: 0.875rem; color: #7f8c8d; margin: 0 0 1rem 0;"></p>
-        <label for="race-config-edit-description" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Description <span style="color: #95a5a6; font-weight: normal;">(optional)</span></label>
-        <textarea id="race-config-edit-description" maxlength="255" rows="2" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1.25rem; box-sizing: border-box; resize: vertical; font-family: inherit;"></textarea>
-        <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
-            <button type="button" id="race-config-edit-cancel" class="course-btn">Cancel</button>
-            <button type="button" id="race-config-edit-save" class="course-btn" style="background: #27ae60; color: #fff; border-color: #219a52; font-weight: 600;">Save</button>
-        </div>
-    </div>
-</div>
-
-<div id="race-config-new-modal" role="dialog" aria-labelledby="race-config-new-title" aria-modal="true" class="race-config-modal">
-    <div class="modal-panel">
-        <h3 id="race-config-new-title" style="margin: 0 0 1rem 0; color: #2c3e50;">New configuration</h3>
-        <label for="race-config-new-label" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Name</label>
-        <input type="text" id="race-config-new-label" placeholder="FM 2027 Test" maxlength="120" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
-        <label for="race-config-new-day" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Day</label>
-        <select id="race-config-new-day" required style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
-            <option value="">Select day…</option>
-            {% for day in day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true) %}
-            <option value="{{ day }}">{{ day | upper }}</option>
-            {% endfor %}
-        </select>
-        <span style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Events</span>
-        <div id="race-config-new-events" class="config-package-events-grid" role="group" aria-label="Events for this configuration"></div>
-        <label for="race-config-new-description" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Description <span style="color: #95a5a6; font-weight: normal;">(optional)</span></label>
-        <textarea id="race-config-new-description" placeholder="Optional notes for this configuration" maxlength="255" rows="2" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1.25rem; box-sizing: border-box; resize: vertical; font-family: inherit;"></textarea>
-        <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
-            <button type="button" id="race-config-new-cancel" class="course-btn">Cancel</button>
-            <button type="button" id="race-config-create-btn" class="course-btn" style="background: #27ae60; color: #fff; border-color: #219a52; font-weight: 600;">Create &amp; open</button>
-        </div>
-    </div>
-</div>
-
-<div id="race-config-workspace" style="display: none;">
-    <div class="race-config-workspace-nav">
-        <div class="race-config-tabs" role="tablist">
-            <button type="button" class="race-config-tab active" data-tab="legs" role="tab" aria-selected="true">Legs</button>
-            <button type="button" class="race-config-tab" data-tab="course" role="tab" aria-selected="false">Course</button>
-            <button type="button" class="race-config-tab" data-tab="runners" role="tab" aria-selected="false">Runners</button>
-        </div>
-        <div style="display: flex; flex-wrap: wrap; align-items: center; gap: 0.75rem;">
-            <div id="race-config-workspace-actions" class="race-config-workspace-actions"></div>
-            <button type="button" id="race-config-change-package" style="padding: 0.35rem 0.75rem; font-size: 0.875rem; cursor: pointer;">Change package</button>
+    <div id="race-config-entry" class="page-shell page-shell--entry">
+        <div class="content-card">
+            <div class="card-header">
+                <h3 class="card-title">Select a configuration</h3>
+                <div class="card-actions">
+                    <button type="button" id="race-config-new-btn">New configuration</button>
+                </div>
+            </div>
+            <div class="scrollable-table-container">
+                <table id="race-config-list-table" class="table-sticky-header">
+                    <thead>
+                        <tr>
+                            <th class="table-sortable" data-sort="label">Name <span class="table-sortable-indicator">↕</span></th>
+                            <th class="table-sortable" data-sort="description">Description <span class="table-sortable-indicator">↕</span></th>
+                            <th class="table-sortable" data-sort="updated">Saved On <span class="table-sortable-indicator">↕</span></th>
+                            <th class="course-map-action-cell" style="width: 5.5rem;">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="race-config-list-tbody">
+                        <tr><td colspan="4" class="placeholder">Loading configurations…</td></tr>
+                    </tbody>
+                </table>
+            </div>
+            <p class="card-help" style="margin-bottom: 0;">Click a row to open a package. Use the edit icon to change name, day, or description; the delete icon permanently removes a package (with confirmation). Packages live under <code>runflow/config/{config_id}/</code>.</p>
         </div>
     </div>
 
-    <div id="race-config-tab-workspace" role="tabpanel">
-        {% include 'partials/course_mapping_workspace.html' %}
+    <div id="race-config-edit-package-modal" role="dialog" aria-labelledby="race-config-edit-package-title" aria-modal="true" class="race-config-modal">
+        <div class="modal-panel">
+            <h3 id="race-config-edit-package-title" style="margin: 0 0 1rem 0; color: #2c3e50;">Edit configuration</h3>
+            <label for="race-config-edit-label" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Name</label>
+            <input type="text" id="race-config-edit-label" maxlength="120" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
+            <label for="race-config-edit-day" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Day</label>
+            <select id="race-config-edit-day" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
+                <option value="">(not set)</option>
+                {% for day in day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true) %}
+                <option value="{{ day }}">{{ day | upper }}</option>
+                {% endfor %}
+            </select>
+            <p id="race-config-edit-events-note" style="font-size: 0.875rem; color: #7f8c8d; margin: 0 0 1rem 0;"></p>
+            <label for="race-config-edit-description" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Description <span style="color: #95a5a6; font-weight: normal;">(optional)</span></label>
+            <textarea id="race-config-edit-description" maxlength="255" rows="2" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1.25rem; box-sizing: border-box; resize: vertical; font-family: inherit;"></textarea>
+            <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
+                <button type="button" id="race-config-edit-cancel" class="course-btn">Cancel</button>
+                <button type="button" id="race-config-edit-save" class="course-btn" style="background: #27ae60; color: #fff; border-color: #219a52; font-weight: 600;">Save</button>
+            </div>
+        </div>
     </div>
 
-    <div id="race-config-tab-runners" role="tabpanel" style="display: none;">
-        {% include 'partials/runners_baseline_body.html' %}
+    <div id="race-config-new-modal" role="dialog" aria-labelledby="race-config-new-title" aria-modal="true" class="race-config-modal">
+        <div class="modal-panel">
+            <h3 id="race-config-new-title" style="margin: 0 0 1rem 0; color: #2c3e50;">New configuration</h3>
+            <label for="race-config-new-label" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Name</label>
+            <input type="text" id="race-config-new-label" placeholder="FM 2027 Test" maxlength="120" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
+            <label for="race-config-new-day" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Day</label>
+            <select id="race-config-new-day" required style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1rem; box-sizing: border-box;">
+                <option value="">Select day…</option>
+                {% for day in day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true) %}
+                <option value="{{ day }}">{{ day | upper }}</option>
+                {% endfor %}
+            </select>
+            <span style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Events</span>
+            <div id="race-config-new-events" class="config-package-events-grid" role="group" aria-label="Events for this configuration"></div>
+            <label for="race-config-new-description" style="display: block; margin-bottom: 0.35rem; font-weight: 600;">Description <span style="color: #95a5a6; font-weight: normal;">(optional)</span></label>
+            <textarea id="race-config-new-description" placeholder="Optional notes for this configuration" maxlength="255" rows="2" style="width: 100%; padding: 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 1rem; margin-bottom: 1.25rem; box-sizing: border-box; resize: vertical; font-family: inherit;"></textarea>
+            <div style="display: flex; gap: 0.75rem; justify-content: flex-end;">
+                <button type="button" id="race-config-new-cancel" class="course-btn">Cancel</button>
+                <button type="button" id="race-config-create-btn" class="course-btn" style="background: #27ae60; color: #fff; border-color: #219a52; font-weight: 600;">Create &amp; open</button>
+            </div>
+        </div>
+    </div>
+
+    <div id="race-config-workspace" class="page-shell page-shell--authoring" style="display: none;">
+        <div class="package-header-card content-card" id="config-package-details-card" style="display: none;">
+            <div class="package-header-body">
+                <div class="context-name-row">
+                    <h2 id="course-map-name-text" class="package-name-heading"></h2>
+                    <input type="text" id="course-map-name" class="config-package-input" placeholder="Package name" maxlength="120" />
+                    <div class="context-actions" id="race-config-context-actions">
+                        <div id="race-config-workspace-actions"></div>
+                    </div>
+                </div>
+                <div class="context-field">
+                    <span class="context-label">DESCRIPTION:</span>
+                    <span id="course-map-description-text" class="context-value context-value--multiline"></span>
+                    <textarea id="course-map-description" class="config-package-input config-package-textarea" placeholder="Optional description" maxlength="255" rows="2"></textarea>
+                </div>
+                <div class="context-field context-field--package-id">
+                    <span class="context-label">PACKAGE ID:</span>
+                    <code id="course-map-id" class="context-value" title=""></code>
+                </div>
+                <div class="context-field-row">
+                    <div class="context-field context-field--inline">
+                        <span class="context-label">EVENT DAY:</span>
+                        <span id="course-map-event-day-text" class="context-value"></span>
+                        <select id="course-map-event-day" class="config-package-input">
+                            <option value="">(not set)</option>
+                            {% for day in day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true) %}
+                            <option value="{{ day }}">{{ day }}</option>
+                            {% endfor %}
+                        </select>
+                    </div>
+                    <div class="context-field context-field--inline" id="config-package-events-field" style="display: none;">
+                        <span class="context-label">EVENTS:</span>
+                        <span id="course-map-package-events-text" class="context-value"></span>
+                    </div>
+                </div>
+            </div>
+            <nav class="subnav-tabs" role="tablist" aria-label="Package authoring">
+                <button type="button" class="subnav-tab active" data-tab="legs" role="tab" aria-selected="true">Legs</button>
+                <button type="button" class="subnav-tab" data-tab="course" role="tab" aria-selected="false">Course</button>
+                <button type="button" class="subnav-tab" data-tab="runners" role="tab" aria-selected="false">Runners</button>
+            </nav>
+        </div>
+
+        <div class="tab-panel-card content-card">
+            <div id="race-config-tab-workspace" role="tabpanel">
+                {% include 'partials/course_mapping_workspace.html' %}
+            </div>
+
+            <div id="race-config-tab-runners" role="tabpanel" style="display: none;">
+                {% include 'partials/runners_baseline_body.html' %}
+            </div>
+        </div>
     </div>
 </div>
 {% endblock %}
@@ -210,5 +159,5 @@
 <script src="/static/js/map/course_mapping.js?v=779a"></script>
 <script src="/static/js/map/segment_recipes.js?v=779b"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
-<script src="/static/js/race_configuration.js?v=771a"></script>
+<script src="/static/js/race_configuration.js?v=780b"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -204,10 +204,11 @@
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
 <script src="/static/js/map/base_map.js"></script>
+<script src="/static/js/map/map_bounds_table_filter.js?v=779a"></script>
 <script src="/static/js/table_actions.js?v=775b"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
-<script src="/static/js/map/course_mapping.js?v=773g"></script>
-<script src="/static/js/map/segment_recipes.js?v=778c"></script>
+<script src="/static/js/map/course_mapping.js?v=779a"></script>
+<script src="/static/js/map/segment_recipes.js?v=779a"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=771a"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -208,7 +208,7 @@
 <script src="/static/js/table_actions.js?v=775b"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
 <script src="/static/js/map/course_mapping.js?v=779a"></script>
-<script src="/static/js/map/segment_recipes.js?v=779a"></script>
+<script src="/static/js/map/segment_recipes.js?v=779b"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=771a"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -51,13 +51,34 @@
         color: #2c3e50;
     }
     #config-package-legs-panel .config-legs-map-section {
-        margin-top: 0.25rem;
-        padding-top: 1.25rem;
-        border-top: 1px solid #ecf0f1;
+        margin-top: 0;
+        padding-top: 0;
+        border-top: none;
         flex: 1 1 auto;
         min-height: 0;
         display: flex;
         flex-direction: column;
+    }
+    #config-package-legs-panel #course-legs-card {
+        padding-top: 1.25rem;
+        margin-top: 0.25rem;
+        border-top: 1px solid #ecf0f1;
+        flex: 0 0 auto;
+    }
+    .config-map-bounds-status {
+        position: absolute;
+        bottom: 10px;
+        left: 10px;
+        z-index: 900;
+        max-width: min(280px, 90%);
+        padding: 0.4rem 0.6rem;
+        border-radius: 4px;
+        background: rgba(255, 255, 255, 0.92);
+        box-shadow: 0 1px 4px rgba(0, 0, 0, 0.12);
+        font-size: 0.8rem;
+        color: #495057;
+        line-height: 1.35;
+        pointer-events: none;
     }
     #config-package-legs-panel .config-legs-map-lead {
         margin: 0 0 0.65rem 0;
@@ -82,6 +103,7 @@
         margin-bottom: 0.75rem;
     }
     #course-preview-map {
+        position: relative;
         height: min(42vh, 380px);
         min-height: 220px;
         width: 100%;

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -513,73 +513,12 @@
         color: #2c3e50;
     }
 
-    .config-package-details-card {
-        padding: 1rem 1.25rem;
-    }
-    .config-package-details-body {
-        display: grid;
-        grid-template-columns: minmax(0, 1fr);
-        gap: 0.65rem;
-    }
-    @media (min-width: 640px) {
-        .config-package-details-body {
-            grid-template-columns: minmax(0, 1.4fr) minmax(0, 2fr);
-            gap: 0.5rem 1.25rem;
-        }
-        .config-package-field-id {
-            grid-column: 1 / -1;
-        }
-    }
-    .config-package-field {
-        display: grid;
-        grid-template-columns: 6.5rem minmax(0, 1fr);
-        gap: 0.35rem 0.75rem;
-        align-items: baseline;
-    }
-    .config-package-label {
-        font-weight: 600;
-        color: #7f8c8d;
-        font-size: 0.8rem;
-        text-transform: uppercase;
-        letter-spacing: 0.02em;
-    }
-    .config-package-id-value {
-        font-size: 0.85rem;
-        color: #5d6d7e;
-        word-break: break-all;
-    }
-    .config-package-value {
-        color: #2c3e50;
-        font-size: 1rem;
-    }
-    .config-package-value-multiline {
-        white-space: pre-wrap;
-    }
-    .config-package-input {
-        display: none;
-        width: 100%;
-        padding: 0.4rem 0.55rem;
-        border: 1px solid #ddd;
-        border-radius: 4px;
-        font-size: 1rem;
-        box-sizing: border-box;
-        font-family: inherit;
-        color: #2c3e50;
-    }
-    .config-package-textarea {
-        resize: vertical;
-        min-height: 2.5em;
-    }
-    #race-config-workspace .course-map-meta-standalone,
-    #race-config-workspace .course-map-header-top {
-        display: none !important;
-    }
-    #race-config-workspace .course-from-map-title {
+    .course-from-map-title {
         margin: 0 0 0.25rem 0;
         font-size: 1.1rem;
         color: #2c3e50;
     }
-    #race-config-workspace .course-from-map-lead {
+    .course-from-map-lead {
         margin: 0 0 0.75rem 0;
         font-size: 0.875rem;
         color: #7f8c8d;

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -1,38 +1,5 @@
 <div id="course-mapping-root">
 
-<div class="card config-package-details-card" id="config-package-details-card" style="display: none; margin-bottom: 1rem;">
-    <div class="config-package-details-body">
-        <div class="config-package-field config-package-field-id">
-            <span class="config-package-label">Package ID</span>
-            <code id="course-map-id" class="config-package-id-value"></code>
-        </div>
-        <div class="config-package-field">
-            <span class="config-package-label">Name</span>
-            <span id="course-map-name-text" class="config-package-value"></span>
-            <input type="text" id="course-map-name" class="config-package-input" placeholder="Package name" maxlength="120" />
-        </div>
-        <div class="config-package-field">
-            <span class="config-package-label">Description</span>
-            <span id="course-map-description-text" class="config-package-value config-package-value-multiline"></span>
-            <textarea id="course-map-description" class="config-package-input config-package-textarea" placeholder="Optional description" maxlength="255" rows="2"></textarea>
-        </div>
-        <div class="config-package-field">
-            <span class="config-package-label">Event day</span>
-            <span id="course-map-event-day-text" class="config-package-value"></span>
-            <select id="course-map-event-day" class="config-package-input">
-                <option value="">(not set)</option>
-                {% for day in day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true) %}
-                <option value="{{ day }}">{{ day }}</option>
-                {% endfor %}
-            </select>
-        </div>
-        <div class="config-package-field" id="config-package-events-field" style="display: none;">
-            <span class="config-package-label">Events</span>
-            <span id="course-map-package-events-text" class="config-package-value"></span>
-        </div>
-    </div>
-</div>
-
 <div class="card" id="course-from-map-card">
     <div id="course-legacy-draw-header">
         <h3 class="course-from-map-title">Course (map)</h3>
@@ -46,7 +13,7 @@
                 </div>
                 <div id="course-map-header-buttons" class="course-map-header-buttons-standalone" style="display: flex; gap: 0.5rem; align-items: center;">
                     <button type="button" id="btn-edit-course" class="course-btn">Edit</button>
-                    <button type="button" id="btn-export" class="course-btn" disabled title="Write segments.csv, flow.csv, locations.csv, GPX to course folder">Export</button>
+                    <button type="button" id="btn-export" class="course-btn" disabled title="Write segments.csv, flow.csv, locations.csv, GPX to course folder">Export package</button>
                     <button type="button" id="btn-delete-course" class="course-btn" disabled title="Delete this course (cannot be undone)">Delete Course</button>
                     <button type="button" id="btn-save-course" class="course-btn primary" disabled style="display: none;">Save</button>
                 </div>
@@ -74,9 +41,11 @@
     <div id="course-map-legacy-slot"></div>
 
     <div id="config-package-legs-panel" class="config-package-panel config-legs-layout" style="display: none;">
-        <section class="course-derived-section config-legs-map-section" aria-labelledby="config-legs-map-heading">
-            <h4 id="config-legs-map-heading" class="course-derived-heading">Leg map</h4>
-            <p class="course-derived-empty config-legs-map-lead">
+        <section class="content-card course-derived-section config-legs-map-section" aria-labelledby="config-legs-map-heading">
+            <div class="card-header">
+                <h4 id="config-legs-map-heading" class="card-title">Leg map</h4>
+            </div>
+            <p class="card-help course-derived-empty config-legs-map-lead">
                 Pan and zoom to filter the legs table below. Select a leg, then <strong>Add Locations</strong>.
                 <strong>Course, water, and official</strong> snap to the purple route;
                 <strong>aid</strong>, <strong>traffic</strong>, and <strong>extract</strong> stay at your click.
@@ -103,18 +72,20 @@
                 </div>
             </div>
         </section>
-        <section class="course-derived-section" id="course-legs-card">
-            <h4 class="course-derived-heading">Course legs</h4>
-            <p class="course-derived-empty" style="margin-bottom: 0.5rem;">
+        <section class="content-card course-derived-section" id="course-legs-card">
+            <div class="card-header">
+                <h4 class="card-title">Course legs</h4>
+                <div class="card-actions course-planner-toolbar config-legs-table-toolbar">
+                <input type="file" id="segment-library-gpx-input" accept=".gpx,.json" multiple style="display: none;" />
+                <button type="button" id="btn-import-gpx" class="course-btn" title="Import GPX routes and optional leg export JSON (locations + metadata)">Import legs…</button>
+                <button type="button" id="btn-draw-leg-map" class="course-btn" disabled title="Coming soon: draw a new leg on the map">Draw leg on map</button>
+                </div>
+            </div>
+            <p class="card-help course-derived-empty">
                 Import GPX files, then select a leg in the table (use <strong>Edit</strong> on that row for leg details).
                 Set <strong>Proxy loc ID</strong> on the
                 <button type="button" id="btn-go-to-recipes" class="course-link-btn">Course</button> tab.
             </p>
-            <div class="course-planner-toolbar config-legs-table-toolbar">
-                <input type="file" id="segment-library-gpx-input" accept=".gpx,.json" multiple style="display: none;" />
-                <button type="button" id="btn-import-gpx" class="course-btn" title="Import GPX routes and optional leg export JSON (locations + metadata)">Import legs…</button>
-                <button type="button" id="btn-draw-leg-map" class="course-btn" disabled title="Coming soon: draw a new leg on the map">Draw leg on map</button>
-            </div>
             <p id="course-legs-status" class="course-derived-empty" style="display: none;"></p>
             <div id="course-legs-table-wrap" class="config-legs-table-region" style="display: none;">
                 <div class="scrollable-table-container config-legs-table-scroll">
@@ -142,12 +113,14 @@
     </div>
 
     <div id="config-package-course-panel" class="config-package-panel" style="display: none;">
-        <section class="course-derived-section" id="course-preview-section" style="display: none;">
-            <div class="course-derived-heading-row">
-                <h4 class="course-derived-heading">Course preview</h4>
-                <div id="course-preview-event-toolbar" class="course-preview-event-toolbar" role="group" aria-label="Event route"></div>
+        <section class="content-card course-derived-section" id="course-preview-section" style="display: none;">
+            <div class="card-header">
+                <h4 class="card-title">Course preview</h4>
+                <div class="card-actions">
+                    <div id="course-preview-event-toolbar" class="course-preview-event-toolbar" role="group" aria-label="Event route"></div>
+                </div>
             </div>
-            <p id="course-preview-empty" class="course-derived-empty">Save event recipes to preview each distance route.</p>
+            <p id="course-preview-empty" class="card-help course-derived-empty">Save event recipes to preview each distance route.</p>
             <p id="course-preview-meta" class="course-derived-empty" style="display: none; margin-bottom: 0.5rem;"></p>
             <div id="course-preview-map-wrap" class="config-course-preview-map-wrap" style="display: none;">
                 <div id="course-preview-map" aria-label="Stitched event route preview">
@@ -155,12 +128,14 @@
                 </div>
             </div>
         </section>
-        <section class="course-derived-section" id="segments-card">
-            <div class="course-derived-heading-row">
-                <h4 class="course-derived-heading">Segments (combined course)</h4>
-                <button type="button" id="btn-edit-event-recipes" class="course-map-action-text-btn" style="display: none;" title="Change leg order per event and re-export segments">Edit event recipes</button>
+        <section class="content-card course-derived-section" id="segments-card">
+            <div class="card-header">
+                <h4 class="card-title">Segments (combined course)</h4>
+                <div class="card-actions">
+                    <button type="button" id="btn-edit-event-recipes" class="course-map-action-text-btn" style="display: none;" title="Change leg order per event and re-export segments">Edit event recipes</button>
+                </div>
             </div>
-            <p id="segments-empty" class="course-derived-empty">Build the combined course from your legs using <strong>event recipes</strong> (set leg order per distance, then export). Pan/zoom the preview map to filter segments and locations tables.</p>
+            <p id="segments-empty" class="card-help course-derived-empty">Build the combined course from your legs using <strong>event recipes</strong> (set leg order per distance, then export). Pan/zoom the preview map to filter segments and locations tables.</p>
             <div id="segments-table-wrap" style="display: none;">
                 <div class="scrollable-table-container course-derived-table-scroll">
                     <table id="segments-table" class="table-sticky-header" style="width: 100%; font-size: 0.875rem;">
@@ -173,13 +148,15 @@
             </div>
         </section>
 
-        <section class="course-derived-section" id="locations-card">
-            <div class="course-derived-heading-row">
-                <h4 class="course-derived-heading">Locations (combined course)</h4>
-                <button type="button" id="btn-edit-locations-grid" class="course-map-action-text-btn" style="display: none;" title="Operational editor for zones, timing, resources, and notes">Edit operations…</button>
-                <button type="button" id="btn-manage-resources" class="course-map-action-text-btn" title="Define schedulable resources">Manage resources</button>
+        <section class="content-card course-derived-section" id="locations-card">
+            <div class="card-header">
+                <h4 class="card-title">Locations (combined course)</h4>
+                <div class="card-actions">
+                    <button type="button" id="btn-edit-locations-grid" class="course-map-action-text-btn" style="display: none;" title="Operational editor for zones, timing, resources, and notes">Edit operations…</button>
+                    <button type="button" id="btn-manage-resources" class="course-map-action-text-btn" title="Define schedulable resources">Manage resources</button>
+                </div>
             </div>
-            <p id="locations-empty" class="course-derived-empty">Locations appear here after you save event recipes. Placements from the Legs tab map sync when you open this tab. Edit resources, segment ID, and remove locations here.</p>
+            <p id="locations-empty" class="card-help course-derived-empty">Locations appear here after you save event recipes. Placements from the Legs tab map sync when you open this tab. Edit resources, segment ID, and remove locations here.</p>
             <div id="locations-table-wrap" style="display: none;">
                 <div class="scrollable-table-container course-derived-table-scroll">
                     <table id="locations-table" class="table-sticky-header" style="width: 100%; font-size: 0.875rem;">

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -74,13 +74,39 @@
     <div id="course-map-legacy-slot"></div>
 
     <div id="config-package-legs-panel" class="config-package-panel config-legs-layout" style="display: none;">
+        <section class="course-derived-section config-legs-map-section" aria-labelledby="config-legs-map-heading">
+            <h4 id="config-legs-map-heading" class="course-derived-heading">Leg map</h4>
+            <p class="course-derived-empty config-legs-map-lead">
+                Pan and zoom to filter the legs table below. Select a leg, then <strong>Add Locations</strong>.
+                <strong>Course, water, and official</strong> snap to the purple route;
+                <strong>aid</strong>, <strong>traffic</strong>, and <strong>extract</strong> stay at your click.
+            </p>
+            <div id="config-legs-map-slot" class="config-legs-map-slot">
+                <div id="course-map-container" class="config-legs-map-region">
+                <div id="course-mapping-map" aria-label="Leg and course map">
+                    <div class="map-loading">Loading map...</div>
+                    <div id="leg-map-bounds-status" class="config-map-bounds-status" aria-live="polite"></div>
+                    <div id="leg-map-toolbar" class="leg-map-toolbar">
+                        <button type="button" id="btn-leg-trim-route" class="course-btn" disabled title="Select a leg, then drag start or end along the route">Trim route</button>
+                        <button type="button" id="btn-leg-reshape-route" class="course-btn" disabled title="Select a leg, simplify the route, then drag yellow anchors to nudge it">Reshape route</button>
+                        <span id="leg-route-edit-actions" class="leg-route-edit-actions" style="display: none;">
+                            <button type="button" id="btn-leg-route-edit-confirm" class="course-btn primary">Confirm</button>
+                            <button type="button" id="btn-leg-route-edit-cancel" class="course-btn">Cancel</button>
+                        </span>
+                        <button type="button" id="btn-leg-add-location" class="course-btn" disabled title="Select a leg in the table first">Add Locations</button>
+                    </div>
+                    <div id="basemap-toggle" style="display: none;">
+                        <button type="button" id="btn-street" class="course-btn active">Street</button>
+                        <button type="button" id="btn-satellite" class="course-btn">Satellite</button>
+                    </div>
+                </div>
+                </div>
+            </div>
+        </section>
         <section class="course-derived-section" id="course-legs-card">
             <h4 class="course-derived-heading">Course legs</h4>
             <p class="course-derived-empty" style="margin-bottom: 0.5rem;">
                 Import GPX files, then select a leg in the table (use <strong>Edit</strong> on that row for leg details).
-                Use <strong>Add Locations</strong> to place pins.
-                <strong>Course, water, and official</strong> snap to the purple route;
-                <strong>aid</strong>, <strong>traffic</strong>, and <strong>extract</strong> stay where you click.
                 Set <strong>Proxy loc ID</strong> on the
                 <button type="button" id="btn-go-to-recipes" class="course-link-btn">Course</button> tab.
             </p>
@@ -113,36 +139,6 @@
             </div>
             <p id="course-legs-empty" class="course-derived-empty">No legs yet. Use <strong>Import GPX</strong> to add one or more route files.</p>
         </section>
-        <section class="course-derived-section config-legs-map-section" aria-labelledby="config-legs-map-heading">
-            <h4 id="config-legs-map-heading" class="course-derived-heading">Leg map</h4>
-            <p class="course-derived-empty config-legs-map-lead">
-                Select a leg, then <strong>Add Locations</strong>.
-                <strong>Course, water, and official</strong> snap to the purple route;
-                <strong>aid</strong>, <strong>traffic</strong>, and <strong>extract</strong> stay at your click.
-                Use <strong>Trim route</strong> to drag the green/red ends along the track and shorten the leg, or <strong>Reshape route</strong> to simplify and nudge corners.
-                <strong>Confirm</strong> saves edits. Click a location pin to edit label/type or delete.
-            </p>
-            <div id="config-legs-map-slot" class="config-legs-map-slot">
-                <div id="course-map-container" class="config-legs-map-region">
-                <div id="course-mapping-map" aria-label="Leg and course map">
-                    <div class="map-loading">Loading map...</div>
-                    <div id="leg-map-toolbar" class="leg-map-toolbar">
-                        <button type="button" id="btn-leg-trim-route" class="course-btn" disabled title="Select a leg, then drag start or end along the route">Trim route</button>
-                        <button type="button" id="btn-leg-reshape-route" class="course-btn" disabled title="Select a leg, simplify the route, then drag yellow anchors to nudge it">Reshape route</button>
-                        <span id="leg-route-edit-actions" class="leg-route-edit-actions" style="display: none;">
-                            <button type="button" id="btn-leg-route-edit-confirm" class="course-btn primary">Confirm</button>
-                            <button type="button" id="btn-leg-route-edit-cancel" class="course-btn">Cancel</button>
-                        </span>
-                        <button type="button" id="btn-leg-add-location" class="course-btn" disabled title="Select a leg in the table first">Add Locations</button>
-                    </div>
-                    <div id="basemap-toggle" style="display: none;">
-                        <button type="button" id="btn-street" class="course-btn active">Street</button>
-                        <button type="button" id="btn-satellite" class="course-btn">Satellite</button>
-                    </div>
-                </div>
-                </div>
-            </div>
-        </section>
     </div>
 
     <div id="config-package-course-panel" class="config-package-panel" style="display: none;">
@@ -154,7 +150,9 @@
             <p id="course-preview-empty" class="course-derived-empty">Save event recipes to preview each distance route.</p>
             <p id="course-preview-meta" class="course-derived-empty" style="display: none; margin-bottom: 0.5rem;"></p>
             <div id="course-preview-map-wrap" class="config-course-preview-map-wrap" style="display: none;">
-                <div id="course-preview-map" aria-label="Stitched event route preview"></div>
+                <div id="course-preview-map" aria-label="Stitched event route preview">
+                    <div id="course-preview-bounds-status" class="config-map-bounds-status" aria-live="polite"></div>
+                </div>
             </div>
         </section>
         <section class="course-derived-section" id="segments-card">
@@ -162,7 +160,7 @@
                 <h4 class="course-derived-heading">Segments (combined course)</h4>
                 <button type="button" id="btn-edit-event-recipes" class="course-map-action-text-btn" style="display: none;" title="Change leg order per event and re-export segments">Edit event recipes</button>
             </div>
-            <p id="segments-empty" class="course-derived-empty">Build the combined course from your legs using <strong>event recipes</strong> (set leg order per distance, then export).</p>
+            <p id="segments-empty" class="course-derived-empty">Build the combined course from your legs using <strong>event recipes</strong> (set leg order per distance, then export). Pan/zoom the preview map to filter segments and locations tables.</p>
             <div id="segments-table-wrap" style="display: none;">
                 <div class="scrollable-table-container course-derived-table-scroll">
                     <table id="segments-table" class="table-sticky-header" style="width: 100%; font-size: 0.875rem;">

--- a/frontend/templates/partials/race_config_page_styles.html
+++ b/frontend/templates/partials/race_config_page_styles.html
@@ -1,0 +1,314 @@
+<style>
+    /* Race Configuration — scoped layout only (Issue #769 shell) */
+    .race-config-page .page-shell {
+        margin-bottom: 2rem;
+    }
+
+    .race-config-page .page-header {
+        margin: 28px 0 18px;
+        padding: 0;
+        background: transparent;
+        border: 0;
+        display: block;
+    }
+    .race-config-page .page-header h1,
+    .race-config-page .page-header h2 {
+        margin: 0;
+        color: #243746;
+        font-size: 28px;
+        font-weight: 700;
+        line-height: 1.2;
+    }
+
+    .race-config-page .content-card {
+        background: #fff;
+        border: 1px solid #e0e0e0;
+        border-radius: 6px;
+        padding: 1.25rem 1.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+    }
+
+    .race-config-page .card-header {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 0.75rem;
+        margin-bottom: 0.35rem;
+    }
+    .race-config-page .card-title {
+        margin: 0;
+        font-size: 1.1rem;
+        font-weight: 600;
+        color: #2c3e50;
+    }
+    .race-config-page .card-help {
+        margin: 0 0 1rem 0;
+        font-size: 0.875rem;
+        color: #7f8c8d;
+        line-height: 1.45;
+    }
+    .race-config-page .card-header + .card-help {
+        margin-top: 0;
+    }
+    .race-config-page .card-actions {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: 0.5rem;
+    }
+    .race-config-page .card-actions button {
+        padding: 0.4rem 0.75rem;
+        border: 1px solid #bdc3c7;
+        border-radius: 4px;
+        background: #fff;
+        font-size: 0.875rem;
+        cursor: pointer;
+    }
+
+    /* Package header card: compact meta + tabs attached at bottom */
+    .race-config-page .package-header-card {
+        padding: 0;
+        overflow: hidden;
+        margin-bottom: 1rem;
+    }
+    .race-config-page .package-header-body {
+        padding: 0.85rem 1.25rem 0.5rem;
+    }
+    .race-config-page .context-name-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: space-between;
+        gap: 0.5rem 1rem;
+        margin-bottom: 0.35rem;
+    }
+    .race-config-page .package-name-heading {
+        flex: 1 1 200px;
+        min-width: 0;
+        margin: 0;
+        color: #243746;
+        font-size: 1.5rem;
+        font-weight: 700;
+        line-height: 1.25;
+    }
+    .race-config-page .context-name-row .config-package-input {
+        display: none;
+        flex: 1 1 100%;
+        max-width: 28rem;
+    }
+    .race-config-page .context-field {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 0.35rem 0.5rem;
+        margin-bottom: 0.3rem;
+        line-height: 1.4;
+    }
+    .race-config-page .context-field-row {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: baseline;
+        gap: 0.5rem 2rem;
+        margin-bottom: 0;
+    }
+    .race-config-page .context-field--inline {
+        margin-bottom: 0;
+    }
+    .race-config-page .context-field .context-label {
+        font-weight: 600;
+        color: #5f6f7a;
+        font-size: 0.75rem;
+        text-transform: uppercase;
+        letter-spacing: 0.02em;
+        flex: 0 0 auto;
+    }
+    .race-config-page .context-field .context-value {
+        color: #243746;
+        font-size: 0.9rem;
+        font-weight: 500;
+    }
+    .race-config-page .context-field .context-value--multiline {
+        white-space: pre-wrap;
+        font-weight: 400;
+    }
+    .race-config-page .context-field--package-id .context-value {
+        font-size: 0.85rem;
+        font-weight: 400;
+        color: #5d6d7e;
+        font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+    }
+    .race-config-page .context-field .config-package-input {
+        display: none;
+        width: 100%;
+        max-width: 28rem;
+        padding: 0.4rem 0.55rem;
+        border: 1px solid #ddd;
+        border-radius: 4px;
+        font-size: 1rem;
+        box-sizing: border-box;
+        font-family: inherit;
+        color: #2c3e50;
+    }
+    .race-config-page .context-field .config-package-textarea {
+        resize: vertical;
+        min-height: 2.5em;
+    }
+
+    .race-config-page .context-actions {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        justify-content: flex-end;
+        gap: 0.5rem;
+        flex: 0 0 auto;
+    }
+    .race-config-page .context-actions button,
+    .race-config-page #race-config-workspace-actions button {
+        padding: 0.4rem 0.75rem;
+        border: 1px solid #bdc3c7;
+        border-radius: 4px;
+        background: #fff;
+        font-size: 0.875rem;
+        cursor: pointer;
+    }
+    .race-config-page .context-actions button.primary,
+    .race-config-page #race-config-workspace-actions button.primary,
+    .race-config-page #race-config-workspace-actions #btn-save-course {
+        background: #3498db;
+        color: #fff;
+        border-color: #2980b9;
+        font-weight: 600;
+    }
+
+    .race-config-page .package-header-card .subnav-tabs {
+        display: flex;
+        align-items: flex-end;
+        gap: 0;
+        margin: 0;
+        padding: 0 0.5rem;
+        background: transparent;
+        border: 0;
+        border-top: 1px solid #e8ecef;
+        border-bottom: 1px solid #d9e0e6;
+        list-style: none;
+    }
+    .race-config-page .package-header-card .subnav-tab {
+        padding: 10px 16px;
+        background: transparent;
+        border: 0;
+        border-bottom: 3px solid transparent;
+        margin-bottom: -1px;
+        color: #5f6f7a;
+        font-weight: 500;
+        font-size: 0.95rem;
+        cursor: pointer;
+        border-radius: 0;
+    }
+    .race-config-page .package-header-card .subnav-tab.active {
+        color: #243746;
+        font-weight: 700;
+        border-bottom-color: #2f9bd3;
+        background: transparent;
+    }
+    .race-config-page .package-header-card .subnav-tab:hover {
+        color: #243746;
+        background: #f5f8fa;
+    }
+
+    .race-config-page .config-package-events-grid {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem 1rem;
+        margin-bottom: 1rem;
+    }
+    .race-config-page .config-package-events-grid label {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.35rem;
+        font-size: 0.9rem;
+        cursor: pointer;
+    }
+
+    .race-config-page #race-config-list-table tbody tr.config-row {
+        cursor: pointer;
+    }
+    .race-config-page #race-config-list-table tbody tr.config-row.selected {
+        background: #e3f2fd;
+    }
+
+    .race-config-page .race-config-modal {
+        display: none;
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.4);
+        z-index: 1000;
+        align-items: center;
+        justify-content: center;
+    }
+    .race-config-page .race-config-modal.open {
+        display: flex;
+    }
+    .race-config-page .race-config-modal .modal-panel {
+        background: #fff;
+        border-radius: 6px;
+        padding: 1.5rem;
+        width: 100%;
+        max-width: 480px;
+        box-shadow: 0 4px 20px rgba(0, 0, 0, 0.15);
+    }
+
+    /* Tab content card below package header */
+    .race-config-page .tab-panel-card {
+        margin-top: 0;
+    }
+    .race-config-page .tab-panel-card #course-from-map-card {
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        margin: 0;
+        background: transparent;
+    }
+    .race-config-page .tab-panel-card .course-map-meta-standalone,
+    .race-config-page .tab-panel-card .course-map-header-top {
+        display: none !important;
+    }
+    .race-config-page .tab-panel-card .content-card.course-derived-section {
+        background: #fff;
+        border: 1px solid #ecf0f1;
+        border-radius: 6px;
+        padding: 1.25rem 1.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+        margin: 0 0 1rem 0;
+    }
+    .race-config-page .tab-panel-card .content-card.course-derived-section:last-child {
+        margin-bottom: 0;
+    }
+    .race-config-page .tab-panel-card #config-package-legs-panel #course-legs-card {
+        margin-top: 0;
+        padding-top: 0;
+        border-top: none;
+    }
+    .race-config-page .tab-panel-card > .card {
+        border: none;
+        box-shadow: none;
+        padding: 0;
+        margin: 0;
+        background: transparent;
+    }
+    .race-config-page .tab-panel-card #error-banner.card {
+        margin-bottom: 1rem;
+        padding: 1rem;
+        border: 1px solid #f5c6cb;
+        border-radius: 6px;
+        background: #fee;
+    }
+    .race-config-page .tab-panel-card > .card:not(#error-banner) {
+        background: #fff;
+        border: 1px solid #ecf0f1;
+        border-radius: 6px;
+        padding: 1.25rem 1.5rem;
+        box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
+        margin-bottom: 1rem;
+    }
+</style>


### PR DESCRIPTION
## Summary

This branch improves the Race Configuration package authoring experience in two areas: **map-driven table filtering** (aligned with Segments/Locations) and a **scoped authoring shell** for package selection and Legs/Course/Runners tabs.

### Map / table UX
- Added `map_bounds_table_filter.js` — debounced pan/zoom filters tables using map bounds (Issue #634 programmatic-move guard).
- **Legs tab:** map above legs table; bounds filter on `course-legs-table`; status chip for filtered row count.
- **Course tab:** preview map filters combined **segments** and **locations** tables via `segmentIntersectsPreviewRoute()` (stitched preview polyline + per-event `{event}_from_km` / `{event}_to_km`, not leg endpoints only).
- Fixed empty segments table after bounds filter when segment geometry spans only part of a leg along the preview route.

### Authoring shell (visual only, no workflow changes)
- Wrapped Race Configuration in `.race-config-page` with scoped layout CSS (`race_config_page_styles.html`).
- **Package selection** remains landing at `/config`; list uses normalized content-card headers.
- **Package open:** compact **package header card** with package name as heading, DESCRIPTION / PACKAGE ID / EVENT DAY + EVENTS metadata, **Export package** only (removed Change package — return via main nav).
- **Underline tabs** (Legs | Course | Runners) attached to bottom of header card; tab bodies in separate content cards below.
- Main nav **Race Configuration** always links to `/config` (package list, no `config_id` query).
- Workspace section headers normalized (`card-header` / `card-title` / `card-help` / `card-actions`).
- Fixed dark site `header` styling bleeding onto page title (use `div.page-header`).

## Commits
- Align Race Configuration map/table UX with Segments and Locations pages
- Fix Course tab segments table empty after map bounds filter
- Refactor Race Configuration package authoring shell layout

## Files changed
| Area | Files |
|------|--------|
| Map filter | `map_bounds_table_filter.js`, `segment_recipes.js`, `course_mapping.js`, `course_mapping_workspace.html`, `course_mapping_styles.html` |
| Shell | `race_configuration.html`, `race_config_page_styles.html`, `race_configuration.js`, `base.html` |

## Test plan
- [ ] `/config` — package list, New configuration, open package
- [ ] Legs — pan/zoom map filters legs table; import GPX / edit leg unchanged
- [ ] Course — preview map filters segments + locations; event recipes / export unchanged
- [ ] Runners tab — baseline workflow unchanged
- [ ] Export package from header card
- [ ] Race Configuration nav returns to `/config` from any tab
- [ ] `POST /runflow/v2/analyze` smoke test on an exported package

## Next: Issue #759 (flow.csv)
Add **`flow_type` on legs and combined-course segments**, then generator + review UI for `flow.csv` (pairwise event rows per shared leg — not one naive row per segment). Reference: `2026_final/flow.csv` patterns vs current `build_flow_csv()` output.