### PR TITLE
Flow.csv authoring, leg export, and recipe-order segment build (#759)

### DIFF
--- a/app/api/bidirectional.py
+++ b/app/api/bidirectional.py
@@ -81,6 +81,7 @@ async def get_bidirectional_segment_detail(
     day: Optional[str] = Query(None, description="Day code (fri|sat|sun|mon)"),
     event_a: Optional[str] = Query(None, description="Event A name"),
     event_b: Optional[str] = Query(None, description="Event B name"),
+    flow_id: Optional[str] = Query(None, description="Unique flow row id"),
 ):
     try:
         from app.utils.run_id import get_latest_run_id, resolve_selected_day
@@ -95,15 +96,22 @@ async def get_bidirectional_segment_detail(
             raise HTTPException(status_code=404, detail="No overlap summary available")
 
         segments = summary.get("segments", [])
-        seg_matches = [
-            seg for seg in segments
-            if str(seg.get("seg_id")) == str(seg_id)
-            and (event_a is None or str(seg.get("event_a")) == str(event_a))
-            and (event_b is None or str(seg.get("event_b")) == str(event_b))
-        ]
+        if flow_id:
+            seg_matches = [
+                seg for seg in segments
+                if str(seg.get("flow_id") or "") == str(flow_id)
+            ]
+        else:
+            seg_matches = [
+                seg for seg in segments
+                if str(seg.get("seg_id")) == str(seg_id)
+                and (event_a is None or str(seg.get("event_a")) == str(event_a))
+                and (event_b is None or str(seg.get("event_b")) == str(event_b))
+            ]
         if not seg_matches:
-            raise HTTPException(status_code=404, detail=f"Segment {seg_id} not found in overlap summary")
-        if len(seg_matches) > 1 and (event_a is None or event_b is None):
+            detail = f"Flow row {flow_id} not found" if flow_id else f"Segment {seg_id} not found in overlap summary"
+            raise HTTPException(status_code=404, detail=detail)
+        if len(seg_matches) > 1 and not flow_id and (event_a is None or event_b is None):
             raise HTTPException(status_code=400, detail="event_a and event_b are required for this segment")
 
         segment = seg_matches[0]

--- a/app/core/artifacts/frontend.py
+++ b/app/core/artifacts/frontend.py
@@ -965,7 +965,10 @@ def generate_segments_geojson(reports_dir: Path, analysis_context: Optional[Any]
             props["events"] = [event for event in ["Full", "Half", "10K"] 
                               if dims.get(event.lower() if event != "10K" else "10K", "") == "y"]
             props["schema"] = schema_key
-            props["description"] = dims.get("description", "No description available")
+            desc_val = dims.get("description", "")
+            if desc_val is None or (isinstance(desc_val, float) and pd.isna(desc_val)):
+                desc_val = ""
+            props["description"] = str(desc_val).strip()
     
     return geojson
 

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -520,22 +520,10 @@ def apply_leg_exports_to_manifest(
     return manifest
 
 
-def export_package_leg_zip(config_id: str, leg_id: str) -> Tuple[bytes, str]:
-    """
-    Build a zip with the leg GPX track and JSON metadata (label, schema, locations, …).
-
-    Returns (zip_bytes, suggested_download_filename).
-    """
-    cid = validate_config_id(config_id)
-    leg_id = str(leg_id).strip()
-    package_path = resolve_config_package_path(cid)
-    lib_dir = package_segment_library_dir(package_path)
-    manifest = load_package_segment_manifest(cid)
-    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
-    idx = _find_leg_index(legs, leg_id)
-    if idx < 0:
-        raise ValueError(f"Leg not found: {leg_id}")
-    entry = legs[idx]
+def _leg_export_files(
+    cid: str, leg_id: str, entry: Dict[str, Any], lib_dir: Path
+) -> Tuple[bytes, bytes]:
+    """Return (gpx_bytes, json_bytes) for one manifest leg entry."""
     file_name = entry.get("file")
     if not file_name:
         raise ValueError(f"Leg {leg_id} has no GPX file")
@@ -565,15 +553,33 @@ def export_package_leg_zip(config_id: str, leg_id: str) -> Tuple[bytes, str]:
             "locations": row["locations"],
         },
     }
+    json_bytes = (json.dumps(payload, indent=2, ensure_ascii=False) + "\n").encode("utf-8")
+    return gpx_path.read_bytes(), json_bytes
+
+
+def export_package_leg_zip(config_id: str, leg_id: str) -> Tuple[bytes, str]:
+    """
+    Build a zip with the leg GPX track and JSON metadata (label, schema, locations, …).
+
+    Returns (zip_bytes, suggested_download_filename).
+    """
+    cid = validate_config_id(config_id)
+    leg_id = str(leg_id).strip()
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    manifest = load_package_segment_manifest(cid)
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    idx = _find_leg_index(legs, leg_id)
+    if idx < 0:
+        raise ValueError(f"Leg not found: {leg_id}")
+    entry = legs[idx]
+    gpx_bytes, json_bytes = _leg_export_files(cid, leg_id, entry, lib_dir)
     gpx_arcname = f"{leg_id}.gpx"
     json_arcname = f"{leg_id}.json"
     buf = io.BytesIO()
     with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
-        zf.writestr(gpx_arcname, gpx_path.read_bytes())
-        zf.writestr(
-            json_arcname,
-            json.dumps(payload, indent=2, ensure_ascii=False) + "\n",
-        )
+        zf.writestr(gpx_arcname, gpx_bytes)
+        zf.writestr(json_arcname, json_bytes)
         zf.writestr(
             "README.txt",
             (
@@ -585,6 +591,47 @@ def export_package_leg_zip(config_id: str, leg_id: str) -> Tuple[bytes, str]:
             ),
         )
     download_name = f"{cid}_leg_{leg_id}.zip"
+    return buf.getvalue(), download_name
+
+
+def export_all_package_legs_zip(config_id: str) -> Tuple[bytes, str]:
+    """
+    Build a zip with every leg's GPX + JSON export (flat layout for re-import).
+
+    Returns (zip_bytes, suggested_download_filename).
+    """
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    manifest = load_package_segment_manifest(cid)
+    legs: List[Dict[str, Any]] = [
+        entry
+        for entry in (manifest_legs(manifest) or [])
+        if isinstance(entry, dict) and str(entry.get("id", "")).strip()
+    ]
+    if not legs:
+        raise ValueError("No legs to export")
+
+    buf = io.BytesIO()
+    exported_ids: List[str] = []
+    with zipfile.ZipFile(buf, "w", zipfile.ZIP_DEFLATED) as zf:
+        for entry in legs:
+            leg_id = str(entry.get("id", "")).strip()
+            gpx_bytes, json_bytes = _leg_export_files(cid, leg_id, entry, lib_dir)
+            zf.writestr(f"{leg_id}.gpx", gpx_bytes)
+            zf.writestr(f"{leg_id}.json", json_bytes)
+            exported_ids.append(leg_id)
+        zf.writestr(
+            "README.txt",
+            (
+                f"Runflow legs export (v{LEG_EXPORT_VERSION})\n"
+                f"config_id: {cid}\n"
+                f"leg_count: {len(exported_ids)}\n\n"
+                "Each leg is a paired {id}.gpx (route) and {id}.json (metadata + locations).\n"
+                "Re-import via Import legs on the Legs tab.\n"
+            ),
+        )
+    download_name = f"{cid}_legs_export.zip"
     return buf.getvalue(), download_name
 
 

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -40,6 +40,8 @@ from app.core.course.segment_library import (
 )
 from app.core.config_package.segment_recipes import package_recipe_event_ids
 from app.utils.constants import (
+    DEFAULT_FLOW_TYPE,
+    FLOW_TYPE_VALUES,
     LEG_MAP_NO_SNAP_LOCATION_TYPES,
     COURSE_EVENT_IDS,
     LOCATION_PLACEMENT_CHOICES,
@@ -86,6 +88,17 @@ def _normalize_segment_direction(direction: Any) -> str:
     if value not in SEGMENT_DIRECTION_VALUES:
         raise ValueError(f"direction must be one of: {', '.join(SEGMENT_DIRECTION_VALUES)}")
     return value
+
+
+def _normalize_flow_type(flow_type: Any) -> str:
+    value = str(flow_type or DEFAULT_FLOW_TYPE).strip().lower()
+    if value not in FLOW_TYPE_VALUES:
+        raise ValueError(f"flow_type must be one of: {', '.join(FLOW_TYPE_VALUES)}")
+    return value
+
+
+def _normalize_flow_notes(notes: Any) -> str:
+    return str(notes or "").strip()[:500]
 
 
 def _slugify(text: str) -> str:
@@ -190,6 +203,8 @@ def leg_row_from_entry(
         "width_m": entry.get("width_m", 3),
         "schema": entry.get("schema", "on_course_open"),
         "direction": entry.get("direction", "uni"),
+        "flow_type": entry.get("flow_type", DEFAULT_FLOW_TYPE),
+        "flow_notes": (entry.get("flow_notes") or "").strip(),
         "description": (entry.get("description") or "").strip(),
         "locations": locations,
         "location_count": len(locations),
@@ -211,6 +226,8 @@ def create_package_leg(
     width_m: float = 3,
     schema: str = "on_course_open",
     direction: str = "uni",
+    flow_type: str = DEFAULT_FLOW_TYPE,
+    flow_notes: str = "",
     description: str = "",
     locations: Optional[List[Dict[str, Any]]] = None,
     leg_id: Optional[str] = None,
@@ -239,6 +256,8 @@ def create_package_leg(
     e_label = end_label.strip() or _default_endpoint_labels(label, parsed)[1]
     schema = _normalize_segment_schema(schema)
     direction = _normalize_segment_direction(direction)
+    flow_type_norm = _normalize_flow_type(flow_type)
+    flow_notes_norm = _normalize_flow_notes(flow_notes)
 
     entry = {
         "id": new_id,
@@ -249,6 +268,8 @@ def create_package_leg(
         "width_m": width_m,
         "schema": schema,
         "direction": direction,
+        "flow_type": flow_type_norm,
+        "flow_notes": flow_notes_norm,
         "description": (description or "").strip(),
         "locations": _normalize_locations(locations),
     }
@@ -295,6 +316,10 @@ def update_package_leg(
         entry["schema"] = _normalize_segment_schema(fields["schema"])
     if "direction" in fields:
         entry["direction"] = _normalize_segment_direction(fields["direction"])
+    if "flow_type" in fields:
+        entry["flow_type"] = _normalize_flow_type(fields["flow_type"])
+    if "flow_notes" in fields:
+        entry["flow_notes"] = _normalize_flow_notes(fields.get("flow_notes"))
     if "locations" in fields:
         entry["locations"] = _normalize_locations(fields.get("locations"))
 
@@ -405,6 +430,13 @@ def merge_leg_export_into_entry(
             entry["direction"] = _normalize_segment_direction(leg_export["direction"])
         except ValueError:
             pass
+    if "flow_type" in leg_export and leg_export["flow_type"]:
+        try:
+            entry["flow_type"] = _normalize_flow_type(leg_export["flow_type"])
+        except ValueError:
+            pass
+    if "flow_notes" in leg_export:
+        entry["flow_notes"] = _normalize_flow_notes(leg_export.get("flow_notes"))
     if "locations" in leg_export:
         entry["locations"] = _normalize_locations(leg_export.get("locations"))
 
@@ -465,6 +497,8 @@ def export_package_leg_zip(config_id: str, leg_id: str) -> Tuple[bytes, str]:
             "width_m": row["width_m"],
             "schema": row["schema"],
             "direction": row["direction"],
+            "flow_type": row["flow_type"],
+            "flow_notes": row["flow_notes"],
             "description": row["description"],
             "length_km": row["length_km"],
             "gpx_file": str(file_name),

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -97,6 +97,39 @@ def _normalize_flow_type(flow_type: Any) -> str:
     return value
 
 
+def _leg_description(entry: Dict[str, Any]) -> str:
+    """Unified segment description from manifest leg (description preferred over legacy flow_notes)."""
+    return (
+        str(entry.get("description") or entry.get("flow_notes") or "").strip()
+    )
+
+
+def _normalize_leg_description(description: Any) -> str:
+    text = str(description or "").strip()
+    if not text:
+        raise ValueError("description is required")
+    if len(text) > 500:
+        raise ValueError("description must be at most 500 characters")
+    return text
+
+
+def _validate_leg_entry(entry: Dict[str, Any]) -> None:
+    """Fail-fast checks for leg metadata required by the authoring UI and exports."""
+    if not str(entry.get("seg_label") or "").strip():
+        raise ValueError("leg_label is required")
+    if not str(entry.get("start_label") or "").strip():
+        raise ValueError("start_label is required")
+    if not str(entry.get("end_label") or "").strip():
+        raise ValueError("end_label is required")
+    _normalize_leg_description(_leg_description(entry))
+    try:
+        width_m = float(entry.get("width_m", 3))
+    except (TypeError, ValueError) as exc:
+        raise ValueError("width_m must be a positive number") from exc
+    if width_m <= 0:
+        raise ValueError("width_m must be greater than 0")
+
+
 def _normalize_flow_notes(notes: Any) -> str:
     return str(notes or "").strip()[:500]
 
@@ -205,7 +238,7 @@ def leg_row_from_entry(
         "direction": entry.get("direction", "uni"),
         "flow_type": entry.get("flow_type", DEFAULT_FLOW_TYPE),
         "flow_notes": (entry.get("flow_notes") or "").strip(),
-        "description": (entry.get("description") or "").strip(),
+        "description": _leg_description(entry),
         "locations": locations,
         "location_count": len(locations),
         "start_lat": start_lat,
@@ -258,6 +291,9 @@ def create_package_leg(
     direction = _normalize_segment_direction(direction)
     flow_type_norm = _normalize_flow_type(flow_type)
     flow_notes_norm = _normalize_flow_notes(flow_notes)
+    description_norm = _normalize_leg_description(
+        (description or "").strip() or flow_notes_norm
+    )
 
     entry = {
         "id": new_id,
@@ -270,12 +306,17 @@ def create_package_leg(
         "direction": direction,
         "flow_type": flow_type_norm,
         "flow_notes": flow_notes_norm,
-        "description": (description or "").strip(),
+        "description": description_norm,
         "locations": _normalize_locations(locations),
     }
+    _validate_leg_entry(entry)
     legs.append(entry)
     set_manifest_legs(manifest, legs)
     save_package_segment_manifest(cid, manifest)
+    try:
+        sync_leg_metadata_if_applied(cid)
+    except FileNotFoundError:
+        pass
     from app.core.config_package.segment_recipes import get_package_segment_library_state
 
     return get_package_segment_library_state(cid)
@@ -309,9 +350,10 @@ def update_package_leg(
         entry["start_label"] = str(fields.get("start_label") or "").strip()
     if "end_label" in fields:
         entry["end_label"] = str(fields.get("end_label") or "").strip()
-    for key in ("width_m", "description"):
-        if key in fields:
-            entry[key] = fields[key]
+    if "width_m" in fields:
+        entry["width_m"] = fields["width_m"]
+    if "description" in fields:
+        entry["description"] = _normalize_leg_description(fields.get("description"))
     if "schema" in fields:
         entry["schema"] = _normalize_segment_schema(fields["schema"])
     if "direction" in fields:
@@ -337,9 +379,27 @@ def update_package_leg(
         if not entry.get("end_label"):
             entry["end_label"] = _default_endpoint_labels(entry.get("seg_label", ""), parsed)[1]
 
+    authoring_keys = (
+        "leg_label",
+        "seg_label",
+        "start_label",
+        "end_label",
+        "description",
+        "width_m",
+        "schema",
+        "direction",
+        "flow_type",
+        "flow_notes",
+    )
+    if any(key in fields for key in authoring_keys):
+        _validate_leg_entry(entry)
     legs[idx] = entry
     set_manifest_legs(manifest, legs)
     save_package_segment_manifest(cid, manifest)
+    try:
+        sync_leg_metadata_if_applied(cid)
+    except FileNotFoundError:
+        pass
     if "locations" in fields:
         try:
             merge_leg_locations_into_course(cid)
@@ -350,7 +410,7 @@ def update_package_leg(
         for key in ("start_label", "end_label", "leg_label", "seg_label")
     ):
         try:
-            sync_leg_locations_if_applied(cid)
+            merge_leg_locations_into_course(cid)
         except FileNotFoundError:
             pass
     from app.core.config_package.segment_recipes import get_package_segment_library_state
@@ -923,6 +983,70 @@ def merge_leg_locations_into_course(config_id: str) -> None:
     save_config_course(cid, course)
 
 
+def _should_sync_leg_metadata_to_course(
+    course: Dict[str, Any], manifest: Dict[str, Any]
+) -> bool:
+    """
+    True when combined-course segments should track manifest leg metadata.
+
+    Requires segment_library_applied (post-apply) or existing library-linked
+    segments (leg_id / legacy chunk_id on a recipe leg).
+    """
+    if course.get("segment_library_applied"):
+        return True
+    allowed = recipe_leg_ids(manifest)
+    if not allowed:
+        return False
+    for seg in course.get("segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        leg_id = segment_leg_id(seg)
+        if leg_id and leg_id in allowed:
+            return True
+    return False
+
+
+def recipe_leg_ids(manifest: Dict[str, Any]) -> set:
+    """Leg ids assigned to at least one event recipe (non-empty order grid cell)."""
+    ids: set = set()
+    recipes = manifest.get("recipes") or {}
+    for seq in recipes.values():
+        if not isinstance(seq, list):
+            continue
+        for cid in seq:
+            leg_id = str(cid or "").strip()
+            if leg_id:
+                ids.add(leg_id)
+    return ids
+
+
+def prune_course_segments_not_in_recipes(config_id: str) -> bool:
+    """Drop combined-course segments whose leg is not used in any event recipe."""
+    cid = validate_config_id(config_id)
+    course = load_config_course(cid)
+    manifest = load_package_segment_manifest(cid)
+    if not _should_sync_leg_metadata_to_course(course, manifest):
+        return False
+    allowed = recipe_leg_ids(manifest)
+    if not allowed:
+        return False
+    leg_order = _manifest_leg_order(manifest)
+    kept: List[Dict[str, Any]] = []
+    removed = False
+    for seg in course.get("segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        leg_id = _leg_id_for_segment(seg, leg_order)
+        if leg_id and leg_id in allowed:
+            kept.append(seg)
+        else:
+            removed = True
+    if removed:
+        course["segments"] = kept
+        save_config_course(cid, course)
+    return removed
+
+
 def _manifest_leg_order(manifest: Dict[str, Any]) -> List[str]:
     order: List[str] = []
     for entry in manifest_legs(manifest) or []:
@@ -946,17 +1070,19 @@ def _leg_id_for_segment(seg: Dict[str, Any], leg_order: Sequence[str]) -> str:
     return ""
 
 
-def sync_leg_segment_labels_into_course(config_id: str) -> bool:
+def sync_leg_metadata_into_course(config_id: str) -> bool:
     """
-    Refresh segment from/to/label fields from leg library metadata.
+    Refresh combined-course segment fields from segment-library leg metadata.
 
-    Called after leg renames without re-running full recipe export.
+    Matches segments to manifest legs by ``leg_id`` (or ``S{n}`` order fallback).
+    Does not recompute per-event km or recipe order — use ``apply_package_recipes`` for that.
     """
     cid = validate_config_id(config_id)
     course = load_config_course(cid)
-    if not course.get("segment_library_applied"):
-        return False
     manifest = load_package_segment_manifest(cid)
+    if not _should_sync_leg_metadata_to_course(course, manifest):
+        return False
+    allowed_legs = recipe_leg_ids(manifest)
     leg_order = _manifest_leg_order(manifest)
     leg_by_id: Dict[str, Dict[str, Any]] = {}
     for entry in manifest_legs(manifest):
@@ -967,33 +1093,78 @@ def sync_leg_segment_labels_into_course(config_id: str) -> bool:
             leg_by_id[leg_id] = entry
 
     updated = False
+    kept_segments: List[Dict[str, Any]] = []
     for seg in course.get("segments") or []:
         if not isinstance(seg, dict):
             continue
         leg_id = _leg_id_for_segment(seg, leg_order)
-        entry = leg_by_id.get(leg_id) if leg_id else None
-        if not entry:
+        if not leg_id or leg_id not in allowed_legs:
+            updated = True
             continue
-        if leg_id and segment_leg_id(seg) != leg_id:
+        entry = leg_by_id.get(leg_id)
+        if not entry:
+            updated = True
+            continue
+        if leg_id and (
+            str(seg.get("leg_id") or "").strip() != leg_id or seg.get("chunk_id")
+        ):
             set_segment_leg_id(seg, leg_id)
             updated = True
         row = leg_row_from_entry(entry)
-        start = row["start_label"]
-        end = row["end_label"]
-        label = row["leg_label"]
-        if start != str(seg.get("from_label") or "").strip():
-            seg["from_label"] = start
+        if str(seg.get("from_label") or "").strip() != row["start_label"]:
+            seg["from_label"] = row["start_label"]
             updated = True
-        if end != str(seg.get("to_label") or "").strip():
-            seg["to_label"] = end
+        if str(seg.get("to_label") or "").strip() != row["end_label"]:
+            seg["to_label"] = row["end_label"]
             updated = True
-        if label != str(seg.get("seg_label") or "").strip():
-            seg["seg_label"] = label
+        if str(seg.get("seg_label") or "").strip() != row["leg_label"]:
+            seg["seg_label"] = row["leg_label"]
             updated = True
+        if str(seg.get("description") or "").strip() != row["description"]:
+            seg["description"] = row["description"]
+            updated = True
+        if str(seg.get("schema") or "on_course_open").strip() != str(
+            row["schema"] or "on_course_open"
+        ).strip():
+            seg["schema"] = row["schema"]
+            updated = True
+        if str(seg.get("direction") or "uni").strip() != str(
+            row["direction"] or "uni"
+        ).strip():
+            seg["direction"] = row["direction"]
+            updated = True
+        if str(seg.get("flow_type") or DEFAULT_FLOW_TYPE).strip().lower() != str(
+            row["flow_type"] or DEFAULT_FLOW_TYPE
+        ).strip().lower():
+            seg["flow_type"] = row["flow_type"]
+            updated = True
+        try:
+            width_new = float(row["width_m"])
+        except (TypeError, ValueError):
+            width_new = 3.0
+        try:
+            width_old = float(seg.get("width_m", 3))
+        except (TypeError, ValueError):
+            width_old = 3.0
+        if width_old != width_new:
+            seg["width_m"] = width_new
+            updated = True
+        kept_segments.append(seg)
 
     if updated:
+        course["segments"] = kept_segments
         save_config_course(cid, course)
     return updated
+
+
+def sync_leg_segment_labels_into_course(config_id: str) -> bool:
+    """Backward-compatible alias for label + metadata sync from legs."""
+    return sync_leg_metadata_into_course(config_id)
+
+
+def sync_leg_metadata_if_applied(config_id: str) -> bool:
+    """Sync leg library metadata onto course segments when recipes have been applied."""
+    return sync_leg_metadata_into_course(config_id)
 
 
 def sync_leg_location_metadata_from_course(config_id: str) -> bool:
@@ -1083,12 +1254,17 @@ def reconcile_leg_locations_to_course(config_id: str) -> bool:
 
 
 def sync_leg_locations_if_applied(config_id: str) -> bool:
-    """Merge leg placements and labels into course.json when recipes have been applied."""
-    course = load_config_course(config_id)
-    if not course.get("segment_library_applied"):
+    """Merge leg placements and segment metadata into course.json when recipes applied."""
+    cid = validate_config_id(config_id)
+    course = load_config_course(cid)
+    try:
+        manifest = load_package_segment_manifest(cid)
+    except FileNotFoundError:
         return False
-    merge_leg_locations_into_course(config_id)
-    sync_leg_segment_labels_into_course(config_id)
+    if not _should_sync_leg_metadata_to_course(course, manifest):
+        return False
+    merge_leg_locations_into_course(cid)
+    sync_leg_metadata_into_course(cid)
     return True
 
 

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -26,6 +26,7 @@ from app.core.config_package.storage import (
     save_config_course,
     validate_config_id,
 )
+from app.core.course.flow_csv import validate_flow_csv_text
 from app.core.course.segment_library import (
     build_course_segments_from_library,
     build_event_gpx_content,
@@ -419,8 +420,14 @@ def export_package_flow_and_gpx_files(config_id: str) -> Dict[str, Any]:
 
     if manifest_path.is_file():
         bundle = export_library_to_course(lib_dir, manifest_path, event_ids=event_ids)
+        flow_csv = bundle["flow_csv"]
+        flow_validation = validate_flow_csv_text(flow_csv)
+        if not flow_validation.ok:
+            raise ValueError(
+                "flow.csv export failed validation: " + "; ".join(flow_validation.errors)
+            )
         flow_backup = _backup_export_file(flow_path)
-        flow_path.write_text(bundle["flow_csv"], encoding="utf-8")
+        flow_path.write_text(flow_csv, encoding="utf-8")
 
         manifest = bundle["manifest"]
         legs_by_id = load_leg_library(lib_dir, manifest)
@@ -450,6 +457,11 @@ def export_package_flow_and_gpx_files(config_id: str) -> Dict[str, Any]:
             event_ids,
             overrides=flow_overrides,
         )
+        flow_validation = validate_flow_csv_text(flow_csv)
+        if not flow_validation.ok:
+            raise ValueError(
+                "flow.csv export failed validation: " + "; ".join(flow_validation.errors)
+            )
         flow_backup = _backup_export_file(flow_path)
         flow_path.write_text(flow_csv, encoding="utf-8")
     else:

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -721,6 +721,9 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
     """
     cid = validate_config_id(config_id)
     package_path = resolve_config_package_path(cid)
+    from app.core.config_package.legs import sync_leg_metadata_into_course
+
+    sync_leg_metadata_into_course(cid)
     course = load_config_course(cid)
     segments = course.get("segments") or []
     if not segments:

--- a/app/core/course/flow_csv.py
+++ b/app/core/course/flow_csv.py
@@ -1,0 +1,395 @@
+"""
+Flow.csv authoring, conservative export, and validation.
+
+Issue #759: Generate a conservative first draft (cross-event pairs only) with
+unique flow_id per row. Same-event and out-and-back rows come from overrides
+or future pass metadata — not Cartesian auto-generation.
+"""
+
+from __future__ import annotations
+
+import csv
+import io
+import re
+from dataclasses import dataclass, field
+from itertools import combinations
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from app.utils.constants import COURSE_EVENT_IDS
+
+FLOW_CSV_COLUMNS = [
+    "flow_id",
+    "seg_id",
+    "seg_label",
+    "event_a",
+    "event_b",
+    "from_km_a",
+    "to_km_a",
+    "from_km_b",
+    "to_km_b",
+    "flow_type",
+    "direction",
+    "notes",
+]
+
+VALID_FLOW_TYPES = frozenset({"overtake", "merge", "counterflow", "none"})
+VALID_DIRECTIONS = frozenset({"uni", "bi"})
+_KM_TOL = 1e-6
+_FLOW_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+@dataclass
+class FlowValidationResult:
+    errors: List[str] = field(default_factory=list)
+    warnings: List[str] = field(default_factory=list)
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def _norm_event(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _km_ranges_identical(
+    from_a: float, to_a: float, from_b: float, to_b: float, *, tol: float = _KM_TOL
+) -> bool:
+    return abs(from_a - from_b) <= tol and abs(to_a - to_b) <= tol
+
+
+def default_flow_id(seg_id: str, event_a: str, event_b: str) -> str:
+    """Stable default flow_id for cross-event auto-generated rows."""
+    return f"{seg_id}_{event_a}_{event_b}"
+
+
+def flow_output_id(row: Dict[str, Any]) -> str:
+    """Per-minute CSV basename identity (without _per_minute.csv suffix)."""
+    fid = str(row.get("flow_id") or "").strip()
+    if fid:
+        return fid
+    return str(row.get("seg_id") or "").strip()
+
+
+def _sanitize_flow_id(value: str) -> str:
+    text = str(value or "").strip()
+    if not text or not _FLOW_ID_RE.match(text):
+        raise ValueError(f"Invalid flow_id: {value!r}")
+    return text
+
+
+def _segment_active_events(seg: Dict[str, Any], event_ids: Sequence[str]) -> List[str]:
+    active: List[str] = []
+    events_list = seg.get("events") or []
+    for eid in event_ids:
+        eid = eid.lower()
+        if eid in events_list:
+            active.append(eid)
+        elif str(seg.get(eid, "n")).lower() == "y":
+            active.append(eid)
+    return active
+
+
+def _segment_km_window(seg: Dict[str, Any], event_id: str) -> Tuple[float, float]:
+    from_km = float(seg.get(f"{event_id}_from_km") or 0)
+    to_km = float(seg.get(f"{event_id}_to_km") or 0)
+    return from_km, to_km
+
+
+def _normalize_override(override: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    if not isinstance(override, dict):
+        return None
+    seg_id = str(override.get("seg_id") or "").strip()
+    event_a = _norm_event(override.get("event_a"))
+    event_b = _norm_event(override.get("event_b"))
+    if not seg_id or not event_a or not event_b:
+        return None
+    return {
+        "seg_id": seg_id,
+        "event_a": event_a,
+        "event_b": event_b,
+        "from_km_a": override.get("from_km_a"),
+        "to_km_a": override.get("to_km_a"),
+        "from_km_b": override.get("from_km_b"),
+        "to_km_b": override.get("to_km_b"),
+        "flow_type": override.get("flow_type"),
+        "direction": override.get("direction"),
+        "notes": override.get("notes"),
+        "flow_id": override.get("flow_id"),
+        "seg_label": override.get("seg_label"),
+        "auto_generated": False,
+    }
+
+
+def build_flow_csv_from_segments(
+    segments: Sequence[Dict[str, Any]],
+    event_ids: Optional[Sequence[str]] = None,
+    *,
+    overrides: Optional[Sequence[Dict[str, Any]]] = None,
+    include_same_event_pairs: bool = False,
+) -> str:
+    """
+    Generate a conservative flow.csv from combined-course segment rows.
+
+    Default: cross-event pairs only (full/half, full/10k, half/10k).
+    Same-event rows are omitted unless ``include_same_event_pairs`` is True
+    (legacy) or supplied via ``overrides`` with distinct km windows.
+    """
+    event_ids = [e.lower() for e in (event_ids or COURSE_EVENT_IDS)]
+    segment_by_id = {
+        str(seg.get("seg_id", "")).strip(): seg
+        for seg in segments
+        if str(seg.get("seg_id", "")).strip()
+    }
+
+    emitted_keys: set = set()
+    rows: List[Dict[str, Any]] = []
+
+    def append_row(row: Dict[str, Any]) -> None:
+        key = (
+            str(row.get("flow_id") or ""),
+            str(row.get("seg_id") or ""),
+            _norm_event(row.get("event_a")),
+            _norm_event(row.get("event_b")),
+        )
+        if key in emitted_keys:
+            return
+        emitted_keys.add(key)
+        rows.append(row)
+
+    for raw_ov in overrides or []:
+        ov = _normalize_override(raw_ov)
+        if not ov:
+            continue
+        seg = segment_by_id.get(ov["seg_id"])
+        if not seg:
+            continue
+        from_a, to_a = (
+            (float(ov["from_km_a"]), float(ov["to_km_a"]))
+            if ov["from_km_a"] is not None and ov["to_km_a"] is not None
+            else _segment_km_window(seg, ov["event_a"])
+        )
+        from_b, to_b = (
+            (float(ov["from_km_b"]), float(ov["to_km_b"]))
+            if ov["from_km_b"] is not None and ov["to_km_b"] is not None
+            else _segment_km_window(seg, ov["event_b"])
+        )
+        if to_a <= from_a and to_b <= from_b:
+            continue
+        if (
+            ov["event_a"] == ov["event_b"]
+            and _km_ranges_identical(from_a, to_a, from_b, to_b)
+        ):
+            continue
+        flow_id = str(ov.get("flow_id") or "").strip() or default_flow_id(
+            ov["seg_id"], ov["event_a"], ov["event_b"]
+        )
+        append_row(
+            {
+                "flow_id": flow_id,
+                "seg_id": ov["seg_id"],
+                "seg_label": str(ov.get("seg_label") or seg.get("seg_label") or "").strip(),
+                "event_a": ov["event_a"],
+                "event_b": ov["event_b"],
+                "from_km_a": from_a,
+                "to_km_a": to_a,
+                "from_km_b": from_b,
+                "to_km_b": to_b,
+                "flow_type": str(
+                    ov.get("flow_type") or seg.get("flow_type") or "overtake"
+                ).strip().lower(),
+                "direction": str(
+                    ov.get("direction") or seg.get("direction") or "uni"
+                ).strip().lower(),
+                "notes": str(ov.get("notes") or "").strip()
+                or str(seg.get("description") or "").strip()
+                or str(seg.get("flow_notes") or "").strip(),
+                "auto_generated": False,
+            }
+        )
+
+    override_pair_keys = {
+        (r["seg_id"], r["event_a"], r["event_b"]) for r in rows
+    }
+
+    for seg in segments:
+        seg_id = str(seg.get("seg_id", "")).strip()
+        if not seg_id:
+            continue
+        seg_label = str(seg.get("seg_label", "")).strip()
+        direction = str(seg.get("direction") or "uni").strip().lower()
+        active = _segment_active_events(seg, event_ids)
+        if len(active) < 2 and not include_same_event_pairs:
+            continue
+
+        pair_list: List[Tuple[str, str]] = []
+        if include_same_event_pairs:
+            pair_list = [(a, b) for a, b in combinations(active, 2)]
+            for e in active:
+                pair_list.append((e, e))
+        else:
+            pair_list = [(a, b) for a, b in combinations(active, 2)]
+
+        for event_a, event_b in pair_list:
+            if (seg_id, event_a, event_b) in override_pair_keys:
+                continue
+            from_a, to_a = _segment_km_window(seg, event_a)
+            from_b, to_b = _segment_km_window(seg, event_b)
+            if to_a <= from_a and to_b <= from_b:
+                continue
+            if event_a == event_b:
+                if not include_same_event_pairs:
+                    continue
+                if _km_ranges_identical(from_a, to_a, from_b, to_b):
+                    continue
+            append_row(
+                {
+                    "flow_id": default_flow_id(seg_id, event_a, event_b),
+                    "seg_id": seg_id,
+                    "seg_label": seg_label,
+                    "event_a": event_a,
+                    "event_b": event_b,
+                    "from_km_a": from_a,
+                    "to_km_a": to_a,
+                    "from_km_b": from_b,
+                    "to_km_b": to_b,
+                    "flow_type": str(seg.get("flow_type") or "overtake").strip().lower(),
+                    "direction": direction,
+                    "notes": str(seg.get("description") or "").strip()
+                    or str(seg.get("flow_notes") or "").strip(),
+                    "auto_generated": True,
+                }
+            )
+
+    out = io.StringIO()
+    writer = csv.writer(out)
+    writer.writerow(FLOW_CSV_COLUMNS)
+    for row in rows:
+        writer.writerow([row.get(col, "") for col in FLOW_CSV_COLUMNS])
+    return out.getvalue()
+
+
+def validate_flow_csv(
+    rows: Sequence[Dict[str, Any]],
+    *,
+    strict_auto_same_event: bool = True,
+) -> FlowValidationResult:
+    """
+    Validate flow.csv rows.
+
+    Hard errors block export/analysis prep; warnings flag authoring gaps.
+    """
+    result = FlowValidationResult()
+    seen_flow_ids: Dict[str, int] = {}
+    bi_output_ids: Dict[str, List[int]] = {}
+
+    for idx, raw in enumerate(rows):
+        row_num = idx + 2  # header + 1-based
+        if not isinstance(raw, dict):
+            result.errors.append(f"Row {row_num}: must be an object")
+            continue
+
+        seg_id = str(raw.get("seg_id") or "").strip()
+        event_a = _norm_event(raw.get("event_a"))
+        event_b = _norm_event(raw.get("event_b"))
+        flow_id = str(raw.get("flow_id") or "").strip() or (
+            default_flow_id(seg_id, event_a, event_b) if seg_id else ""
+        )
+        flow_type = str(raw.get("flow_type") or "").strip().lower()
+        direction = str(raw.get("direction") or "").strip().lower()
+        auto_generated = bool(raw.get("auto_generated"))
+
+        if not seg_id:
+            result.errors.append(f"Row {row_num}: seg_id is required")
+        if not event_a or not event_b:
+            result.errors.append(f"Row {row_num}: event_a and event_b are required")
+        if flow_type not in VALID_FLOW_TYPES:
+            result.errors.append(
+                f"Row {row_num}: flow_type must be one of {sorted(VALID_FLOW_TYPES)}"
+            )
+        if direction not in VALID_DIRECTIONS:
+            result.errors.append(
+                f"Row {row_num}: direction must be one of {sorted(VALID_DIRECTIONS)}"
+            )
+        if flow_id:
+            if not _FLOW_ID_RE.match(flow_id):
+                result.errors.append(f"Row {row_num}: invalid flow_id {flow_id!r}")
+            seen_flow_ids[flow_id] = seen_flow_ids.get(flow_id, 0) + 1
+
+        try:
+            from_a = float(raw.get("from_km_a"))
+            to_a = float(raw.get("to_km_a"))
+            from_b = float(raw.get("from_km_b"))
+            to_b = float(raw.get("to_km_b"))
+        except (TypeError, ValueError):
+            result.errors.append(f"Row {row_num}: km columns must be numeric")
+            continue
+
+        same_event = event_a == event_b
+        identical_km = _km_ranges_identical(from_a, to_a, from_b, to_b)
+        notes = str(raw.get("notes") or "").strip()
+
+        if (
+            strict_auto_same_event
+            and auto_generated
+            and same_event
+            and identical_km
+        ):
+            result.errors.append(
+                f"Row {row_num} ({flow_id}): auto-generated same-event row with "
+                "identical A/B km windows is not allowed"
+            )
+        elif same_event and identical_km and not notes:
+            result.warnings.append(
+                f"Row {row_num} ({flow_id}): same-event row with identical km "
+                "windows should include notes explaining the interaction or be removed"
+            )
+
+        if direction == "bi" and identical_km:
+            result.warnings.append(
+                f"Row {row_num} ({flow_id}): direction=bi but A/B km windows are "
+                "identical — confirm outbound/return split or override km ranges"
+            )
+
+        if same_event and direction == "bi" and identical_km:
+            result.warnings.append(
+                f"Row {row_num} ({flow_id}): same-event bidirectional segment "
+                "without distinct outbound/return km windows"
+            )
+
+        if flow_type == "counterflow" and direction == "uni":
+            result.warnings.append(
+                f"Row {row_num} ({flow_id}): flow_type=counterflow with direction=uni "
+                "(allowed, but verify intent)"
+            )
+
+        if same_event and not notes:
+            result.warnings.append(
+                f"Row {row_num} ({flow_id}): same-event row has blank notes"
+            )
+
+        if direction == "bi":
+            bi_output_ids.setdefault(flow_output_id(raw), []).append(row_num)
+
+    for fid, count in seen_flow_ids.items():
+        if count > 1:
+            result.errors.append(f"Duplicate flow_id: {fid} ({count} rows)")
+
+    for output_id, row_nums in bi_output_ids.items():
+        if len(row_nums) > 1:
+            result.errors.append(
+                f"Multiple direction=bi rows share output id {output_id!r} "
+                f"(rows {row_nums}); use unique flow_id values"
+            )
+
+    return result
+
+
+def parse_flow_csv_text(csv_text: str) -> List[Dict[str, Any]]:
+    """Parse flow.csv text into row dicts (all string values preserved)."""
+    reader = csv.DictReader(io.StringIO(csv_text))
+    return [dict(row) for row in reader]
+
+
+def validate_flow_csv_text(csv_text: str, **kwargs: Any) -> FlowValidationResult:
+    return validate_flow_csv(parse_flow_csv_text(csv_text), **kwargs)

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -18,7 +18,7 @@ from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import yaml
 
-from app.core.course.export import build_segments_csv, enrich_segments_event_distances
+from app.core.course.export import build_segments_csv
 from app.core.course.flow_csv import build_flow_csv_from_segments
 from app.core.gpx.processor import parse_gpx_file
 from app.utils.constants import COURSE_EVENT_IDS
@@ -200,6 +200,29 @@ def _events_for_leg(
     return out
 
 
+def _recipe_leg_order(
+    manifest: Dict[str, Any],
+    legs_by_id: Dict[str, Dict[str, Any]],
+    event_ids: Sequence[str],
+    recipes: Dict[str, Any],
+) -> List[str]:
+    """Leg ids in recipe traversal order (union across events, first-seen wins)."""
+    ordered: List[str] = []
+    seen: set[str] = set()
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        for raw_id in recipes.get(key) or []:
+            cid = str(raw_id).strip()
+            if not cid or cid in seen or cid not in legs_by_id:
+                continue
+            events = _events_for_leg(cid, recipes, event_ids)
+            if not events:
+                continue
+            seen.add(cid)
+            ordered.append(cid)
+    return ordered
+
+
 def build_course_segments_from_library(
     manifest: Dict[str, Any],
     legs_by_id: Dict[str, Dict[str, Any]],
@@ -227,13 +250,16 @@ def build_course_segments_from_library(
             cum += float(ch["length_km"])
             event_cum_at_leg[eid.lower()][cid] = round(cum, 2)
 
+    entries_by_id: Dict[str, Dict[str, Any]] = {
+        str(entry.get("id", "")).strip(): entry
+        for entry in manifest_legs(manifest)
+        if isinstance(entry, dict) and entry.get("id")
+    }
+
     segments: List[Dict[str, Any]] = []
-    leg_order = manifest_legs(manifest)
     segment_index = 0
-    for entry in leg_order:
-        if not isinstance(entry, dict):
-            continue
-        cid = str(entry.get("id", "")).strip()
+    for cid in _recipe_leg_order(manifest, legs_by_id, event_ids, recipes):
+        entry = entries_by_id.get(cid) or {}
         ch = legs_by_id.get(cid)
         if not ch:
             continue
@@ -274,7 +300,6 @@ def build_course_segments_from_library(
             seg[f"{el}_to_km"] = to_km
         segments.append(seg)
 
-    enrich_segments_event_distances(segments, event_ids)
     return segments
 
 

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -13,13 +13,13 @@ from __future__ import annotations
 import csv
 import io
 import math
-from itertools import combinations
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 import yaml
 
 from app.core.course.export import build_segments_csv, enrich_segments_event_distances
+from app.core.course.flow_csv import build_flow_csv_from_segments
 from app.core.gpx.processor import parse_gpx_file
 from app.utils.constants import COURSE_EVENT_IDS
 
@@ -276,96 +276,6 @@ def build_course_segments_from_library(
 
     enrich_segments_event_distances(segments, event_ids)
     return segments
-
-
-def build_flow_csv_from_segments(
-    segments: Sequence[Dict[str, Any]],
-    event_ids: Optional[Sequence[str]] = None,
-    *,
-    overrides: Optional[Sequence[Dict[str, Any]]] = None,
-    include_same_event_pairs: bool = True,
-) -> str:
-    """
-    Generate 2026-style flow.csv from multi-event segment rows.
-
-    For each segment used by 2+ events, emit one row per event pair (A,B) with
-    from_km_a/to_km_a and from_km_b/to_km_b from segment per-event columns.
-    """
-    event_ids = [e.lower() for e in (event_ids or COURSE_EVENT_IDS)]
-    override_index = {
-        (str(o.get("seg_id", "")), str(o.get("event_a", "")), str(o.get("event_b", ""))): o
-        for o in (overrides or [])
-        if isinstance(o, dict)
-    }
-
-    out = io.StringIO()
-    w = csv.writer(out)
-    w.writerow(
-        [
-            "seg_id",
-            "seg_label",
-            "event_a",
-            "event_b",
-            "from_km_a",
-            "to_km_a",
-            "from_km_b",
-            "to_km_b",
-            "flow_type",
-            "direction",
-            "notes",
-        ]
-    )
-
-    for seg in segments:
-        seg_id = str(seg.get("seg_id", "")).strip()
-        seg_label = str(seg.get("seg_label", "")).strip()
-        direction = seg.get("direction", "uni")
-        active = []
-        for eid in event_ids:
-            if eid in (seg.get("events") or []):
-                active.append(eid)
-            elif str(seg.get(eid, "n")).lower() == "y":
-                active.append(eid)
-        if len(active) < 2 and not include_same_event_pairs:
-            continue
-        pairs: List[Tuple[str, str]] = []
-        if include_same_event_pairs:
-            pairs = [(a, b) for a, b in combinations(active, 2)]
-            for e in active:
-                pairs.append((e, e))
-        else:
-            pairs = [(a, b) for a, b in combinations(active, 2)]
-        for event_a, event_b in pairs:
-            from_a = float(seg.get(f"{event_a}_from_km") or 0)
-            to_a = float(seg.get(f"{event_a}_to_km") or 0)
-            from_b = float(seg.get(f"{event_b}_from_km") or 0)
-            to_b = float(seg.get(f"{event_b}_to_km") or 0)
-            if to_a <= from_a and to_b <= from_b:
-                continue
-            key = (seg_id, event_a, event_b)
-            ov = override_index.get(key, {})
-            flow_type = ov.get("flow_type") or seg.get("flow_type") or "overtake"
-            notes = (
-                ov.get("notes")
-                or str(seg.get("description") or "").strip()
-                or str(seg.get("flow_notes") or "").strip()
-            )
-            w.writerow(
-                [
-                    seg_id,
-                    seg_label,
-                    event_a,
-                    event_b,
-                    from_a,
-                    to_a,
-                    from_b,
-                    to_b,
-                    flow_type,
-                    direction,
-                    notes,
-                ]
-            )
-    return out.getvalue()
 
 
 def export_library_to_course(

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -237,9 +237,14 @@ def build_course_segments_from_library(
         ch = legs_by_id.get(cid)
         if not ch:
             continue
+        events = _events_for_leg(cid, recipes, event_ids)
+        if not events:
+            continue
         segment_index += 1
         length_km = float(ch["length_km"])
-        events = _events_for_leg(cid, recipes, event_ids)
+        leg_description = (
+            str(entry.get("description") or entry.get("flow_notes") or "").strip()
+        )
         seg: Dict[str, Any] = {
             "seg_id": f"S{segment_index}",
             "seg_label": (entry.get("seg_label") or ch.get("name") or cid).strip(),
@@ -249,8 +254,8 @@ def build_course_segments_from_library(
             "schema": entry.get("schema", "on_course_open"),
             "direction": entry.get("direction", "uni"),
             "flow_type": (entry.get("flow_type") or "none").strip().lower(),
-            "flow_notes": (entry.get("flow_notes") or "").strip(),
-            "description": (entry.get("description") or "").strip(),
+            "flow_notes": leg_description,
+            "description": leg_description,
             "events": events,
             "leg_id": cid,
             "length_km": length_km,
@@ -340,7 +345,11 @@ def build_flow_csv_from_segments(
             key = (seg_id, event_a, event_b)
             ov = override_index.get(key, {})
             flow_type = ov.get("flow_type") or seg.get("flow_type") or "overtake"
-            notes = ov.get("notes") or seg.get("flow_notes") or ""
+            notes = (
+                ov.get("notes")
+                or str(seg.get("description") or "").strip()
+                or str(seg.get("flow_notes") or "").strip()
+            )
             w.writerow(
                 [
                     seg_id,

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -248,6 +248,8 @@ def build_course_segments_from_library(
             "width_m": entry.get("width_m", 3),
             "schema": entry.get("schema", "on_course_open"),
             "direction": entry.get("direction", "uni"),
+            "flow_type": (entry.get("flow_type") or "none").strip().lower(),
+            "flow_notes": (entry.get("flow_notes") or "").strip(),
             "description": (entry.get("description") or "").strip(),
             "events": events,
             "leg_id": cid,

--- a/app/core/v2/overlaps.py
+++ b/app/core/v2/overlaps.py
@@ -17,6 +17,7 @@ import math
 import numpy as np
 import pandas as pd
 
+from app.core.course.flow_csv import flow_output_id, validate_flow_csv
 from app.core.v2.models import Day, Event
 from app.utils.constants import (
     REPORTS_OVERLAPS_DIRNAME,
@@ -28,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class OverlapSummary:
+    flow_id: str
     seg_id: str
     seg_label: str
     event_a: str
@@ -113,9 +115,7 @@ def _minute_series(
 
 def _write_overlap_csv(
     output_dir: Path,
-    seg_id: str,
-    event_a: str,
-    event_b: str,
+    output_id: str,
     event_a_label: str,
     event_b_label: str,
     minute_starts: List[float],
@@ -123,7 +123,7 @@ def _write_overlap_csv(
     metrics_b: List[Dict[str, int]],
 ) -> str:
     output_dir.mkdir(parents=True, exist_ok=True)
-    csv_filename = f"{seg_id}_per_minute.csv"
+    csv_filename = f"{output_id}_per_minute.csv"
     csv_path = output_dir / csv_filename
 
     headers = [
@@ -193,6 +193,30 @@ def generate_bidirectional_overlap_reports(
         & (flow_df["direction_norm"] == "bi")
     ].copy()
 
+    bi_rows = [
+        {
+            "flow_id": str(row.get("flow_id") or "").strip(),
+            "seg_id": str(row.get("seg_id") or "").strip(),
+            "event_a": str(row.get("event_a_norm") or ""),
+            "event_b": str(row.get("event_b_norm") or ""),
+            "direction": "bi",
+            "from_km_a": row.get("from_km_a"),
+            "to_km_a": row.get("to_km_a"),
+            "from_km_b": row.get("from_km_b"),
+            "to_km_b": row.get("to_km_b"),
+            "flow_type": row.get("flow_type"),
+            "notes": row.get("notes"),
+            "auto_generated": False,
+        }
+        for _, row in eligible.iterrows()
+    ]
+    validation = validate_flow_csv(bi_rows, strict_auto_same_event=False)
+    if not validation.ok:
+        raise ValueError(
+            "Invalid bidirectional flow.csv rows for overlap reports: "
+            + "; ".join(validation.errors)
+        )
+
     analyzed_count = int(len(eligible))
     overlap_count = 0
     summaries: List[OverlapSummary] = []
@@ -201,9 +225,18 @@ def generate_bidirectional_overlap_reports(
     overlaps_dir = reports_dir / REPORTS_OVERLAPS_DIRNAME
 
     for _, row in eligible.iterrows():
+        flow_id = str(row.get("flow_id") or "").strip()
         seg_id = str(row["seg_id"])
         event_a = str(row["event_a_norm"])
         event_b = str(row["event_b_norm"])
+        output_id = flow_output_id(
+            {
+                "flow_id": flow_id,
+                "seg_id": seg_id,
+                "event_a": event_a,
+                "event_b": event_b,
+            }
+        )
         event_a_label = event_a
         event_b_label = event_b
         if event_a == event_b:
@@ -242,9 +275,7 @@ def generate_bidirectional_overlap_reports(
 
         csv_filename = _write_overlap_csv(
             overlaps_dir,
-            seg_id,
-            event_a,
-            event_b,
+            output_id,
             event_a_label,
             event_b_label,
             minute_starts,
@@ -260,6 +291,7 @@ def generate_bidirectional_overlap_reports(
 
         summaries.append(
             OverlapSummary(
+                flow_id=output_id,
                 seg_id=seg_id,
                 seg_label=seg_label,
                 event_a=event_a,

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -101,6 +101,8 @@ class UpdateLegRequest(BaseModel):
     width_m: Optional[float] = None
     schema: Optional[str] = None
     direction: Optional[str] = None
+    flow_type: Optional[str] = None
+    flow_notes: Optional[str] = None
     description: Optional[str] = None
     locations: Optional[List[Dict[str, Any]]] = None
 
@@ -330,6 +332,8 @@ async def api_create_package_leg(
     width_m: float = Form(3.0),
     schema: str = Form("on_course_open"),
     direction: str = Form("uni"),
+    flow_type: str = Form("none"),
+    flow_notes: str = Form(""),
     description: str = Form(""),
 ) -> JSONResponse:
     """Create a course leg from an uploaded GPX file."""
@@ -348,6 +352,8 @@ async def api_create_package_leg(
             width_m=width_m,
             schema=schema,
             direction=direction,
+            flow_type=flow_type,
+            flow_notes=flow_notes,
             description=description,
         )
         return JSONResponse(content={"ok": True, **state})

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -30,6 +30,7 @@ from app.core.config_package import (
 from app.core.config_package.legs import (
     create_package_leg,
     delete_package_leg,
+    export_all_package_legs_zip,
     export_package_leg_zip,
     get_leg_line_geojson,
     reconcile_leg_locations_to_course,
@@ -379,6 +380,26 @@ async def api_update_package_leg_geometry(
     try:
         state = update_package_leg_geometry(config_id, leg_id, body.coordinates)
         return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/api/config/packages/{config_id}/segment-library/export-legs")
+async def api_export_all_package_legs(
+    request: Request,
+    config_id: str,
+) -> Response:
+    """Download a zip with every leg GPX track and JSON metadata."""
+    require_auth(request)
+    try:
+        zip_bytes, filename = export_all_package_legs_zip(config_id)
+        return Response(
+            content=zip_bytes,
+            media_type="application/zip",
+            headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+        )
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ValueError as e:

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -34,6 +34,7 @@ from app.core.config_package.legs import (
     get_leg_line_geojson,
     reconcile_leg_locations_to_course,
     remove_leg_location_from_manifest,
+    sync_leg_metadata_into_course,
     sync_leg_locations_if_applied,
     update_package_leg,
     update_package_leg_geometry,
@@ -265,6 +266,7 @@ async def api_load_config_course(
     require_auth(request)
     try:
         reconcile_leg_locations_to_course(config_id)
+        sync_leg_metadata_into_course(config_id)
         course = load_config_course(config_id)
         return JSONResponse(
             content={"ok": True, "config_id": config_id, "course": course}
@@ -284,11 +286,13 @@ async def api_save_config_course(
     """Save course.json for a config package (validated workspace schema)."""
     require_auth(request)
     try:
-        save_config_course(config_id, body.course)
         from app.core.config_package.legs import sync_leg_location_metadata_from_course
 
+        save_config_course(config_id, body.course)
+        sync_leg_metadata_into_course(config_id)
         sync_leg_location_metadata_from_course(config_id)
         reconcile_leg_locations_to_course(config_id)
+        sync_leg_metadata_into_course(config_id)
         course = load_config_course(config_id)
         return JSONResponse(
             content={"ok": True, "config_id": config_id, "course": course}

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -21,6 +21,7 @@ from app.common.config import load_reporting
 from app.utils.constants import (
     COURSE_EVENT_IDS,
     DAY_SHORT_CODES,
+    FLOW_TYPE_CHOICES,
     LOCATION_TYPE_CHOICES,
     LEG_MAP_NO_SNAP_LOCATION_TYPES,
     OFF_COURSE_LOCATION_TYPES,
@@ -395,6 +396,7 @@ async def course_mapping(request: Request):
     event_choices = [{"value": e, "label": e.upper() if e == "10k" else e.capitalize()} for e in COURSE_EVENT_IDS]
     segment_schema_choices = list(SEGMENT_SCHEMA_CHOICES)
     segment_direction_choices = list(SEGMENT_DIRECTION_CHOICES)
+    flow_type_choices = list(FLOW_TYPE_CHOICES)
     return templates.TemplateResponse(
         request=request,
         name="pages/course_mapping.html",
@@ -405,6 +407,7 @@ async def course_mapping(request: Request):
             "event_choices": event_choices,
             "segment_schema_choices": segment_schema_choices,
             "segment_direction_choices": segment_direction_choices,
+            "flow_type_choices": flow_type_choices,
             "day_short_codes": DAY_SHORT_CODES,
             "off_course_location_types": list(OFF_COURSE_LOCATION_TYPES),
         },
@@ -524,6 +527,7 @@ async def race_configuration_page(request: Request):
     ]
     segment_schema_choices = list(SEGMENT_SCHEMA_CHOICES)
     segment_direction_choices = list(SEGMENT_DIRECTION_CHOICES)
+    flow_type_choices = list(FLOW_TYPE_CHOICES)
     return templates.TemplateResponse(
         request=request,
         name="pages/race_configuration.html",
@@ -534,6 +538,7 @@ async def race_configuration_page(request: Request):
             "event_choices": event_choices,
             "segment_schema_choices": segment_schema_choices,
             "segment_direction_choices": segment_direction_choices,
+            "flow_type_choices": flow_type_choices,
             "day_short_codes": DAY_SHORT_CODES,
             "off_course_location_types": list(OFF_COURSE_LOCATION_TYPES),
             "leg_map_no_snap_location_types": list(LEG_MAP_NO_SNAP_LOCATION_TYPES),

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -152,6 +152,16 @@ DEFAULT_SEGMENT_WIDTH_M = 5.0
 DEFAULT_FLOW_TYPE = "none"
 DEFAULT_ZONE = "green"
 
+# Flow types for legs / flow.csv (Issue #759; must match preflight flow.csv validation)
+FLOW_TYPE_CHOICES = [
+    {"value": "overtake", "label": "Overtake"},
+    {"value": "merge", "label": "Merge"},
+    {"value": "counterflow", "label": "Counterflow"},
+    {"value": "parallel", "label": "Parallel"},
+    {"value": "none", "label": "None"},
+]
+FLOW_TYPE_VALUES = [c["value"] for c in FLOW_TYPE_CHOICES]
+
 # Map density thresholds for zone determination (frontend)
 MAP_DENSITY_THRESHOLDS = {
     "green": 0.36,

--- a/docs/dev-guides/segment-library-2027.md
+++ b/docs/dev-guides/segment-library-2027.md
@@ -62,10 +62,11 @@ Density (`get_shared_segments`, bins) uses these flags — **shared segments mus
 
 For each segment row where **2+ events** are active:
 
-- Emit rows for event pairs `(A, B)` (and same-event pairs where needed, e.g. 10k/10k on B3-style legs).
-- `from_km_a` / `to_km_a` = segment’s `{event_a}_from_km` / `{event_a}_to_km`.
-- `from_km_b` / `to_km_b` = same for event B.
-- Default `flow_type`: `overtake`; overrides in manifest `flow_overrides` or future UI.
+- Emit **cross-event** pairs only (`full/half`, `full/10k`, `half/10k`) with a unique `flow_id` per row.
+- Same-event rows (out/back, lap, slow/fast) come from manifest `flow_overrides` when A/B km windows differ.
+- Do **not** auto-generate `event_a == event_b` rows when A/B km ranges are identical.
+- `from_km_a` / `to_km_a` = segment’s `{event_a}_from_km` / `{event_a}_to_km`; same for event B.
+- Default `flow_type`: `overtake`; `none` supported via overrides. Bidirectional per-minute CSVs use `flow_id`.
 
 **Not** the old stub in `build_flow_csv()` (one row per segment, same event A/B).
 

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -168,6 +168,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (!data) return;
                 if (data.ok && data.course) {
                     setCourse(pkgId, data.course, options);
+                    enrichCourseSegmentsFromLegLibrary();
                     if (window.PENDING_PACKAGE_META) {
                         var pending = window.PENDING_PACKAGE_META;
                         syncCourseHeaderFromPackageMeta(
@@ -667,6 +668,35 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!usePackageLevelEditSave()) return false;
         var legsPanel = document.getElementById('config-package-legs-panel');
         return !!(legsPanel && legsPanel.style.display !== 'none');
+    }
+
+    function legMetadataForSegment(seg, segIdx) {
+        if (
+            !usePackageLevelEditSave() ||
+            !window.segmentRecipes ||
+            !window.segmentRecipes.resolveLegLabelsForSegment
+        ) {
+            return null;
+        }
+        return window.segmentRecipes.resolveLegLabelsForSegment(seg, segIdx);
+    }
+
+    /** Fill empty combined-course segment descriptions from manifest legs (Legs tab). */
+    function enrichCourseSegmentsFromLegLibrary() {
+        if (!usePackageLevelEditSave() || !currentCourse || !currentCourse.segments) return;
+        var changed = false;
+        currentCourse.segments.forEach(function (seg, segIdx) {
+            var meta = legMetadataForSegment(seg, segIdx);
+            if (!meta) return;
+            if (!(seg.description || '').trim() && (meta.description || '').trim()) {
+                seg.description = meta.description.trim();
+                changed = true;
+            }
+        });
+        if (changed) {
+            renderSegmentsList();
+            renderSegmentInfoIcons();
+        }
     }
 
     function setCourse(id, course, options) {
@@ -2038,10 +2068,12 @@ document.addEventListener('DOMContentLoaded', function () {
         descLab.style.display = 'block';
         descLab.style.fontWeight = '600';
         descLab.style.fontSize = '0.85rem';
+        var legMeta = legMetadataForSegment(s, segIdx);
         var inputDesc = document.createElement('textarea');
         inputDesc.id = 'segment-editor-description';
         inputDesc.rows = 2;
-        inputDesc.value = s.description || '';
+        inputDesc.value = (s.description || '').trim()
+            || (legMeta && legMeta.description ? legMeta.description : '');
         inputDesc.style.width = '100%';
         inputDesc.style.boxSizing = 'border-box';
         descWrap.appendChild(descLab);
@@ -4788,6 +4820,7 @@ document.addEventListener('DOMContentLoaded', function () {
             saveAll: saveConfigPackageWorkspace,
             syncHeaderFromMeta: syncCourseHeaderFromPackageMeta,
             reloadCourse: loadConfigPackageCourse,
+            enrichCourseSegmentsFromLegLibrary: enrichCourseSegmentsFromLegLibrary,
             hasCombinedCourse: function () {
                 return !!(
                     currentCourse &&

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -590,6 +590,7 @@
         libraryState = data;
         orderGrid = data.order_grid || {};
         renderLegsTable();
+        updateLegActionButtons();
         syncLegsTableBoundsFilterItems();
         renderRecipeTable();
         renderTotals(data.recipe_lengths_km);
@@ -636,6 +637,11 @@
     }
 
     function updateLegActionButtons() {
+        var hasLegs = !!(libraryState && libraryState.legs && libraryState.legs.length);
+        var exportAllBtn = document.getElementById('btn-export-all-legs');
+        if (exportAllBtn) {
+            exportAllBtn.disabled = !hasLegs;
+        }
         var hasLeg = !!selectedLegId;
         var hasLine = !!(selectedLegLatLngs && selectedLegLatLngs.length >= 2);
         var routeEditActive = isLegRouteEditActive();
@@ -2031,6 +2037,52 @@
         selectLegById(leg.id);
     }
 
+    function downloadLegExportBlob(blob, filename, statusMsg) {
+        var url = URL.createObjectURL(blob);
+        var a = document.createElement('a');
+        a.href = url;
+        a.download = filename;
+        a.style.display = 'none';
+        document.body.appendChild(a);
+        a.click();
+        document.body.removeChild(a);
+        URL.revokeObjectURL(url);
+        setLegStatus(statusMsg);
+    }
+
+    function exportAllLegs() {
+        var legs = (libraryState && libraryState.legs) || [];
+        if (!legs.length) {
+            setLegStatus('No legs to export.', true);
+            return;
+        }
+        setLegStatus('Preparing export for ' + legs.length + ' leg' + (legs.length === 1 ? '' : 's') + '…');
+        fetch(apiBase() + '/segment-library/export-legs', { credentials: 'same-origin' })
+            .then(function (r) {
+                if (!r.ok) {
+                    return r.json().then(function (d) {
+                        throw new Error(formatApiError(r, d));
+                    });
+                }
+                var disposition = r.headers.get('Content-Disposition') || '';
+                var match = /filename="?([^";]+)"?/i.exec(disposition);
+                var filename = (match && match[1]) || 'legs_export.zip';
+                return r.blob().then(function (blob) {
+                    return { blob: blob, filename: filename };
+                });
+            })
+            .then(function (payload) {
+                downloadLegExportBlob(
+                    payload.blob,
+                    payload.filename,
+                    'Exported ' + legs.length + ' leg' + (legs.length === 1 ? '' : 's') + '.'
+                );
+            })
+            .catch(function (err) {
+                setLegStatus(err.message || String(err), true);
+            });
+    }
+
     function exportLeg(legId) {
         var leg = (libraryState && libraryState.legs || []).find(function (c) {
             return c.id === legId;
@@ -2055,16 +2107,11 @@
                 });
             })
             .then(function (payload) {
-                var url = URL.createObjectURL(payload.blob);
-                var a = document.createElement('a');
-                a.href = url;
-                a.download = payload.filename;
-                a.style.display = 'none';
-                document.body.appendChild(a);
-                a.click();
-                document.body.removeChild(a);
-                URL.revokeObjectURL(url);
-                setLegStatus('Exported leg ' + legId + ' (' + label + ').');
+                downloadLegExportBlob(
+                    payload.blob,
+                    payload.filename,
+                    'Exported leg ' + legId + ' (' + label + ').'
+                );
             })
             .catch(function (err) {
                 setLegStatus(err.message || String(err), true);
@@ -2890,12 +2937,16 @@
 
     function bindUi() {
         var importBtn = document.getElementById('btn-import-gpx');
+        var exportAllBtn = document.getElementById('btn-export-all-legs');
         var bulkInput = document.getElementById('segment-library-gpx-input');
         if (importBtn && bulkInput) {
             importBtn.addEventListener('click', function () {
                 bulkInput.value = '';
                 bulkInput.click();
             });
+        }
+        if (exportAllBtn) {
+            exportAllBtn.addEventListener('click', exportAllLegs);
         }
         if (bulkInput) {
             bulkInput.addEventListener('change', function () {

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -54,6 +54,26 @@
         return v;
     }
 
+    function flowTypeLabelForValue(value) {
+        var v = String(value || 'none');
+        var raw = window.FLOW_TYPE_CHOICES_FROM_SERVER || [];
+        var found = raw.find(function (c) { return String(c.value) === v; });
+        if (found && found.label) return found.label;
+        return v;
+    }
+
+    function flowTypeChoices() {
+        var raw = window.FLOW_TYPE_CHOICES_FROM_SERVER || [];
+        if (raw.length) return raw.slice();
+        return [
+            { value: 'overtake', label: 'Overtake' },
+            { value: 'merge', label: 'Merge' },
+            { value: 'counterflow', label: 'Counterflow' },
+            { value: 'parallel', label: 'Parallel' },
+            { value: 'none', label: 'None' }
+        ];
+    }
+
     function formatLegWidth(width) {
         if (width == null || width === '') return '—';
         var n = Number(width);
@@ -2098,6 +2118,7 @@
                 formatLegWidth(ch.width_m),
                 schemaLabelForValue(ch.schema),
                 directionLabelForValue(ch.direction),
+                flowTypeLabelForValue(ch.flow_type),
                 String(ch.location_count != null ? ch.location_count : (ch.locations || []).length)
             ].forEach(function (text) {
                 var td = document.createElement('td');
@@ -2522,7 +2543,9 @@
             end_label: '',
             width_m: 3,
             schema: 'on_course_open',
-            direction: 'uni'
+            direction: 'uni',
+            flow_type: 'none',
+            flow_notes: ''
         };
 
         if (title) {
@@ -2618,6 +2641,28 @@
         addField('Width (m)', 'leg-width', leg.width_m, 'number');
         addSelectField('Schema', 'leg-schema', leg.schema || 'on_course_open', segmentSchemaChoices());
         addSelectField('Direction', 'leg-direction', leg.direction || 'uni', segmentDirectionChoices());
+        addSelectField('Flow type', 'leg-flow-type', leg.flow_type || 'none', flowTypeChoices());
+
+        var notesWrap = document.createElement('div');
+        notesWrap.style.marginBottom = '0.65rem';
+        var notesLab = document.createElement('label');
+        notesLab.textContent = 'Flow notes (optional)';
+        notesLab.style.display = 'block';
+        notesLab.style.fontWeight = '600';
+        notesLab.style.fontSize = '0.85rem';
+        var notesTa = document.createElement('textarea');
+        notesTa.id = 'leg-flow-notes';
+        notesTa.rows = 2;
+        notesTa.maxLength = 500;
+        notesTa.placeholder = 'Notes for flow.csv export';
+        notesTa.value = leg.flow_notes != null ? String(leg.flow_notes) : '';
+        notesTa.style.width = '100%';
+        notesTa.style.boxSizing = 'border-box';
+        notesTa.style.resize = 'vertical';
+        notesTa.style.fontFamily = 'inherit';
+        notesWrap.appendChild(notesLab);
+        notesWrap.appendChild(notesTa);
+        body.appendChild(notesWrap);
 
         footer.innerHTML = '';
         var cancelBtn = document.createElement('button');
@@ -2662,7 +2707,9 @@
             end_label: (document.getElementById('leg-end-label') || {}).value || '',
             width_m: parseFloat((document.getElementById('leg-width') || {}).value) || 3,
             schema: ((document.getElementById('leg-schema') || {}).value || 'on_course_open').trim(),
-            direction: ((document.getElementById('leg-direction') || {}).value || 'uni').trim()
+            direction: ((document.getElementById('leg-direction') || {}).value || 'uni').trim(),
+            flow_type: ((document.getElementById('leg-flow-type') || {}).value || 'none').trim(),
+            flow_notes: ((document.getElementById('leg-flow-notes') || {}).value || '').trim()
         };
     }
 
@@ -2681,6 +2728,8 @@
             fd.append('width_m', String(fields.width_m));
             fd.append('schema', fields.schema);
             fd.append('direction', fields.direction);
+            fd.append('flow_type', fields.flow_type);
+            fd.append('flow_notes', fields.flow_notes);
             setLegStatus('Saving leg…');
             fetch(apiBase() + '/segment-library/legs', { method: 'POST', credentials: 'same-origin', body: fd })
                 .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -602,16 +602,32 @@
                 clearLegMap();
             }
         }
+        var reloadPromise = null;
         if (
             window.configPackageCourse &&
             window.configPackageCourse.reloadCourse
         ) {
-            window.configPackageCourse.reloadCourse({ skipMapRefresh: true });
+            reloadPromise = window.configPackageCourse.reloadCourse({ skipMapRefresh: true });
         } else if (
             window.configPackageCourse &&
             typeof window.configPackageCourse.renderSegmentsList === 'function'
         ) {
             window.configPackageCourse.renderSegmentsList();
+        }
+        if (reloadPromise && typeof reloadPromise.then === 'function') {
+            reloadPromise.then(function () {
+                if (
+                    window.configPackageCourse &&
+                    window.configPackageCourse.enrichCourseSegmentsFromLegLibrary
+                ) {
+                    window.configPackageCourse.enrichCourseSegmentsFromLegLibrary();
+                }
+            });
+        } else if (
+            window.configPackageCourse &&
+            window.configPackageCourse.enrichCourseSegmentsFromLegLibrary
+        ) {
+            window.configPackageCourse.enrichCourseSegmentsFromLegLibrary();
         }
     }
 
@@ -2229,10 +2245,14 @@
         var legId = resolveLegIdForSegment(seg, segIdx);
         var ch = libraryState.legs.find(function (c) { return c.id === legId; });
         if (!ch) return null;
+        var description = (ch.description != null && String(ch.description).trim())
+            ? String(ch.description).trim()
+            : (ch.flow_notes != null ? String(ch.flow_notes).trim() : '');
         return {
             from: (ch.start_label || '').trim(),
             to: (ch.end_label || '').trim(),
-            seg_label: (ch.leg_label || '').trim()
+            seg_label: (ch.leg_label || '').trim(),
+            description: description
         };
     }
 
@@ -2545,7 +2565,7 @@
             schema: 'on_course_open',
             direction: 'uni',
             flow_type: 'none',
-            flow_notes: ''
+            description: ''
         };
 
         if (title) {
@@ -2646,16 +2666,18 @@
         var notesWrap = document.createElement('div');
         notesWrap.style.marginBottom = '0.65rem';
         var notesLab = document.createElement('label');
-        notesLab.textContent = 'Flow notes (optional)';
+        notesLab.textContent = 'Description';
         notesLab.style.display = 'block';
         notesLab.style.fontWeight = '600';
         notesLab.style.fontSize = '0.85rem';
         var notesTa = document.createElement('textarea');
-        notesTa.id = 'leg-flow-notes';
+        notesTa.id = 'leg-description';
         notesTa.rows = 2;
         notesTa.maxLength = 500;
-        notesTa.placeholder = 'Notes for flow.csv export';
-        notesTa.value = leg.flow_notes != null ? String(leg.flow_notes) : '';
+        notesTa.placeholder = 'Segment description (syncs to Course tab)';
+        notesTa.value = leg.description != null && String(leg.description).trim()
+            ? String(leg.description)
+            : (leg.flow_notes != null ? String(leg.flow_notes) : '');
         notesTa.style.width = '100%';
         notesTa.style.boxSizing = 'border-box';
         notesTa.style.resize = 'vertical';
@@ -2709,12 +2731,30 @@
             schema: ((document.getElementById('leg-schema') || {}).value || 'on_course_open').trim(),
             direction: ((document.getElementById('leg-direction') || {}).value || 'uni').trim(),
             flow_type: ((document.getElementById('leg-flow-type') || {}).value || 'none').trim(),
-            flow_notes: ((document.getElementById('leg-flow-notes') || {}).value || '').trim()
+            description: ((document.getElementById('leg-description') || {}).value || '').trim()
         };
+    }
+
+    function validateLegFields(fields) {
+        var missing = [];
+        if (!String(fields.leg_label || '').trim()) missing.push('Leg label');
+        if (!String(fields.start_label || '').trim()) missing.push('Start place');
+        if (!String(fields.end_label || '').trim()) missing.push('End place');
+        if (!String(fields.description || '').trim()) missing.push('Description');
+        if (!(fields.width_m > 0)) missing.push('Width (m)');
+        if (missing.length) {
+            return 'Required: ' + missing.join(', ') + '.';
+        }
+        return '';
     }
 
     function saveLegEditor() {
         var fields = collectLegFields();
+        var validationError = validateLegFields(fields);
+        if (validationError) {
+            setLegStatus(validationError, true);
+            return;
+        }
         if (legEditorMode === 'create') {
             if (!pendingGpxFile) {
                 setLegStatus('Choose a GPX file first.', true);
@@ -2729,7 +2769,7 @@
             fd.append('schema', fields.schema);
             fd.append('direction', fields.direction);
             fd.append('flow_type', fields.flow_type);
-            fd.append('flow_notes', fields.flow_notes);
+            fd.append('description', fields.description);
             setLegStatus('Saving leg…');
             fetch(apiBase() + '/segment-library/legs', { method: 'POST', credentials: 'same-origin', body: fd })
                 .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })

--- a/frontend/templates/pages/course_mapping.html
+++ b/frontend/templates/pages/course_mapping.html
@@ -50,6 +50,7 @@
     window.EVENT_CHOICES_FROM_SERVER = {{ event_choices | tojson }};
     window.SEGMENT_SCHEMA_CHOICES_FROM_SERVER = {{ (segment_schema_choices | default([])) | tojson }};
     window.SEGMENT_DIRECTION_CHOICES_FROM_SERVER = {{ (segment_direction_choices | default([])) | tojson }};
+    window.FLOW_TYPE_CHOICES_FROM_SERVER = {{ (flow_type_choices | default([])) | tojson }};
     window.DAY_SHORT_CODES_FROM_SERVER = {{ (day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true)) | tojson }};
 </script>
 <!-- Leaflet JS -->

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -488,8 +488,9 @@
             row.dataset.segId = segment.seg_id;
             row.dataset.eventA = segment.event_a;
             row.dataset.eventB = segment.event_b;
+            row.dataset.flowId = segment.flow_id || '';
             row.innerHTML = `
-                <td>${segment.seg_id || "—"}</td>
+                <td>${segment.flow_id || segment.seg_id || "—"}</td>
                 <td>${segment.seg_label || "—"}</td>
                 <td>${segment.event_a || "—"} / ${segment.event_b || "—"}</td>
                 <td>${segment.overlap_start || "—"}–${segment.overlap_end || "—"}</td>
@@ -520,7 +521,10 @@
             return;
         }
 
-        const apiUrl = `/api/bidirectional/segment/${encodeURIComponent(segment.seg_id)}?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}&event_a=${encodeURIComponent(segment.event_a)}&event_b=${encodeURIComponent(segment.event_b)}`;
+        let apiUrl = `/api/bidirectional/segment/${encodeURIComponent(segment.seg_id)}?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}&event_a=${encodeURIComponent(segment.event_a)}&event_b=${encodeURIComponent(segment.event_b)}`;
+        if (segment.flow_id) {
+            apiUrl += `&flow_id=${encodeURIComponent(segment.flow_id)}`;
+        }
         fetch(apiUrl, { cache: 'no-store' })
             .then(response => {
                 if (!response.ok) {

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -149,6 +149,7 @@
     window.EVENT_CHOICES_FROM_SERVER = {{ (event_choices | default([])) | tojson }};
     window.SEGMENT_SCHEMA_CHOICES_FROM_SERVER = {{ (segment_schema_choices | default([])) | tojson }};
     window.SEGMENT_DIRECTION_CHOICES_FROM_SERVER = {{ (segment_direction_choices | default([])) | tojson }};
+    window.FLOW_TYPE_CHOICES_FROM_SERVER = {{ (flow_type_choices | default([])) | tojson }};
     window.DAY_SHORT_CODES_FROM_SERVER = {{ (day_short_codes | default(['fri', 'sat', 'sun', 'mon'], true)) | tojson }};
 </script>
 <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
@@ -157,7 +158,7 @@
 <script src="/static/js/table_actions.js?v=775b"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
 <script src="/static/js/map/course_mapping.js?v=779a"></script>
-<script src="/static/js/map/segment_recipes.js?v=779b"></script>
+<script src="/static/js/map/segment_recipes.js?v=759a"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=780b"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -157,8 +157,8 @@
 <script src="/static/js/map/map_bounds_table_filter.js?v=779a"></script>
 <script src="/static/js/table_actions.js?v=775b"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
-<script src="/static/js/map/course_mapping.js?v=779a"></script>
-<script src="/static/js/map/segment_recipes.js?v=759a"></script>
+<script src="/static/js/map/course_mapping.js?v=779b"></script>
+<script src="/static/js/map/segment_recipes.js?v=779b"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=780b"></script>
 {% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -158,7 +158,7 @@
 <script src="/static/js/table_actions.js?v=775b"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
 <script src="/static/js/map/course_mapping.js?v=779b"></script>
-<script src="/static/js/map/segment_recipes.js?v=779b"></script>
+<script src="/static/js/map/segment_recipes.js?v=779e"></script>
 <script src="/static/js/runners_baseline.js?v=756i"></script>
 <script src="/static/js/race_configuration.js?v=780b"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -100,6 +100,7 @@
                                 <th>Width</th>
                                 <th>Schema</th>
                                 <th>Dir</th>
+                                <th>Flow</th>
                                 <th>Locs</th>
                                 <th class="course-map-action-cell">Actions</th>
                             </tr>

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -78,6 +78,7 @@
                 <div class="card-actions course-planner-toolbar config-legs-table-toolbar">
                 <input type="file" id="segment-library-gpx-input" accept=".gpx,.json" multiple style="display: none;" />
                 <button type="button" id="btn-import-gpx" class="course-btn" title="Import GPX routes and optional leg export JSON (locations + metadata)">Import legs…</button>
+                <button type="button" id="btn-export-all-legs" class="course-btn" disabled title="Download all legs (GPX + metadata + locations per leg)">Export legs…</button>
                 <button type="button" id="btn-draw-leg-map" class="course-btn" disabled title="Coming soon: draw a new leg on the map">Draw leg on map</button>
                 </div>
             </div>

--- a/tests/unit/test_flow_csv.py
+++ b/tests/unit/test_flow_csv.py
@@ -1,0 +1,177 @@
+"""Unit tests for conservative flow.csv export and validation."""
+
+import csv
+import io
+
+import pytest
+
+from app.core.course.flow_csv import (
+    build_flow_csv_from_segments,
+    default_flow_id,
+    parse_flow_csv_text,
+    validate_flow_csv,
+    validate_flow_csv_text,
+)
+
+
+def _parse(csv_text: str):
+    return parse_flow_csv_text(csv_text)
+
+
+def test_cross_event_only_by_default():
+    segments = [
+        {
+            "seg_id": "S1",
+            "seg_label": "Shared start",
+            "direction": "uni",
+            "full": "y",
+            "half": "y",
+            "10k": "y",
+            "full_from_km": 0,
+            "full_to_km": 2.0,
+            "half_from_km": 0,
+            "half_to_km": 2.0,
+            "10k_from_km": 0,
+            "10k_to_km": 2.0,
+        }
+    ]
+    csv_text = build_flow_csv_from_segments(segments, ["full", "half", "10k"])
+    rows = _parse(csv_text)
+    assert len(rows) == 3
+    pairs = {(r["event_a"], r["event_b"]) for r in rows}
+    assert pairs == {("full", "half"), ("full", "10k"), ("half", "10k")}
+    assert all(r["flow_id"] == default_flow_id("S1", r["event_a"], r["event_b"]) for r in rows)
+    assert not any(r["event_a"] == r["event_b"] for r in rows)
+
+
+def test_same_event_from_override_with_distinct_km():
+    segments = [
+        {
+            "seg_id": "S4",
+            "seg_label": "Trail return",
+            "direction": "bi",
+            "full": "y",
+            "10k": "y",
+            "full_from_km": 15.0,
+            "full_to_km": 17.0,
+            "10k_from_km": 4.0,
+            "10k_to_km": 6.0,
+        }
+    ]
+    overrides = [
+        {
+            "seg_id": "S4",
+            "event_a": "10k",
+            "event_b": "10k",
+            "from_km_a": 2.7,
+            "to_km_a": 4.25,
+            "from_km_b": 4.25,
+            "to_km_b": 5.8,
+            "flow_type": "overtake",
+            "direction": "bi",
+            "flow_id": "S4b",
+            "notes": "10K outbound vs return",
+        }
+    ]
+    csv_text = build_flow_csv_from_segments(
+        segments, ["full", "10k"], overrides=overrides
+    )
+    rows = _parse(csv_text)
+    same_event = [r for r in rows if r["event_a"] == r["event_b"]]
+    assert len(same_event) == 1
+    assert same_event[0]["flow_id"] == "S4b"
+    cross = [r for r in rows if r["event_a"] != r["event_b"]]
+    assert len(cross) == 1
+    assert cross[0]["flow_id"] == "S4_full_10k"
+
+
+def test_validate_rejects_duplicate_bi_output_id():
+    rows = [
+        {
+            "flow_id": "S4",
+            "seg_id": "S4",
+            "event_a": "full",
+            "event_b": "10k",
+            "from_km_a": 15.0,
+            "to_km_a": 17.0,
+            "from_km_b": 4.0,
+            "to_km_b": 6.0,
+            "flow_type": "overtake",
+            "direction": "bi",
+        },
+        {
+            "flow_id": "S4",
+            "seg_id": "S4",
+            "event_a": "10k",
+            "event_b": "10k",
+            "from_km_a": 2.7,
+            "to_km_a": 4.25,
+            "from_km_b": 4.25,
+            "to_km_b": 5.8,
+            "flow_type": "overtake",
+            "direction": "bi",
+        },
+    ]
+    result = validate_flow_csv(rows)
+    assert not result.ok
+    assert any("share output id" in err for err in result.errors)
+
+
+def test_validate_rejects_auto_same_event_identical_km():
+    rows = [
+        {
+            "flow_id": "S4_full_full",
+            "seg_id": "S4",
+            "event_a": "full",
+            "event_b": "full",
+            "from_km_a": 15.44,
+            "to_km_a": 17.03,
+            "from_km_b": 15.44,
+            "to_km_b": 17.03,
+            "flow_type": "overtake",
+            "direction": "bi",
+            "auto_generated": True,
+        }
+    ]
+    result = validate_flow_csv(rows)
+    assert not result.ok
+    assert any("auto-generated same-event" in err for err in result.errors)
+
+
+def test_validate_allows_none_flow_type():
+    rows = [
+        {
+            "flow_id": "C1",
+            "seg_id": "C1",
+            "event_a": "full",
+            "event_b": "full",
+            "from_km_a": 4.25,
+            "to_km_a": 5.08,
+            "from_km_b": 13.96,
+            "to_km_b": 14.79,
+            "flow_type": "none",
+            "direction": "bi",
+            "notes": "Full out/back reference",
+        }
+    ]
+    result = validate_flow_csv(rows)
+    assert result.ok
+
+
+def test_validate_flow_csv_text_round_trip():
+    segments = [
+        {
+            "seg_id": "S2",
+            "seg_label": "Friel to turn",
+            "direction": "bi",
+            "full": "y",
+            "10k": "y",
+            "full_from_km": 2.7,
+            "full_to_km": 4.3,
+            "10k_from_km": 2.7,
+            "10k_to_km": 4.3,
+        }
+    ]
+    csv_text = build_flow_csv_from_segments(segments, ["full", "10k"])
+    result = validate_flow_csv_text(csv_text)
+    assert result.ok

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -18,7 +18,14 @@ from app.core.config_package.legs import (
     sync_leg_segment_labels_into_course,
     update_package_leg,
     update_package_leg_geometry,
+    _normalize_flow_notes,
+    _normalize_flow_type,
     _normalize_locations,
+)
+from app.core.course.segment_library import (
+    build_course_segments_from_library,
+    build_flow_csv_from_segments,
+    load_leg_library,
 )
 from app.core.config_package.segment_recipes import import_gpx_files_to_library, parse_leg_gpx
 from app.core.config_package.location_ids import assign_unique_location_ids
@@ -968,3 +975,117 @@ def test_export_config_package_segments_fails_on_invalid_proxy(
     save_config_course(config_id, course)
     with pytest.raises(ValueError, match="Cannot export locations.csv"):
         export_config_package_segments(config_id)
+
+
+def test_normalize_flow_type_rejects_invalid():
+    assert _normalize_flow_type("merge") == "merge"
+    assert _normalize_flow_notes("  note  ") == "note"
+    with pytest.raises(ValueError, match="flow_type"):
+        _normalize_flow_type("diverge")
+
+
+def test_leg_flow_type_persisted_and_exported(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Flow meta", "", event_day="sun", package_events=["full", "half"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Shared start",
+                        "file": "01.gpx",
+                        "schema": "on_course_open",
+                        "direction": "uni",
+                        "flow_type": "overtake",
+                        "flow_notes": "Initial note",
+                    }
+                ],
+                "recipes": {"full": ["01"], "half": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (lib_dir / "01.gpx").write_text(
+        """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><name>Shared start</name><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>""",
+        encoding="utf-8",
+    )
+
+    update_package_leg(
+        config_id,
+        "01",
+        {"flow_type": "merge", "flow_notes": "Keep right critical"},
+    )
+    manifest = yaml.safe_load((lib_dir / "manifest.yaml").read_text())
+    assert manifest["legs"][0]["flow_type"] == "merge"
+    assert manifest["legs"][0]["flow_notes"] == "Keep right critical"
+
+    row = leg_row_from_entry(manifest["legs"][0], parse_leg_gpx(lib_dir / "01.gpx"))
+    assert row["flow_type"] == "merge"
+    assert row["flow_notes"] == "Keep right critical"
+
+    zip_bytes, _ = export_package_leg_zip(config_id, "01")
+    with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+        payload = json.loads(zf.read("01.json"))
+    assert payload["leg"]["flow_type"] == "merge"
+    assert payload["leg"]["flow_notes"] == "Keep right critical"
+
+
+def test_flow_type_propagates_to_segments_and_flow_csv(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    lib_dir = tmp_path / "pkg" / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    manifest = {
+        "legs": [
+            {
+                "id": "01",
+                "seg_label": "Leg A",
+                "file": "01.gpx",
+                "flow_type": "counterflow",
+                "flow_notes": "Shared trail",
+            }
+        ],
+        "recipes": {"full": ["01"], "10k": ["01"]},
+    }
+    (lib_dir / "manifest.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    (lib_dir / "01.gpx").write_text(
+        """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>""",
+        encoding="utf-8",
+    )
+    legs_by_id = load_leg_library(lib_dir.parent, manifest)
+    segments = build_course_segments_from_library(
+        manifest, legs_by_id, event_ids=["full", "10k"]
+    )
+    assert segments[0]["flow_type"] == "counterflow"
+    assert segments[0]["flow_notes"] == "Shared trail"
+    csv_text = build_flow_csv_from_segments(segments, ["full", "10k"])
+    assert ",counterflow," in csv_text
+    assert "Shared trail" in csv_text

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -15,6 +15,7 @@ from app.core.config_package.legs import (
     reconcile_leg_locations_to_course,
     remove_leg_location_from_manifest,
     sync_leg_location_metadata_from_course,
+    sync_leg_metadata_into_course,
     sync_leg_segment_labels_into_course,
     update_package_leg,
     update_package_leg_geometry,
@@ -437,6 +438,266 @@ def test_sync_leg_segment_labels_from_manifest(tmp_path, monkeypatch):
     assert seg["from_label"] == "Start"
     assert seg["to_label"] == "Trail at Friel"
     assert seg["seg_label"] == "Start to Friel"
+
+
+def test_sync_leg_flow_type_to_segment(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Flow sync", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Start to Friel",
+                        "file": "01.gpx",
+                        "flow_type": "merge",
+                        "flow_notes": "Keep right",
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    course_path = package_path / "course.json"
+    course = json.loads(course_path.read_text())
+    course["segment_library_applied"] = True
+    course["segments"] = [
+        {
+            "seg_id": "S1",
+            "leg_id": "01",
+            "seg_label": "Start to Friel",
+            "flow_type": "overtake",
+            "flow_notes": "",
+            "events": ["full"],
+        }
+    ]
+    course_path.write_text(json.dumps(course, indent=2))
+
+    assert sync_leg_metadata_into_course(config_id) is True
+    merged = load_config_course(config_id)
+    seg = merged["segments"][0]
+    assert seg["flow_type"] == "merge"
+    assert seg["description"] == "Keep right"
+
+
+def test_sync_leg_description_with_chunk_id_without_applied_flag(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Chunk sync", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Start to Friel",
+                        "start_label": "Start",
+                        "end_label": "Friel",
+                        "description": "From manifest legs",
+                        "file": "01.gpx",
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    course_path = package_path / "course.json"
+    course = json.loads(course_path.read_text())
+    course["segments"] = [
+        {
+            "seg_id": "S1",
+            "chunk_id": "01",
+            "seg_label": "01_start_friel",
+            "description": "",
+            "events": ["full"],
+        }
+    ]
+    course_path.write_text(json.dumps(course, indent=2))
+
+    assert sync_leg_metadata_into_course(config_id) is True
+    merged = load_config_course(config_id)
+    assert merged["segments"][0]["description"] == "From manifest legs"
+    assert merged["segments"][0].get("leg_id") == "01"
+    assert "chunk_id" not in merged["segments"][0]
+
+
+def test_sync_leg_description_to_segment(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Desc sync", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Start to Friel",
+                        "file": "01.gpx",
+                        "description": "Shared start corridor",
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    course_path = package_path / "course.json"
+    course = json.loads(course_path.read_text())
+    course["segment_library_applied"] = True
+    course["segments"] = [
+        {
+            "seg_id": "S1",
+            "leg_id": "01",
+            "seg_label": "Start to Friel",
+            "description": "",
+            "events": ["full"],
+        }
+    ]
+    course_path.write_text(json.dumps(course, indent=2))
+
+    assert sync_leg_metadata_into_course(config_id) is True
+    merged = load_config_course(config_id)
+    assert merged["segments"][0]["description"] == "Shared start corridor"
+
+
+def test_prune_segments_not_in_recipes_on_sync(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Prune sync", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {"id": "01", "seg_label": "Used", "file": "01.gpx"},
+                    {"id": "09", "seg_label": "Unused", "file": "09.gpx"},
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    course_path = package_path / "course.json"
+    course = json.loads(course_path.read_text())
+    course["segment_library_applied"] = True
+    course["segments"] = [
+        {"seg_id": "S1", "leg_id": "01", "events": ["full"]},
+        {"seg_id": "S9", "leg_id": "09", "events": []},
+    ]
+    course_path.write_text(json.dumps(course, indent=2))
+
+    assert sync_leg_metadata_into_course(config_id) is True
+    merged = load_config_course(config_id)
+    assert [s["leg_id"] for s in merged["segments"]] == ["01"]
+
+
+def test_update_package_leg_syncs_flow_type_without_recipe_apply(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Flow update", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Leg one",
+                        "start_label": "Start",
+                        "end_label": "End",
+                        "description": "Leg one segment",
+                        "file": "01.gpx",
+                        "flow_type": "none",
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    course_path = package_path / "course.json"
+    course = json.loads(course_path.read_text())
+    course["segment_library_applied"] = True
+    course["segments"] = [
+        {
+            "seg_id": "S1",
+            "leg_id": "01",
+            "flow_type": "overtake",
+            "events": ["full"],
+        }
+    ]
+    course_path.write_text(json.dumps(course, indent=2))
+    (lib_dir / "01.gpx").write_text(
+        """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>""",
+        encoding="utf-8",
+    )
+
+    update_package_leg(
+        config_id,
+        "01",
+        {"flow_type": "counterflow", "description": "Bi traffic"},
+    )
+    merged = load_config_course(config_id)
+    assert merged["segments"][0]["flow_type"] == "counterflow"
+    assert merged["segments"][0]["description"] == "Bi traffic"
 
 
 def test_update_package_leg_merges_locations_before_recipes_applied(tmp_path, monkeypatch):
@@ -977,6 +1238,53 @@ def test_export_config_package_segments_fails_on_invalid_proxy(
         export_config_package_segments(config_id)
 
 
+def test_update_package_leg_requires_description(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Desc required", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Leg one",
+                        "start_label": "Start",
+                        "end_label": "End",
+                        "description": "Initial",
+                        "file": "01.gpx",
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (lib_dir / "01.gpx").write_text(
+        """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>""",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(ValueError, match="description is required"):
+        update_package_leg(config_id, "01", {"description": "   "})
+
+
 def test_normalize_flow_type_rejects_invalid():
     assert _normalize_flow_type("merge") == "merge"
     assert _normalize_flow_notes("  note  ") == "note"
@@ -1005,11 +1313,13 @@ def test_leg_flow_type_persisted_and_exported(tmp_path, monkeypatch):
                     {
                         "id": "01",
                         "seg_label": "Shared start",
+                        "start_label": "Start",
+                        "end_label": "End",
+                        "description": "Initial note",
                         "file": "01.gpx",
                         "schema": "on_course_open",
                         "direction": "uni",
                         "flow_type": "overtake",
-                        "flow_notes": "Initial note",
                     }
                 ],
                 "recipes": {"full": ["01"], "half": ["01"]},
@@ -1031,21 +1341,21 @@ def test_leg_flow_type_persisted_and_exported(tmp_path, monkeypatch):
     update_package_leg(
         config_id,
         "01",
-        {"flow_type": "merge", "flow_notes": "Keep right critical"},
+        {"flow_type": "merge", "description": "Keep right critical"},
     )
     manifest = yaml.safe_load((lib_dir / "manifest.yaml").read_text())
     assert manifest["legs"][0]["flow_type"] == "merge"
-    assert manifest["legs"][0]["flow_notes"] == "Keep right critical"
+    assert manifest["legs"][0]["description"] == "Keep right critical"
 
     row = leg_row_from_entry(manifest["legs"][0], parse_leg_gpx(lib_dir / "01.gpx"))
     assert row["flow_type"] == "merge"
-    assert row["flow_notes"] == "Keep right critical"
+    assert row["description"] == "Keep right critical"
 
     zip_bytes, _ = export_package_leg_zip(config_id, "01")
     with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
         payload = json.loads(zf.read("01.json"))
     assert payload["leg"]["flow_type"] == "merge"
-    assert payload["leg"]["flow_notes"] == "Keep right critical"
+    assert payload["leg"]["description"] == "Keep right critical"
 
 
 def test_flow_type_propagates_to_segments_and_flow_csv(tmp_path, monkeypatch):
@@ -1080,12 +1390,12 @@ def test_flow_type_propagates_to_segments_and_flow_csv(tmp_path, monkeypatch):
 </gpx>""",
         encoding="utf-8",
     )
-    legs_by_id = load_leg_library(lib_dir.parent, manifest)
+    legs_by_id = load_leg_library(lib_dir, manifest)
     segments = build_course_segments_from_library(
         manifest, legs_by_id, event_ids=["full", "10k"]
     )
     assert segments[0]["flow_type"] == "counterflow"
-    assert segments[0]["flow_notes"] == "Shared trail"
+    assert segments[0]["description"] == "Shared trail"
     csv_text = build_flow_csv_from_segments(segments, ["full", "10k"])
     assert ",counterflow," in csv_text
     assert "Shared trail" in csv_text

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -8,6 +8,7 @@ import pytest
 
 from app.core.config_package.legs import (
     allocate_next_leg_id,
+    export_all_package_legs_zip,
     export_package_leg_zip,
     leg_row_from_entry,
     merge_leg_locations_into_course,
@@ -988,6 +989,54 @@ def test_export_package_leg_zip(tmp_path, monkeypatch):
     assert leg["width_m"] == 4
     assert len(leg["locations"]) == 1
     assert leg["locations"][0]["loc_label"] == "Water stop"
+
+
+def test_export_all_package_legs_zip(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package(
+        "Export all", "", event_day="sun", package_events=["full"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    gpx_body = """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>"""
+    (lib_dir / "01_a.gpx").write_text(gpx_body, encoding="utf-8")
+    (lib_dir / "02_b.gpx").write_text(gpx_body, encoding="utf-8")
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {"id": "01", "seg_label": "Leg one", "file": "01_a.gpx"},
+                    {"id": "02", "seg_label": "Leg two", "file": "02_b.gpx"},
+                ],
+                "recipes": {"full": ["01", "02"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    zip_bytes, filename = export_all_package_legs_zip(config_id)
+    assert filename == f"{config_id}_legs_export.zip"
+    with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+        names = set(zf.namelist())
+        assert "01.gpx" in names
+        assert "01.json" in names
+        assert "02.gpx" in names
+        assert "02.json" in names
+        meta = json.loads(zf.read("02.json").decode("utf-8"))
+    assert meta["leg"]["leg_label"] == "Leg two"
 
 
 def test_import_gpx_with_leg_export_json(tmp_path, monkeypatch):

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -99,3 +99,33 @@ def test_export_bundle_writes_csv():
     bundle = export_library_to_course(LIBRARY_DIR, MANIFEST)
     assert "full,half,10k" in bundle["segments_csv"].splitlines()[0]
     assert "event_a" in bundle["flow_csv"]
+
+
+def test_build_course_segments_follows_recipe_order_not_manifest_order(manifest, legs_by_id):
+    """Leg ids after 15 in manifest must not push recipe-middle legs to the end."""
+    recipes = {
+        "full": ["01", "02", "03", "16", "04"],
+        "half": [],
+        "10k": [],
+    }
+    manifest = dict(manifest)
+    manifest["recipes"] = recipes
+    legs = dict(legs_by_id)
+    legs["03"] = {**legs["03"], "length_km": 5.57}
+    legs["16"] = {
+        **legs["03"],
+        "id": "16",
+        "length_km": 5.57,
+        "file": "16_stub.gpx",
+    }
+    segments = build_course_segments_from_library(
+        manifest, legs, event_ids=["full", "half", "10k"]
+    )
+    full_leg_order = [s["leg_id"] for s in segments if "full" in s.get("events", [])]
+    assert full_leg_order == ["01", "02", "03", "16", "04"]
+    leg16 = next(s for s in segments if s["leg_id"] == "16")
+    assert leg16["seg_id"] == "S4"
+    assert leg16["full_from_km"] == pytest.approx(9.87, abs=0.05)
+    assert leg16["full_to_km"] == pytest.approx(15.44, abs=0.05)
+    leg04 = next(s for s in segments if s["leg_id"] == "04")
+    assert leg04["full_from_km"] == pytest.approx(15.44, abs=0.05)

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -48,7 +48,12 @@ def test_multi_event_segment_rows(manifest, legs_by_id):
     segments = build_course_segments_from_library(
         manifest, legs_by_id, event_ids=["full", "half", "10k"]
     )
-    assert len(segments) == len(manifest_legs(manifest))
+    recipe_ids = set()
+    for seq in (manifest.get("recipes") or {}).values():
+        recipe_ids.update(seq)
+    assert len(segments) == len(recipe_ids)
+    assert "09" not in {s["leg_id"] for s in segments}
+    assert "10" not in {s["leg_id"] for s in segments}
     assert segments[0]["leg_id"] == "01"
     s1 = next(s for s in segments if s["seg_id"] == "S1")
     assert set(s1["events"]) == {"full", "half", "10k"}
@@ -64,6 +69,17 @@ def test_multi_event_segment_rows(manifest, legs_by_id):
 def test_10k_recipe_length(manifest, legs_by_id):
     bundle = export_library_to_course(LIBRARY_DIR, MANIFEST, event_ids=["10k"])
     assert bundle["recipe_lengths_km"]["10k"] == pytest.approx(10.02, abs=0.2)
+
+
+def test_build_course_segments_skips_unassigned_legs(manifest, legs_by_id):
+    segments = build_course_segments_from_library(
+        manifest, legs_by_id, event_ids=["full", "half", "10k"]
+    )
+    leg_ids = {s["leg_id"] for s in segments}
+    assert "09" not in leg_ids
+    assert "10" not in leg_ids
+    for seg in segments:
+        assert seg.get("events")
 
 
 def test_flow_pairs_on_shared_segment(manifest, legs_by_id):

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -88,9 +88,9 @@ def test_flow_pairs_on_shared_segment(manifest, legs_by_id):
     )
     csv_text = build_flow_csv_from_segments(segments, ["full", "half", "10k"])
     lines = [ln for ln in csv_text.strip().splitlines() if ln]
-    assert lines[0].startswith("seg_id,")
+    assert lines[0].startswith("flow_id,seg_id,")
     assert any(",10k,half," in ln or ",half,10k," in ln for ln in lines)
-    assert any(ln.startswith("S1,") for ln in lines[1:])
+    assert any(",S1," in ln for ln in lines[1:])
 
 
 def test_export_bundle_writes_csv():


### PR DESCRIPTION
## Summary

- Add `flow_type` and `flow_notes` to config package legs with UI support (#759).
- Sync leg descriptions into course segments on apply; enrich client fallback for segment descriptions.
- Add conservative `flow.csv` export (cross-event pairs by default; same-event via `flow_overrides`).
- Add bulk **Export legs…** and harden package leg/flow authoring.
- **Fix:** Build `course.json` segments in **recipe order** (not manifest file order) and stop overwriting recipe-based km with manifest-order accumulation (fixes split legs like Blake out/back appearing at wrong position/km).

## Test plan

- [x] `pytest tests/unit/test_segment_library.py tests/unit/test_flow_csv.py tests/unit/test_package_legs.py`
- [ ] Apply recipes on a package with split uni legs (e.g. 03 + 16); confirm leg 16 is S4 with correct `full_from_km`
- [ ] Export package; verify `flow.csv` and leg export zip


Made with [Cursor](https://cursor.com)