### PR TITLE
Leg platform: stable IDs, export v2, org library (#780)

### DIFF
--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -19,6 +19,7 @@ from app.core.config_package.location_ids import (
     assign_unique_location_ids,
     parse_location_id,
 )
+from app.core.config_package.location_keys import ensure_location_key
 from app.core.config_package.segment_recipes import (
     load_package_segment_manifest,
     package_segment_library_dir,
@@ -60,6 +61,7 @@ _LEG_LOC_PRESERVE_FIELDS = (
     "lat",
     "lon",
     "placement",
+    "location_key",
     "notes",
     "buffer",
     "interval",
@@ -72,8 +74,10 @@ _LEG_LOC_PRESERVE_FIELDS = (
     "resources",
 )
 
+_LEG_LOC_EXPORT_FIELDS = _LEG_LOC_PRESERVE_FIELDS
+
 _LEG_ID_RE = re.compile(r"^\d{2,3}$")
-LEG_EXPORT_VERSION = 1
+LEG_EXPORT_VERSION = 2
 
 
 def _normalize_segment_schema(schema: Any) -> str:
@@ -139,10 +143,16 @@ def _slugify(text: str) -> str:
     return slug[:48] or "leg"
 
 
-def _normalize_locations(raw: Any) -> List[Dict[str, Any]]:
+def _normalize_locations(
+    raw: Any,
+    *,
+    assign_keys: bool = True,
+    used_location_keys: Optional[set[str]] = None,
+) -> List[Dict[str, Any]]:
     if not isinstance(raw, list):
         return []
     allowed_types = set(LOCATION_TYPE_CHOICES)
+    used_keys: set[str] = set(used_location_keys or set())
     out: List[Dict[str, Any]] = []
     for item in raw:
         if not isinstance(item, dict):
@@ -164,15 +174,29 @@ def _normalize_locations(raw: Any) -> List[Dict[str, Any]]:
             placement = str(item.get("placement") or "along").strip().lower()
             if placement not in LOCATION_PLACEMENT_CHOICES:
                 placement = "along"
-        out.append(
-            {
-                "loc_label": label,
-                "loc_type": loc_type,
-                "lat": round(lat, 6),
-                "lon": round(lon, 6),
-                "placement": placement,
-            }
-        )
+        row: Dict[str, Any] = {
+            "loc_label": label,
+            "loc_type": loc_type,
+            "lat": round(lat, 6),
+            "lon": round(lon, 6),
+            "placement": placement,
+        }
+        for field in _LEG_LOC_EXPORT_FIELDS:
+            if field in row:
+                continue
+            if field not in item:
+                continue
+            val = item[field]
+            if field == "resources":
+                if isinstance(val, dict):
+                    row[field] = val
+                continue
+            if val in (None, ""):
+                continue
+            row[field] = val
+        if assign_keys:
+            ensure_location_key(row, used_keys)
+        out.append(row)
     return out
 
 
@@ -504,16 +528,22 @@ def merge_leg_export_into_entry(
 def apply_leg_exports_to_manifest(
     manifest: Dict[str, Any],
     exports_by_leg_id: Dict[str, Dict[str, Any]],
+    *,
+    exports_by_gpx_file: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
-    """Merge runflow leg export JSON payloads into manifest legs by leg id."""
-    if not exports_by_leg_id:
+    """Merge runflow leg export JSON payloads into manifest legs by id or GPX file."""
+    if not exports_by_leg_id and not exports_by_gpx_file:
         return manifest
+    by_file = exports_by_gpx_file or {}
     legs = list(manifest_legs(manifest))
     for entry in legs:
         if not isinstance(entry, dict):
             continue
         leg_id = str(entry.get("id", "")).strip()
-        leg_export = exports_by_leg_id.get(leg_id)
+        file_name = str(entry.get("file") or "").strip()
+        leg_export = exports_by_leg_id.get(leg_id) or (
+            by_file.get(file_name) if file_name else None
+        )
         if leg_export:
             merge_leg_export_into_entry(entry, leg_export)
     set_manifest_legs(manifest, legs)
@@ -955,13 +985,17 @@ def merge_leg_locations_into_course(config_id: str) -> None:
         package_events = list(COURSE_EVENT_IDS)
     event_ids = package_events or list(COURSE_EVENT_IDS)
 
-    existing_leg: Dict[str, Dict[str, Any]] = {}
+    existing_by_loc_key: Dict[str, Dict[str, Any]] = {}
+    existing_by_leg_loc_key: Dict[str, Dict[str, Any]] = {}
     for loc in course.get("locations") or []:
         if not isinstance(loc, dict) or loc.get("source") != "leg":
             continue
-        key = str(loc.get("leg_loc_key") or "").strip()
-        if key:
-            existing_leg[key] = loc
+        loc_key = str(loc.get("location_key") or "").strip()
+        if loc_key:
+            existing_by_loc_key[loc_key] = loc
+        leg_key = str(loc.get("leg_loc_key") or "").strip()
+        if leg_key:
+            existing_by_leg_loc_key[leg_key] = loc
 
     locations: List[Dict[str, Any]] = [
         loc
@@ -984,9 +1018,18 @@ def merge_leg_locations_into_course(config_id: str) -> None:
         seg_id = str(seg.get("seg_id", "")).strip() if seg else ""
         event_flags = _event_flags_for_segment(seg, event_ids)
 
-        for i, loc in enumerate(_normalize_locations(entry.get("locations"))):
+        used_loc_keys: set[str] = set(existing_by_loc_key.keys())
+        for i, loc in enumerate(
+            _normalize_locations(
+                entry.get("locations"),
+                used_location_keys=used_loc_keys,
+            )
+        ):
             key = leg_loc_key(leg_id, i)
-            prev = existing_leg.get(key)
+            loc_key = str(loc.get("location_key") or "").strip()
+            prev = existing_by_loc_key.get(loc_key) if loc_key else None
+            if prev is None:
+                prev = existing_by_leg_loc_key.get(key)
             on_course = loc["loc_type"] in ON_COURSE_LOCATION_TYPES
             row: Dict[str, Any] = {
                 "loc_label": loc["loc_label"],
@@ -995,14 +1038,28 @@ def merge_leg_locations_into_course(config_id: str) -> None:
                 "lon": loc["lon"],
                 "leg_id": leg_id,
                 "leg_loc_key": key,
+                "location_key": loc_key or (prev.get("location_key") if prev else ""),
                 "placement": loc.get("placement", "along"),
                 "source": "leg",
                 "seg_id": seg_id if on_course else "",
             }
+            if not row["location_key"]:
+                ensure_location_key(row, used_loc_keys)
             for ev, flag in event_flags.items():
                 row[ev] = flag
             for ev in COURSE_EVENT_IDS:
                 row.setdefault(ev, "n")
+
+            for field in _LEG_LOC_PRESERVE_FIELDS:
+                if field in row and row[field] not in (None, ""):
+                    continue
+                val = loc.get(field)
+                if field == "resources":
+                    if isinstance(val, dict):
+                        row[field] = val
+                    continue
+                if val not in (None, ""):
+                    row[field] = val
 
             if prev:
                 prev_id = parse_location_id(prev.get("id", prev.get("loc_id")))
@@ -1259,6 +1316,7 @@ def sync_leg_location_metadata_from_course(config_id: str) -> bool:
             "lat": loc.get("lat"),
             "lon": loc.get("lon"),
             "placement": loc.get("placement"),
+            "location_key": loc.get("location_key"),
         }
         for field in _LEG_LOC_PRESERVE_FIELDS:
             if field in leg_payload:

--- a/app/core/config_package/location_keys.py
+++ b/app/core/config_package/location_keys.py
@@ -1,0 +1,47 @@
+"""Stable authoring keys for config-package locations (Issue #780)."""
+
+from __future__ import annotations
+
+import re
+import secrets
+from typing import Any, Dict, Optional, Set
+
+# Crockford base32 (no 0/O, 1/I/L) — short keys for authoring UI.
+_LOCATION_KEY_ALPHABET = "23456789ABCDEFGHJKMNPQRSTUVWXYZ"
+LOCATION_KEY_LENGTH = 5
+LOCATION_KEY_RE = re.compile(rf"^[{_LOCATION_KEY_ALPHABET}]{{{LOCATION_KEY_LENGTH}}}$")
+
+
+def is_valid_location_key(value: Any) -> bool:
+    if value is None:
+        return False
+    return bool(LOCATION_KEY_RE.match(str(value).strip()))
+
+
+def generate_location_key(used: Optional[Set[str]] = None) -> str:
+    """Allocate a unique short location_key (5-char Crockford base32)."""
+    taken = {str(k).strip() for k in (used or set()) if k}
+    for _ in range(256):
+        key = "".join(
+            secrets.choice(_LOCATION_KEY_ALPHABET) for _ in range(LOCATION_KEY_LENGTH)
+        )
+        if key not in taken:
+            return key
+    raise RuntimeError("Could not allocate location_key")
+
+
+def ensure_location_key(
+    loc: Dict[str, Any],
+    used: Optional[Set[str]] = None,
+) -> str:
+    """Ensure ``loc`` has a valid ``location_key``; return the key."""
+    existing = str(loc.get("location_key") or "").strip()
+    taken = {str(k).strip() for k in (used or set()) if k}
+    if is_valid_location_key(existing) and existing not in taken:
+        loc["location_key"] = existing
+        taken.add(existing)
+        return existing
+    key = generate_location_key(taken)
+    loc["location_key"] = key
+    taken.add(key)
+    return key

--- a/app/core/config_package/org_leg_library.py
+++ b/app/core/config_package/org_leg_library.py
@@ -37,6 +37,20 @@ def _manifest_path() -> Path:
     return get_org_legs_dir() / MANIFEST_YAML
 
 
+def save_org_leg_manifest(manifest: Dict[str, Any]) -> Path:
+    """Persist org leg library manifest."""
+    import yaml
+
+    org_dir = get_org_legs_dir()
+    org_dir.mkdir(parents=True, exist_ok=True)
+    path = _manifest_path()
+    manifest.setdefault("version", 2)
+    manifest.setdefault("label", "Org leg library")
+    with open(path, "w", encoding="utf-8") as fh:
+        yaml.safe_dump(manifest, fh, sort_keys=False, allow_unicode=True)
+    return path
+
+
 def load_org_leg_manifest() -> Dict[str, Any]:
     path = _manifest_path()
     if not path.is_file():
@@ -143,3 +157,70 @@ def import_org_leg_to_package(config_id: str, org_leg_id: str) -> Dict[str, Any]
     state["imported_org_leg_id"] = org_leg_id
     state["imported_package_leg_id"] = new_id
     return state
+
+
+def publish_package_leg_to_org_library(config_id: str, leg_id: str) -> Dict[str, Any]:
+    """
+    Copy a package leg (GPX + metadata + locations) into the org leg library.
+
+    Returns summary with ``org_leg_id`` assigned in the org manifest.
+    """
+    from app.core.config_package.legs import _find_leg_index
+
+    cid = validate_config_id(config_id)
+    leg_id = str(leg_id).strip()
+    if not leg_id:
+        raise ValueError("leg_id is required")
+
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    manifest = load_package_segment_manifest(cid)
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    idx = _find_leg_index(legs, leg_id)
+    if idx < 0:
+        raise ValueError(f"Leg not found: {leg_id}")
+    source = dict(legs[idx])
+    file_name = str(source.get("file") or "").strip()
+    if not file_name:
+        raise ValueError(f"Leg {leg_id} has no GPX file")
+    src_gpx = lib_dir / file_name
+    if not src_gpx.is_file():
+        raise FileNotFoundError(f"GPX not found: {file_name}")
+
+    org_manifest = load_org_leg_manifest()
+    org_dir = get_org_legs_dir()
+    org_dir.mkdir(parents=True, exist_ok=True)
+    org_legs: List[Dict[str, Any]] = list(manifest_legs(org_manifest))
+    org_id = allocate_next_leg_id(org_legs)
+
+    stem = file_name
+    if "_" in stem:
+        stem = stem.split("_", 1)[-1]
+    dest_name = f"{org_id}_{stem}" if stem.lower().endswith(".gpx") else f"{org_id}.gpx"
+    shutil.copy2(src_gpx, org_dir / dest_name)
+
+    entry = {
+        "id": org_id,
+        "file": dest_name,
+        "seg_label": str(source.get("seg_label") or leg_id).strip() or leg_id,
+        "start_label": str(source.get("start_label") or "").strip(),
+        "end_label": str(source.get("end_label") or "").strip(),
+        "width_m": source.get("width_m", 3),
+        "schema": source.get("schema", "on_course_open"),
+        "direction": source.get("direction", "uni"),
+        "description": str(source.get("description") or "").strip(),
+        "flow_type": source.get("flow_type"),
+        "flow_notes": source.get("flow_notes"),
+        "locations": source.get("locations") or [],
+    }
+    entry = {k: v for k, v in entry.items() if v not in (None, "")}
+    org_legs.append(entry)
+    set_manifest_legs(org_manifest, org_legs)
+    save_org_leg_manifest(org_manifest)
+    return {
+        "org_leg_id": org_id,
+        "package_leg_id": leg_id,
+        "file": dest_name,
+        "leg_label": entry.get("seg_label"),
+        "location_count": len(entry.get("locations") or []),
+    }

--- a/app/core/config_package/org_leg_library.py
+++ b/app/core/config_package/org_leg_library.py
@@ -1,0 +1,145 @@
+"""
+Org-level leg library outside config packages (Issue #780).
+
+Legs live under ``{runflow}/org/legs/`` with the same manifest + GPX layout as a
+package ``segment_library/``. Packages import copies with freshly allocated ids.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+from typing import Any, Dict, List
+
+from app.core.config_package.legs import allocate_next_leg_id, leg_row_from_entry
+from app.core.config_package.segment_recipes import (
+    load_package_segment_manifest,
+    package_segment_library_dir,
+    save_package_segment_manifest,
+)
+from app.core.config_package.storage import resolve_config_package_path, validate_config_id
+from app.core.course.segment_library import (
+    manifest_legs,
+    parse_leg_gpx,
+    set_manifest_legs,
+)
+from app.utils.run_id import get_runflow_root
+
+ORG_LEGS_DIRNAME = "legs"
+MANIFEST_YAML = "manifest.yaml"
+
+
+def get_org_legs_dir() -> Path:
+    return get_runflow_root() / "org" / ORG_LEGS_DIRNAME
+
+
+def _manifest_path() -> Path:
+    return get_org_legs_dir() / MANIFEST_YAML
+
+
+def load_org_leg_manifest() -> Dict[str, Any]:
+    path = _manifest_path()
+    if not path.is_file():
+        return {"version": 2, "label": "Org leg library", "legs": [], "recipes": {}}
+    import yaml
+
+    with open(path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh) or {}
+    if not isinstance(data, dict):
+        raise ValueError("Invalid org leg manifest")
+    data.setdefault("legs", [])
+    return data
+
+
+def list_org_legs() -> List[Dict[str, Any]]:
+    """Summarize org library legs for picker UI."""
+    manifest = load_org_leg_manifest()
+    lib_dir = get_org_legs_dir()
+    rows: List[Dict[str, Any]] = []
+    for entry in manifest_legs(manifest) or []:
+        if not isinstance(entry, dict):
+            continue
+        leg_id = str(entry.get("id", "")).strip()
+        if not leg_id:
+            continue
+        loaded: Dict[str, Any] = {}
+        file_name = entry.get("file")
+        if file_name:
+            gpx_path = lib_dir / str(file_name)
+            if gpx_path.is_file():
+                try:
+                    loaded = parse_leg_gpx(gpx_path)
+                    loaded["file"] = gpx_path.name
+                except ValueError:
+                    pass
+        row = leg_row_from_entry(entry, loaded)
+        row["org_leg_id"] = leg_id
+        rows.append(row)
+    return rows
+
+
+def import_org_leg_to_package(config_id: str, org_leg_id: str) -> Dict[str, Any]:
+    """
+    Copy one org-library leg (GPX + metadata) into a config package.
+
+    The package receives a new system-assigned leg id when the org id is taken.
+    """
+    from app.core.config_package.segment_recipes import get_package_segment_library_state
+
+    cid = validate_config_id(config_id)
+    org_leg_id = str(org_leg_id).strip()
+    if not org_leg_id:
+        raise ValueError("org_leg_id is required")
+
+    org_manifest = load_org_leg_manifest()
+    org_dir = get_org_legs_dir()
+    source = None
+    for entry in manifest_legs(org_manifest) or []:
+        if isinstance(entry, dict) and str(entry.get("id", "")).strip() == org_leg_id:
+            source = dict(entry)
+            break
+    if not source:
+        raise ValueError(f"Org leg not found: {org_leg_id}")
+
+    file_name = str(source.get("file") or "").strip()
+    if not file_name:
+        raise ValueError(f"Org leg {org_leg_id} has no GPX file")
+    src_gpx = org_dir / file_name
+    if not src_gpx.is_file():
+        raise FileNotFoundError(f"Org GPX not found: {file_name}")
+
+    package_path = resolve_config_package_path(cid)
+    lib_dir = package_segment_library_dir(package_path)
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    manifest = load_package_segment_manifest(cid)
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+
+    new_id = allocate_next_leg_id(legs)
+    label = str(source.get("seg_label") or org_leg_id).strip() or org_leg_id
+    dest_name = f"{new_id}_{file_name.split('_', 1)[-1] if '_' in file_name else file_name}"
+    if not dest_name.lower().endswith(".gpx"):
+        dest_name = f"{new_id}.gpx"
+    shutil.copy2(src_gpx, lib_dir / dest_name)
+
+    entry = {
+        "id": new_id,
+        "file": dest_name,
+        "seg_label": label,
+        "start_label": str(source.get("start_label") or "").strip(),
+        "end_label": str(source.get("end_label") or "").strip(),
+        "width_m": source.get("width_m", 3),
+        "schema": source.get("schema", "on_course_open"),
+        "direction": source.get("direction", "uni"),
+        "description": str(source.get("description") or "").strip(),
+        "flow_type": source.get("flow_type"),
+        "flow_notes": source.get("flow_notes"),
+        "locations": source.get("locations") or [],
+    }
+    entry = {k: v for k, v in entry.items() if v not in (None, "")}
+    legs.append(entry)
+    set_manifest_legs(manifest, legs)
+    save_package_segment_manifest(cid, manifest)
+    state = get_package_segment_library_state(cid)
+    state["imported_org_leg_id"] = org_leg_id
+    state["imported_package_leg_id"] = new_id
+    return state

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -192,6 +192,22 @@ def _leg_id_from_filename(filename: str) -> str:
     return stem[:24]
 
 
+def _remediate_duplicate_leg_ids(legs: List[Dict[str, Any]]) -> None:
+    """Reassign duplicate leg ids so each manifest row has a unique id (#780)."""
+    from app.core.config_package.legs import allocate_next_leg_id
+
+    seen: set[str] = set()
+    for entry in legs:
+        if not isinstance(entry, dict):
+            continue
+        lid = str(entry.get("id", "")).strip()
+        if lid and lid not in seen:
+            seen.add(lid)
+            continue
+        entry["id"] = allocate_next_leg_id(legs)
+        seen.add(str(entry["id"]))
+
+
 def sync_manifest_legs_from_gpx(
     lib_dir: Path,
     manifest: Optional[Dict[str, Any]] = None,
@@ -199,8 +215,11 @@ def sync_manifest_legs_from_gpx(
     """
     Ensure manifest lists every leg GPX in lib_dir (except 00_* combined routes).
 
-    New files get default metadata; existing entries keep seg_id, width, recipes, etc.
+    Existing legs match by ``file`` name and keep their id. New GPX files receive
+    the next system-assigned id (not the numeric filename prefix).
     """
+    from app.core.config_package.legs import allocate_next_leg_id
+
     manifest = normalize_library_manifest(dict(manifest or _default_manifest()))
     existing_by_file = {
         str(c.get("file", "")): c
@@ -212,12 +231,13 @@ def sync_manifest_legs_from_gpx(
         name = gpx_path.name
         if name.startswith("00_"):
             continue
-        cid = _leg_id_from_filename(name)
-        if not cid:
-            continue
         prior = existing_by_file.get(name) or {}
         if prior.get("id"):
-            cid = str(prior["id"])
+            cid = str(prior["id"]).strip()
+        else:
+            cid = allocate_next_leg_id(legs)
+        if not cid:
+            continue
         try:
             parsed = parse_leg_gpx(gpx_path)
         except ValueError:
@@ -241,6 +261,7 @@ def sync_manifest_legs_from_gpx(
                 "locations": prior.get("locations") or [],
             }
         )
+    _remediate_duplicate_leg_ids(legs)
     set_manifest_legs(manifest, legs)
     return manifest
 
@@ -627,6 +648,7 @@ def import_gpx_files_to_library(
     lib_dir.mkdir(parents=True, exist_ok=True)
     saved_gpx: List[str] = []
     exports_by_leg_id: Dict[str, Dict[str, Any]] = {}
+    exports_by_gpx_file: Dict[str, Dict[str, Any]] = {}
     for name, data in uploads:
         safe = Path(name).name
         lower = safe.lower()
@@ -641,6 +663,9 @@ def import_gpx_files_to_library(
             )
             if leg_id:
                 exports_by_leg_id[leg_id] = leg_export
+            gpx_file = str(leg_export.get("gpx_file") or "").strip()
+            if gpx_file:
+                exports_by_gpx_file[gpx_file] = leg_export
             dest = lib_dir / safe
             dest.write_bytes(data)
             continue
@@ -653,6 +678,8 @@ def import_gpx_files_to_library(
         raise ValueError("No .gpx files uploaded")
     manifest = load_package_segment_manifest(config_id)
     manifest = sync_manifest_legs_from_gpx(lib_dir, manifest)
-    manifest = apply_leg_exports_to_manifest(manifest, exports_by_leg_id)
+    manifest = apply_leg_exports_to_manifest(
+        manifest, exports_by_leg_id, exports_by_gpx_file=exports_by_gpx_file
+    )
     save_package_segment_manifest(config_id, manifest)
     return get_package_segment_library_state(config_id)

--- a/app/core/locations/schema.py
+++ b/app/core/locations/schema.py
@@ -199,7 +199,21 @@ def normalize_location_record(
         except (TypeError, ValueError):
             out[key] = defaults[key]
 
-    for key in ("proxy_loc_id", "seg_id", "day", "zone", "equipment", "contact", "notes", "loc_label"):
+    for key in (
+        "proxy_loc_id",
+        "seg_id",
+        "day",
+        "zone",
+        "equipment",
+        "contact",
+        "notes",
+        "loc_label",
+        "location_key",
+        "leg_loc_key",
+        "leg_id",
+        "placement",
+        "source",
+    ):
         if out.get(key) is None:
             out[key] = ""
         else:

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -40,6 +40,7 @@ from app.core.config_package.legs import (
     update_package_leg,
     update_package_leg_geometry,
 )
+from app.core.config_package.org_leg_library import import_org_leg_to_package, list_org_legs
 from app.core.config_package.segment_recipes import (
     apply_package_recipes,
     get_event_route_preview,
@@ -556,6 +557,34 @@ async def api_delete_package_leg(
     require_auth(request)
     try:
         state = delete_package_leg(config_id, leg_id)
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/api/org/legs")
+async def api_list_org_legs(request: Request) -> JSONResponse:
+    """List legs in the org-level library (runflow/org/legs/)."""
+    require_auth(request)
+    try:
+        legs = list_org_legs()
+        return JSONResponse(content={"ok": True, "legs": legs})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/config/packages/{config_id}/segment-library/import-org-leg/{org_leg_id}")
+async def api_import_org_leg(
+    request: Request,
+    config_id: str,
+    org_leg_id: str,
+) -> JSONResponse:
+    """Copy one org-library leg into the package segment library."""
+    require_auth(request)
+    try:
+        state = import_org_leg_to_package(config_id, org_leg_id)
         return JSONResponse(content={"ok": True, **state})
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -40,7 +40,11 @@ from app.core.config_package.legs import (
     update_package_leg,
     update_package_leg_geometry,
 )
-from app.core.config_package.org_leg_library import import_org_leg_to_package, list_org_legs
+from app.core.config_package.org_leg_library import (
+    import_org_leg_to_package,
+    list_org_legs,
+    publish_package_leg_to_org_library,
+)
 from app.core.config_package.segment_recipes import (
     apply_package_recipes,
     get_event_route_preview,
@@ -571,6 +575,23 @@ async def api_list_org_legs(request: Request) -> JSONResponse:
     try:
         legs = list_org_legs()
         return JSONResponse(content={"ok": True, "legs": legs})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/config/packages/{config_id}/segment-library/legs/{leg_id}/publish-to-org")
+async def api_publish_leg_to_org_library(
+    request: Request,
+    config_id: str,
+    leg_id: str,
+) -> JSONResponse:
+    """Publish one package leg to the org-level leg library."""
+    require_auth(request)
+    try:
+        result = publish_package_leg_to_org_library(config_id, leg_id)
+        return JSONResponse(content={"ok": True, **result})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -1469,9 +1469,17 @@ document.addEventListener('DOMContentLoaded', function () {
         var row = document.getElementById('locations-thead-row');
         if (!row) return;
         row.innerHTML = '';
-        ['ID', 'Type', 'Label', 'Zone'].forEach(function (text) {
+        [
+            { text: 'ID', title: 'Crew-facing loc_id (stable across re-apply)' },
+            { text: 'Key', title: 'Stable internal location_key' },
+            'Type',
+            'Label',
+            'Zone'
+        ].forEach(function (col) {
             var th = document.createElement('th');
+            var text = typeof col === 'string' ? col : col.text;
             th.textContent = text;
+            if (typeof col === 'object' && col.title) th.title = col.title;
             row.appendChild(th);
         });
         getPackageResources().forEach(function (res) {
@@ -3756,6 +3764,12 @@ document.addEventListener('DOMContentLoaded', function () {
             });
             idCell.appendChild(idBtn);
             tr.appendChild(idCell);
+            var keyTd = document.createElement('td');
+            keyTd.textContent = (loc.location_key && String(loc.location_key).trim())
+                ? String(loc.location_key).trim()
+                : '—';
+            keyTd.title = 'Stable authoring key (internal)';
+            tr.appendChild(keyTd);
             tr.appendChild(document.createElement('td')).textContent = typeLabel;
             tr.appendChild(document.createElement('td')).textContent = loc.loc_label || '';
             tr.appendChild(document.createElement('td')).textContent =
@@ -3811,6 +3825,7 @@ document.addEventListener('DOMContentLoaded', function () {
         var totalTr = document.createElement('tr');
         totalTr.className = 'locations-totals-row';
         totalTr.appendChild(document.createElement('td')).textContent = 'Total';
+        totalTr.appendChild(document.createElement('td')).textContent = '';
         totalTr.appendChild(document.createElement('td')).textContent = '';
         totalTr.appendChild(document.createElement('td')).textContent = '';
         totalTr.appendChild(document.createElement('td')).textContent = '';

--- a/frontend/static/js/map/location_grid_editor.js
+++ b/frontend/static/js/map/location_grid_editor.js
@@ -13,7 +13,7 @@
     var dirty = false;
     var rowMaps = {};
 
-    var COLLAPSED_COLS = 9;
+    var COLLAPSED_COLS = 10;
 
     var BULK_FIELDS = [
         { key: 'zone', label: 'Zone', type: 'text' },
@@ -443,6 +443,7 @@
             { key: '_expand', label: '', width: 36 },
             { key: '_select', label: '', width: 40 },
             { key: 'id', label: 'ID', width: 48 },
+            { key: 'location_key', label: 'Key', width: 56 },
             { key: 'loc_label', label: 'Label', width: 140 },
             { key: 'loc_type', label: 'Type', width: 88 },
             { key: 'zone', label: 'Zone', width: 72 },
@@ -524,6 +525,13 @@
             idTd.className = 'location-grid-readonly';
             idTd.textContent = String(locationId(loc, rowIndex));
             tr.appendChild(idTd);
+
+            var keyTd = document.createElement('td');
+            keyTd.className = 'location-grid-readonly';
+            keyTd.textContent = (loc.location_key && String(loc.location_key).trim())
+                ? String(loc.location_key).trim()
+                : '—';
+            tr.appendChild(keyTd);
 
             var labelTd = document.createElement('td');
             labelTd.className = 'location-grid-readonly';

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -2083,6 +2083,166 @@
             });
     }
 
+    function setOrgLibraryStatus(msg, isError) {
+        var el = document.getElementById('org-leg-library-status');
+        if (!el) return;
+        if (!msg) {
+            el.style.display = 'none';
+            el.textContent = '';
+            return;
+        }
+        el.style.display = 'block';
+        el.textContent = msg;
+        el.style.color = isError ? '#c0392b' : '';
+    }
+
+    function closeOrgLibraryModal() {
+        var modal = document.getElementById('org-leg-library-modal');
+        if (!modal) return;
+        modal.hidden = true;
+        modal.setAttribute('aria-hidden', 'true');
+        setOrgLibraryStatus('');
+    }
+
+    function openOrgLibraryModal() {
+        var modal = document.getElementById('org-leg-library-modal');
+        if (!modal) return;
+        modal.hidden = false;
+        modal.setAttribute('aria-hidden', 'false');
+        refreshOrgLibraryModal();
+    }
+
+    function refreshOrgLibraryPublishSelect() {
+        var sel = document.getElementById('org-leg-publish-select');
+        if (!sel) return;
+        var legs = (libraryState && libraryState.legs) || [];
+        sel.innerHTML = '';
+        legs.forEach(function (leg) {
+            var opt = document.createElement('option');
+            opt.value = leg.id;
+            opt.textContent = leg.id + ' — ' + ((leg.leg_label || '').trim() || 'Leg');
+            sel.appendChild(opt);
+        });
+        var pubBtn = document.getElementById('btn-org-leg-publish');
+        if (pubBtn) pubBtn.disabled = !legs.length;
+    }
+
+    function renderOrgLibraryTable(orgLegs) {
+        var empty = document.getElementById('org-leg-library-empty');
+        var wrap = document.getElementById('org-leg-library-table-wrap');
+        var tbody = document.getElementById('org-leg-library-tbody');
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        if (!orgLegs || !orgLegs.length) {
+            if (empty) empty.style.display = 'block';
+            if (wrap) wrap.style.display = 'none';
+            return;
+        }
+        if (empty) empty.style.display = 'none';
+        if (wrap) wrap.style.display = 'block';
+        orgLegs.forEach(function (leg) {
+            var tr = document.createElement('tr');
+            var orgId = leg.org_leg_id || leg.id;
+            [
+                orgId,
+                (leg.leg_label || '').slice(0, 48),
+                leg.length_km != null ? Number(leg.length_km).toFixed(2) : '—',
+                String(leg.location_count != null ? leg.location_count : (leg.locations || []).length)
+            ].forEach(function (text) {
+                var td = document.createElement('td');
+                td.textContent = text;
+                tr.appendChild(td);
+            });
+            var actionTd = document.createElement('td');
+            var btn = document.createElement('button');
+            btn.type = 'button';
+            btn.className = 'course-btn';
+            btn.textContent = 'Add to package';
+            btn.addEventListener('click', function () {
+                importOrgLegToPackage(orgId);
+            });
+            actionTd.appendChild(btn);
+            tr.appendChild(actionTd);
+            tbody.appendChild(tr);
+        });
+    }
+
+    function refreshOrgLibraryModal() {
+        refreshOrgLibraryPublishSelect();
+        setOrgLibraryStatus('Loading org library…');
+        fetch('/api/org/legs', { credentials: 'same-origin' })
+            .then(function (r) {
+                return r.json().then(function (d) {
+                    if (!r.ok) throw new Error(formatApiError(r, d));
+                    return d;
+                });
+            })
+            .then(function (data) {
+                renderOrgLibraryTable(data.legs || []);
+                setOrgLibraryStatus('');
+            })
+            .catch(function (err) {
+                setOrgLibraryStatus(err.message || String(err), true);
+            });
+    }
+
+    function importOrgLegToPackage(orgLegId) {
+        setOrgLibraryStatus('Adding org leg ' + orgLegId + '…');
+        fetch(
+            apiBase() + '/segment-library/import-org-leg/' + encodeURIComponent(orgLegId),
+            { method: 'POST', credentials: 'same-origin' }
+        )
+            .then(function (r) {
+                return r.json().then(function (d) {
+                    if (!r.ok) throw new Error(formatApiError(r, d));
+                    return d;
+                });
+            })
+            .then(function (data) {
+                libraryState = data;
+                renderLegsTable();
+                renderRecipeTable();
+                setOrgLibraryStatus(
+                    'Added org leg ' + orgLegId + ' as package leg ' +
+                        (data.imported_package_leg_id || '') + '.'
+                );
+                setLegStatus('Imported org leg ' + orgLegId + '.');
+            })
+            .catch(function (err) {
+                setOrgLibraryStatus(err.message || String(err), true);
+            });
+    }
+
+    function publishLegToOrgLibrary() {
+        var sel = document.getElementById('org-leg-publish-select');
+        var legId = sel && sel.value;
+        if (!legId) {
+            setOrgLibraryStatus('Select a package leg to publish.', true);
+            return;
+        }
+        setOrgLibraryStatus('Publishing leg ' + legId + '…');
+        fetch(
+            apiBase() + '/segment-library/legs/' + encodeURIComponent(legId) + '/publish-to-org',
+            { method: 'POST', credentials: 'same-origin' }
+        )
+            .then(function (r) {
+                return r.json().then(function (d) {
+                    if (!r.ok) throw new Error(formatApiError(r, d));
+                    return d;
+                });
+            })
+            .then(function (data) {
+                setOrgLibraryStatus(
+                    'Published as org leg ' + (data.org_leg_id || '') +
+                        ' (' + (data.leg_label || '') + ').'
+                );
+                refreshOrgLibraryModal();
+            })
+            .catch(function (err) {
+                setOrgLibraryStatus(err.message || String(err), true);
+            });
+    }
+
     function exportLeg(legId) {
         var leg = (libraryState && libraryState.legs || []).find(function (c) {
             return c.id === legId;
@@ -2948,6 +3108,18 @@
         if (exportAllBtn) {
             exportAllBtn.addEventListener('click', exportAllLegs);
         }
+        var orgLibBtn = document.getElementById('btn-org-leg-library');
+        if (orgLibBtn) {
+            orgLibBtn.addEventListener('click', openOrgLibraryModal);
+        }
+        var orgLibClose = document.getElementById('org-leg-library-close');
+        if (orgLibClose) orgLibClose.addEventListener('click', closeOrgLibraryModal);
+        var orgLibDone = document.getElementById('org-leg-library-done');
+        if (orgLibDone) orgLibDone.addEventListener('click', closeOrgLibraryModal);
+        var orgLibBackdrop = document.querySelector('#org-leg-library-modal .course-location-modal-backdrop');
+        if (orgLibBackdrop) orgLibBackdrop.addEventListener('click', closeOrgLibraryModal);
+        var orgPublishBtn = document.getElementById('btn-org-leg-publish');
+        if (orgPublishBtn) orgPublishBtn.addEventListener('click', publishLegToOrgLibrary);
         if (bulkInput) {
             bulkInput.addEventListener('change', function () {
                 uploadGpxBulk(bulkInput.files);

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -78,14 +78,15 @@
                 <div class="card-actions course-planner-toolbar config-legs-table-toolbar">
                 <input type="file" id="segment-library-gpx-input" accept=".gpx,.json" multiple style="display: none;" />
                 <button type="button" id="btn-import-gpx" class="course-btn" title="Import GPX routes and optional leg export JSON (locations + metadata)">Import legs…</button>
+                <button type="button" id="btn-org-leg-library" class="course-btn" title="Add legs from your organization library or publish legs for reuse">Org library…</button>
                 <button type="button" id="btn-export-all-legs" class="course-btn" disabled title="Download all legs (GPX + metadata + locations per leg)">Export legs…</button>
                 <button type="button" id="btn-draw-leg-map" class="course-btn" disabled title="Coming soon: draw a new leg on the map">Draw leg on map</button>
                 </div>
             </div>
             <p class="card-help course-derived-empty">
-                Import GPX files, then select a leg in the table (use <strong>Edit</strong> on that row for leg details).
-                Set <strong>Proxy loc ID</strong> on the
-                <button type="button" id="btn-go-to-recipes" class="course-link-btn">Course</button> tab.
+                <strong>Import legs…</strong> uploads GPX (+ optional JSON). <strong>Org library…</strong> reuses legs shared across races.
+                Select a leg in the table (<strong>Edit</strong> for details). After <strong>Apply recipes</strong>, locations sync to the
+                <button type="button" id="btn-go-to-recipes" class="course-link-btn">Course</button> tab — <strong>ID</strong> stays stable; <strong>Key</strong> is the internal anchor.
             </p>
             <p id="course-legs-status" class="course-derived-empty" style="display: none;"></p>
             <div id="course-legs-table-wrap" class="config-legs-table-region" style="display: none;">
@@ -158,12 +159,12 @@
                     <button type="button" id="btn-manage-resources" class="course-map-action-text-btn" title="Define schedulable resources">Manage resources</button>
                 </div>
             </div>
-            <p id="locations-empty" class="card-help course-derived-empty">Locations appear here after you save event recipes. Placements from the Legs tab map sync when you open this tab. Edit resources, segment ID, and remove locations here.</p>
+            <p id="locations-empty" class="card-help course-derived-empty">Locations appear here after you apply event recipes. Leg placements sync from the Legs tab. <strong>ID</strong> is the crew-facing <code>loc_id</code> in exports; <strong>Key</strong> is a stable internal reference that keeps the same ID when you re-apply recipes.</p>
             <div id="locations-table-wrap" style="display: none;">
                 <div class="scrollable-table-container course-derived-table-scroll">
                     <table id="locations-table" class="table-sticky-header" style="width: 100%; font-size: 0.875rem;">
                         <thead>
-                            <tr id="locations-thead-row"><th>ID</th><th>Type</th><th>Label</th><th>Zone</th><th></th></tr>
+                            <tr id="locations-thead-row"><th>ID</th><th title="Stable authoring key (internal)">Key</th><th>Type</th><th>Label</th><th>Zone</th><th></th></tr>
                         </thead>
                         <tbody id="locations-tbody"></tbody>
                     </table>
@@ -331,6 +332,48 @@
         <div class="course-location-modal-footer">
             <button type="button" id="resources-editor-save" class="course-btn primary">Save resources</button>
             <button type="button" id="resources-editor-cancel" class="course-btn">Cancel</button>
+        </div>
+    </div>
+</div>
+
+<div id="org-leg-library-modal" class="course-location-modal" hidden aria-hidden="true">
+    <div class="course-location-modal-backdrop"></div>
+    <div class="course-location-modal-panel segment-recipes-modal-panel" role="dialog" aria-labelledby="org-leg-library-title">
+        <div class="course-location-modal-header">
+            <h4 id="org-leg-library-title" class="course-derived-heading" style="margin: 0;">Organization leg library</h4>
+            <button type="button" id="org-leg-library-close" aria-label="Close">&times;</button>
+        </div>
+        <div class="course-location-modal-body">
+            <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;">
+                Shared legs live outside this package. <strong>Add to package</strong> copies a leg here with a new package ID.
+                <strong>Publish to org</strong> saves the selected package leg for other races.
+            </p>
+            <p id="org-leg-library-status" class="course-derived-empty" style="display: none;"></p>
+            <h5 class="course-derived-heading" style="margin: 0.5rem 0;">Org legs</h5>
+            <div id="org-leg-library-empty" class="card-help course-derived-empty">No org legs yet. Publish a leg from this package below.</div>
+            <div id="org-leg-library-table-wrap" class="scrollable-table-container course-derived-table-scroll" style="display: none; max-height: 220px;">
+                <table class="table-sticky-header course-planner-table" style="width: 100%; font-size: 0.875rem;">
+                    <thead>
+                        <tr>
+                            <th>ID</th>
+                            <th>Label</th>
+                            <th>km</th>
+                            <th>Locs</th>
+                            <th></th>
+                        </tr>
+                    </thead>
+                    <tbody id="org-leg-library-tbody"></tbody>
+                </table>
+            </div>
+            <h5 class="course-derived-heading" style="margin: 1rem 0 0.5rem 0;">Publish from this package</h5>
+            <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
+                <label for="org-leg-publish-select" style="font-size: 0.875rem;">Package leg</label>
+                <select id="org-leg-publish-select" class="course-input" style="min-width: 12rem;"></select>
+                <button type="button" id="btn-org-leg-publish" class="course-btn">Publish to org library</button>
+            </div>
+        </div>
+        <div class="course-location-modal-footer">
+            <button type="button" id="org-leg-library-done" class="course-btn primary">Done</button>
         </div>
     </div>
 </div>

--- a/tests/unit/test_location_keys.py
+++ b/tests/unit/test_location_keys.py
@@ -1,0 +1,32 @@
+"""Tests for stable location_key allocation (Issue #780)."""
+
+import re
+
+from app.core.config_package.location_keys import (
+    LOCATION_KEY_RE,
+    ensure_location_key,
+    generate_location_key,
+    is_valid_location_key,
+)
+
+
+def test_generate_location_key_format():
+    key = generate_location_key()
+    assert is_valid_location_key(key)
+    assert LOCATION_KEY_RE.match(key)
+
+
+def test_ensure_location_key_preserves_existing():
+    used = set()
+    loc = {"location_key": "ABCDE", "loc_label": "A"}
+    assert ensure_location_key(loc, used) == "ABCDE"
+    assert loc["location_key"] == "ABCDE"
+
+
+def test_ensure_location_key_allocates_when_missing():
+    used = {"ABCDE"}
+    loc = {"loc_label": "B"}
+    key = ensure_location_key(loc, used)
+    assert is_valid_location_key(key)
+    assert key != "ABCDE"
+    assert loc["location_key"] == key

--- a/tests/unit/test_org_leg_library.py
+++ b/tests/unit/test_org_leg_library.py
@@ -2,7 +2,11 @@
 
 import yaml
 
-from app.core.config_package.org_leg_library import import_org_leg_to_package, list_org_legs
+from app.core.config_package.org_leg_library import (
+    import_org_leg_to_package,
+    list_org_legs,
+    publish_package_leg_to_org_library,
+)
 from app.core.config_package.storage import create_config_package
 
 _GPX = """<?xml version="1.0"?>
@@ -56,3 +60,54 @@ def test_list_and_import_org_leg(tmp_path, monkeypatch):
     assert state["imported_package_leg_id"] == "01"
     assert len(state["legs"]) == 1
     assert state["legs"][0]["leg_label"] == "Org trail"
+
+
+def test_publish_package_leg_to_org_library(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path / "config",
+    )
+    monkeypatch.setattr(
+        "app.core.config_package.org_leg_library.get_runflow_root",
+        lambda: tmp_path,
+    )
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    package_path = tmp_path / "config" / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    (lib_dir / "01_trail.gpx").write_text(_GPX, encoding="utf-8")
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "file": "01_trail.gpx",
+                        "seg_label": "Package trail",
+                        "locations": [
+                            {
+                                "loc_label": "Water",
+                                "loc_type": "water",
+                                "lat": 45.961,
+                                "lon": -66.642,
+                                "placement": "along",
+                            }
+                        ],
+                    }
+                ],
+                "recipes": {},
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    published = publish_package_leg_to_org_library(config_id, "01")
+    assert published["org_leg_id"] == "01"
+    assert published["package_leg_id"] == "01"
+
+    rows = list_org_legs()
+    assert len(rows) == 1
+    assert rows[0]["leg_label"] == "Package trail"
+    assert rows[0]["location_count"] == 1

--- a/tests/unit/test_org_leg_library.py
+++ b/tests/unit/test_org_leg_library.py
@@ -1,0 +1,58 @@
+"""Tests for org-level leg library (Issue #780)."""
+
+import yaml
+
+from app.core.config_package.org_leg_library import import_org_leg_to_package, list_org_legs
+from app.core.config_package.storage import create_config_package
+
+_GPX = """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><name>Org trail</name><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>"""
+
+
+def test_list_and_import_org_leg(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path / "config",
+    )
+    monkeypatch.setattr(
+        "app.core.config_package.org_leg_library.get_runflow_root",
+        lambda: tmp_path,
+    )
+
+    org_dir = tmp_path / "org" / "legs"
+    org_dir.mkdir(parents=True)
+    (org_dir / "05_org_trail.gpx").write_text(_GPX, encoding="utf-8")
+    (org_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "05",
+                        "file": "05_org_trail.gpx",
+                        "seg_label": "Org trail",
+                        "start_label": "Start",
+                        "end_label": "End",
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    rows = list_org_legs()
+    assert len(rows) == 1
+    assert rows[0]["org_leg_id"] == "05"
+    assert rows[0]["leg_label"] == "Org trail"
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    state = import_org_leg_to_package(config_id, "05")
+    assert state["imported_org_leg_id"] == "05"
+    assert state["imported_package_leg_id"] == "01"
+    assert len(state["legs"]) == 1
+    assert state["legs"][0]["leg_label"] == "Org trail"

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -1448,3 +1448,133 @@ def test_flow_type_propagates_to_segments_and_flow_csv(tmp_path, monkeypatch):
     csv_text = build_flow_csv_from_segments(segments, ["full", "10k"])
     assert ",counterflow," in csv_text
     assert "Shared trail" in csv_text
+
+
+def test_merge_preserves_loc_id_via_location_key(tmp_path, monkeypatch):
+    """Re-merge keeps loc_id when location_key matches (#780)."""
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package("Loc key", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Leg",
+                        "file": "01.gpx",
+                        "locations": [
+                            {
+                                "loc_label": "Water",
+                                "loc_type": "water",
+                                "lat": 45.961,
+                                "lon": -66.642,
+                                "placement": "along",
+                                "location_key": "WATER",
+                                "notes": "North side",
+                            }
+                        ],
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (lib_dir / "01.gpx").write_text(
+        """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>""",
+        encoding="utf-8",
+    )
+    course_path = package_path / "course.json"
+    course = load_config_course(config_id)
+    course["segment_library_applied"] = True
+    course["segments"] = [{"seg_id": "S1", "leg_id": "01", "events": ["full"]}]
+    course_path.write_text(json.dumps(course, indent=2))
+
+    merge_leg_locations_into_course(config_id)
+    first = load_config_course(config_id)["locations"][0]
+    first_id = first["id"]
+    assert first.get("location_key") == "WATER"
+    assert first.get("notes") == "North side"
+
+    merge_leg_locations_into_course(config_id)
+    second = load_config_course(config_id)["locations"][0]
+    assert second["id"] == first_id
+    assert second.get("location_key") == "WATER"
+
+
+def test_leg_export_v2_includes_full_location_fields(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package("Export v2", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    package_path = tmp_path / config_id
+    lib_dir = package_path / "segment_library"
+    lib_dir.mkdir(parents=True, exist_ok=True)
+    import yaml
+
+    (lib_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "01",
+                        "seg_label": "Trail",
+                        "file": "01.gpx",
+                        "schema": "on_course_narrow",
+                        "direction": "bi",
+                        "width_m": 4,
+                        "locations": [
+                            {
+                                "loc_label": "Aid",
+                                "loc_type": "aid",
+                                "lat": 45.961,
+                                "lon": -66.642,
+                                "placement": "along",
+                                "notes": "Tent A",
+                                "buffer": 15,
+                                "zone": "A",
+                            }
+                        ],
+                    }
+                ],
+                "recipes": {"full": ["01"]},
+            }
+        ),
+        encoding="utf-8",
+    )
+    (lib_dir / "01.gpx").write_text(
+        """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>""",
+        encoding="utf-8",
+    )
+
+    zip_bytes, _ = export_package_leg_zip(config_id, "01")
+    with zipfile.ZipFile(BytesIO(zip_bytes)) as zf:
+        meta = json.loads(zf.read("01.json").decode("utf-8"))
+    assert meta["export_version"] == 2
+    loc = meta["leg"]["locations"][0]
+    assert loc["notes"] == "Tent A"
+    assert loc["buffer"] == 15
+    assert loc.get("location_key")

--- a/tests/unit/test_segment_recipes_package.py
+++ b/tests/unit/test_segment_recipes_package.py
@@ -1,4 +1,4 @@
-"""Tests for config package segment recipes (#769)."""
+"""Tests for config package segment recipes (#769 / #780)."""
 
 import pytest
 
@@ -8,6 +8,15 @@ from app.core.config_package.segment_recipes import (
     recipes_from_order_grid,
     sync_manifest_legs_from_gpx,
 )
+from app.core.course.segment_library import manifest_legs
+
+_GPX_MIN = """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>"""
 
 
 def test_recipes_from_order_grid():
@@ -26,6 +35,40 @@ def test_recipes_from_order_grid():
 def test_leg_id_from_filename():
     assert _leg_id_from_filename("01_start_friel.gpx") == "01"
     assert _leg_id_from_filename("00_full.gpx") == ""
+
+
+def test_sync_manifest_legs_distinct_ids_for_shared_prefix(tmp_path):
+    """Regression: 03_A.gpx and 03_B.gpx must not both become leg id 03 (#780)."""
+    lib = tmp_path
+    (lib / "03_blake_out.gpx").write_text(_GPX_MIN, encoding="utf-8")
+    (lib / "03_blake_back.gpx").write_text(_GPX_MIN, encoding="utf-8")
+    manifest = sync_manifest_legs_from_gpx(lib)
+    ids = [str(leg["id"]) for leg in manifest_legs(manifest)]
+    assert len(ids) == 2
+    assert len(set(ids)) == 2
+
+
+def test_sync_manifest_legs_preserves_id_by_filename(tmp_path):
+    lib = tmp_path
+    (lib / "16_return.gpx").write_text(_GPX_MIN, encoding="utf-8")
+    import yaml
+
+    manifest = {
+        "legs": [
+            {
+                "id": "16",
+                "file": "16_return.gpx",
+                "seg_label": "Return",
+            }
+        ],
+        "recipes": {},
+    }
+    (lib / "manifest.yaml").write_text(yaml.safe_dump(manifest), encoding="utf-8")
+    out = sync_manifest_legs_from_gpx(lib, manifest)
+    legs = manifest_legs(out)
+    assert len(legs) == 1
+    assert legs[0]["id"] == "16"
+    assert legs[0]["file"] == "16_return.gpx"
 
 
 def test_order_grid_roundtrip():


### PR DESCRIPTION
## Summary
- **Phase A (#780 §2):** Bulk GPX import assigns system leg ids via `allocate_next_leg_id` (match existing legs by `file`); duplicate-id remediation; export JSON matched by GPX filename when ids differ
- **Phase B (#780 §1):** `location_key` (5-char Crockford base32) on leg locations; merge matches by `location_key` first to preserve `loc_id` across re-export
- **Leg export v2:** Full location metadata (notes, buffer, zone, resources, `location_key`, …) in zip JSON
- **Org leg library:** `runflow/org/legs/` manifest + GPX; `GET /api/org/legs`, `POST .../import-org-leg/{org_leg_id}`

## Test plan
- [x] `pytest tests/unit/test_location_keys.py tests/unit/test_segment_recipes_package.py tests/unit/test_org_leg_library.py tests/unit/test_package_legs.py` (45 passed)
- [ ] Import `03_A.gpx` + `03_B.gpx` on fresh package — distinct leg ids
- [ ] Apply recipes twice — existing location `loc_id` unchanged when `location_key` stable
- [ ] Populate `runflow/org/legs/manifest.yaml` + GPX; import org leg into package

## Follow-ups (not in this PR)
- Phase C: `proxy_location_key` → export int mapping
- Phase D: optional `location_key` column in `locations.csv` + crew docs
- UI: org leg picker on Legs tab


Made with [Cursor](https://cursor.com)