### PR TITLE
Org-primary leg library for recipes and apply (#780)

### DIFF
--- a/app/core/artifacts/frontend.py
+++ b/app/core/artifacts/frontend.py
@@ -585,6 +585,25 @@ def _load_schema_keys(reports_dir):
     return schema_keys
 
 
+def _resolve_schema_key(seg_id: str, schema_keys: dict, dims: dict) -> str:
+    """
+    Resolve operational schema for a segment.
+
+    Prefer bins.parquet schema_key; fall back to segments.csv ``schema`` column
+    for segments skipped by density (e.g. short connectors with no bins).
+    """
+    from_bins = schema_keys.get(seg_id)
+    if from_bins is not None and str(from_bins).strip():
+        return str(from_bins).strip()
+    for field in ("schema_key", "schema"):
+        val = dims.get(field)
+        if val is not None and str(val).strip():
+            return str(val).strip()
+    raise ValueError(
+        f"Segment {seg_id} missing schema in bins metadata and segments.csv."
+    )
+
+
 def _create_segment_feature(seg_id, segment_dims, schema_keys):
     """Create a GeoJSON feature for a segment."""
     dims = segment_dims.get(seg_id, {})
@@ -597,9 +616,7 @@ def _create_segment_feature(seg_id, segment_dims, schema_keys):
     direction = dims.get("direction")
     if not direction:
         raise ValueError(f"Segment {seg_id} missing direction in segments metadata.")
-    schema_key = schema_keys.get(seg_id)
-    if not schema_key:
-        raise ValueError(f"Segment {seg_id} missing schema_key in bins metadata.")
+    schema_key = _resolve_schema_key(seg_id, schema_keys, dims)
     
     # Issue #655: Calculate length_km from event-specific fields
     length_km = None
@@ -671,9 +688,7 @@ def _build_segment_feature_properties(seg_id, segment_dims, schema_keys):
     direction = dims.get("direction")
     if not direction:
         raise ValueError(f"Segment {seg_id} missing direction in segments metadata.")
-    schema_key = schema_keys.get(seg_id)
-    if not schema_key:
-        raise ValueError(f"Segment {seg_id} missing schema_key in bins metadata.")
+    schema_key = _resolve_schema_key(seg_id, schema_keys, dims)
     
     # Issue #655: Calculate length_km from event-specific fields
     length_km = None
@@ -920,13 +935,7 @@ def generate_segments_geojson(reports_dir: Path, analysis_context: Optional[Any]
             direction = dims.get("direction")
             if not direction:
                 raise ValueError(f"Segment {seg_id} missing direction in segments metadata.")
-            # Issue #655: Make schema_key optional - if not found in bins, try to get from segments_df or use default
-            schema_key = schema_keys.get(seg_id) or dims.get("schema_key")
-            if not schema_key:
-                raise ValueError(
-                    f"Segment {seg_id} missing schema_key in bins metadata and segments.csv. "
-                    "This is a data validation error - fail-fast."
-                )
+            schema_key = _resolve_schema_key(seg_id, schema_keys, dims)
             # Update properties with dimensions
             props["label"] = seg_label
             

--- a/app/core/artifacts/segment_maps.py
+++ b/app/core/artifacts/segment_maps.py
@@ -70,7 +70,12 @@ def export_segment_map_pngs(
 
         metrics = segment_metrics.get(seg_id)
         if not metrics or "worst_los" not in metrics:
-            raise ValueError(f"Missing worst_los for segment {seg_id} in segment_metrics.")
+            # Short or connector segments may be in geojson but skipped by density (no bins).
+            logger.warning(
+                "Skipping segment map for %s: no density metrics (missing worst_los).",
+                seg_id,
+            )
+            continue
 
         los_grade = str(metrics.get("worst_los"))
         color = los_colors.get(los_grade)

--- a/app/core/config_package/leg_library_resolver.py
+++ b/app/core/config_package/leg_library_resolver.py
@@ -1,0 +1,78 @@
+"""Resolve whether recipe legs load from org library or package segment_library."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, List, Set, Tuple
+
+from app.core.config_package.org_leg_library import get_org_legs_dir, load_org_leg_manifest
+from app.core.config_package.segment_recipes import (
+    load_package_segment_manifest,
+    package_segment_library_dir,
+)
+from app.core.config_package.storage import resolve_config_package_path, validate_config_id
+from app.core.course.segment_library import manifest_legs
+
+LEG_SOURCE_ORG = "org"
+LEG_SOURCE_PACKAGE = "package"
+
+
+def effective_leg_source(package_manifest: Dict[str, Any]) -> str:
+    """Org-primary for new packages; legacy packages with local legs stay on package."""
+    explicit = str(package_manifest.get("leg_source") or "").strip().lower()
+    if explicit in (LEG_SOURCE_ORG, LEG_SOURCE_PACKAGE):
+        return explicit
+    if manifest_legs(package_manifest):
+        return LEG_SOURCE_PACKAGE
+    return LEG_SOURCE_ORG
+
+
+def recipe_leg_ids_from_package(config_id: str) -> Set[str]:
+    """Leg ids referenced in any event recipe for this package."""
+    manifest = load_package_segment_manifest(config_id)
+    ids: Set[str] = set()
+    for seq in (manifest.get("recipes") or {}).values():
+        if not isinstance(seq, list):
+            continue
+        for raw in seq:
+            lid = str(raw).strip()
+            if lid:
+                ids.add(lid)
+    return ids
+
+
+def resolve_leg_library(
+    config_id: str,
+) -> Tuple[Path, Dict[str, Any], str, Dict[str, Any]]:
+    """
+    Return (library_dir, leg_manifest, leg_source, package_manifest).
+
+    ``leg_manifest`` holds leg GPX metadata. Recipes and flow_overrides always
+    come from the package manifest when applying/exporting.
+    """
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    pkg_manifest = load_package_segment_manifest(cid)
+    source = effective_leg_source(pkg_manifest)
+
+    if source == LEG_SOURCE_ORG:
+        org_dir = get_org_legs_dir()
+        org_manifest = load_org_leg_manifest()
+        return org_dir, org_manifest, LEG_SOURCE_ORG, pkg_manifest
+
+    lib_dir = package_segment_library_dir(package_path)
+    return lib_dir, pkg_manifest, LEG_SOURCE_PACKAGE, pkg_manifest
+
+
+def combined_manifest_for_apply(config_id: str) -> Tuple[Path, Dict[str, Any]]:
+    """Org/package leg metadata + package recipes for segment export."""
+    lib_dir, leg_manifest, _source, pkg_manifest = resolve_leg_library(config_id)
+    combined = dict(leg_manifest)
+    combined["recipes"] = pkg_manifest.get("recipes") or {}
+    combined["flow_overrides"] = (
+        pkg_manifest.get("flow_overrides")
+        or leg_manifest.get("flow_overrides")
+        or []
+    )
+    combined["label"] = pkg_manifest.get("label") or leg_manifest.get("label") or ""
+    return lib_dir, combined

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -973,8 +973,14 @@ def merge_leg_locations_into_course(config_id: str) -> None:
   notes, etc.) matched by ``leg_loc_key``. Sets ``seg_id`` from the combined
     segment whose ``leg_id`` matches the leg.
     """
+    from app.core.config_package.leg_library_resolver import (
+        recipe_leg_ids_from_package,
+        resolve_leg_library,
+    )
+
     cid = validate_config_id(config_id)
-    manifest = load_package_segment_manifest(cid)
+    _lib_dir, manifest, _leg_source, _pkg_manifest = resolve_leg_library(cid)
+    recipe_ids = recipe_leg_ids_from_package(cid)
     course = load_config_course(cid)
     segments = [
         s for s in (course.get("segments") or []) if isinstance(s, dict)
@@ -1013,6 +1019,8 @@ def merge_leg_locations_into_course(config_id: str) -> None:
             continue
         leg_id = str(entry.get("id", "")).strip()
         if not leg_id:
+            continue
+        if recipe_ids and leg_id not in recipe_ids:
             continue
         seg = _segment_for_leg(segments, leg_id)
         seg_id = str(seg.get("seg_id", "")).strip() if seg else ""

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -758,6 +758,42 @@ def _segment_for_leg(
     return None
 
 
+def _segments_for_leg(
+    segments: Sequence[Dict[str, Any]], leg_id: str
+) -> List[Dict[str, Any]]:
+    leg_id = str(leg_id).strip()
+    return [
+        seg
+        for seg in segments
+        if isinstance(seg, dict) and segment_leg_id(seg) == leg_id
+    ]
+
+
+def _seg_ids_for_leg(segments: Sequence[Dict[str, Any]], leg_id: str) -> str:
+    return ",".join(
+        str(seg.get("seg_id", "")).strip()
+        for seg in _segments_for_leg(segments, leg_id)
+        if str(seg.get("seg_id", "")).strip()
+    )
+
+
+def _event_flags_for_leg(
+    segments: Sequence[Dict[str, Any]],
+    leg_id: str,
+    event_ids: Sequence[str],
+) -> Dict[str, str]:
+    """Union event flags across all segment rows sharing a library leg."""
+    on_seg: set[str] = set()
+    for seg in _segments_for_leg(segments, leg_id):
+        for eid in seg.get("events") or []:
+            on_seg.add(str(eid).strip().lower())
+    flags: Dict[str, str] = {}
+    for eid in event_ids:
+        el = str(eid).strip().lower()
+        flags[el] = "y" if el in on_seg else "n"
+    return flags
+
+
 def _parse_location_seg_ids(seg_id_value: Any) -> List[str]:
     """Parse comma-separated seg_id(s) on a location row."""
     if seg_id_value is None:
@@ -827,8 +863,7 @@ def refresh_location_seg_ids_from_segments(
 
         leg_id = _leg_id_for_location(loc)
         if leg_id:
-            seg = _segment_for_leg(segments, leg_id)
-            new_seg = str(seg.get("seg_id", "")).strip() if seg else ""
+            new_seg = _seg_ids_for_leg(segments, leg_id)
             if new_seg != old_seg:
                 loc["seg_id"] = new_seg
                 updated += 1
@@ -1022,9 +1057,8 @@ def merge_leg_locations_into_course(config_id: str) -> None:
             continue
         if recipe_ids and leg_id not in recipe_ids:
             continue
-        seg = _segment_for_leg(segments, leg_id)
-        seg_id = str(seg.get("seg_id", "")).strip() if seg else ""
-        event_flags = _event_flags_for_segment(seg, event_ids)
+        seg_id = _seg_ids_for_leg(segments, leg_id)
+        event_flags = _event_flags_for_leg(segments, leg_id, event_ids)
 
         used_loc_keys: set[str] = set(existing_by_loc_key.keys())
         for i, loc in enumerate(

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -1329,9 +1329,15 @@ def sync_leg_location_metadata_from_course(config_id: str) -> bool:
     Course tab is master for loc_label and related fields edited there; the manifest
     is updated so Legs tab and subsequent merges stay consistent.
     """
+    from app.core.config_package.leg_library_resolver import (
+        LEG_SOURCE_ORG,
+        resolve_leg_library,
+    )
+    from app.core.config_package.org_leg_library import save_org_leg_manifest
+
     cid = validate_config_id(config_id)
     course = load_config_course(cid)
-    manifest = load_package_segment_manifest(cid)
+    _lib_dir, manifest, leg_source, _pkg_manifest = resolve_leg_library(cid)
     legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
     leg_index: Dict[str, int] = {}
     for i, entry in enumerate(legs):
@@ -1392,7 +1398,10 @@ def sync_leg_location_metadata_from_course(config_id: str) -> bool:
 
     if changed:
         set_manifest_legs(manifest, legs)
-        save_package_segment_manifest(cid, manifest)
+        if leg_source == LEG_SOURCE_ORG:
+            save_org_leg_manifest(manifest)
+        else:
+            save_package_segment_manifest(cid, manifest)
     return changed
 
 

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -1223,15 +1223,17 @@ def sync_leg_metadata_into_course(config_id: str) -> bool:
     Matches segments to manifest legs by ``leg_id`` (or ``S{n}`` order fallback).
     Does not recompute per-event km or recipe order — use ``apply_package_recipes`` for that.
     """
+    from app.core.config_package.leg_library_resolver import resolve_leg_library
+
     cid = validate_config_id(config_id)
     course = load_config_course(cid)
-    manifest = load_package_segment_manifest(cid)
-    if not _should_sync_leg_metadata_to_course(course, manifest):
+    _lib_dir, leg_manifest, _leg_source, pkg_manifest = resolve_leg_library(cid)
+    if not _should_sync_leg_metadata_to_course(course, pkg_manifest):
         return False
-    allowed_legs = recipe_leg_ids(manifest)
-    leg_order = _manifest_leg_order(manifest)
+    allowed_legs = recipe_leg_ids(pkg_manifest)
+    leg_order = _manifest_leg_order(leg_manifest)
     leg_by_id: Dict[str, Dict[str, Any]] = {}
-    for entry in manifest_legs(manifest):
+    for entry in manifest_legs(leg_manifest):
         if not isinstance(entry, dict):
             continue
         leg_id = str(entry.get("id", "")).strip()
@@ -1263,8 +1265,15 @@ def sync_leg_metadata_into_course(config_id: str) -> bool:
         if str(seg.get("to_label") or "").strip() != row["end_label"]:
             seg["to_label"] = row["end_label"]
             updated = True
-        if str(seg.get("seg_label") or "").strip() != row["leg_label"]:
-            seg["seg_label"] = row["leg_label"]
+        seg_label = row["leg_label"]
+        try:
+            occ = int(seg.get("leg_occurrence") or 1)
+        except (TypeError, ValueError):
+            occ = 1
+        if occ > 1:
+            seg_label = f"{seg_label} ({occ})"
+        if str(seg.get("seg_label") or "").strip() != seg_label:
+            seg["seg_label"] = seg_label
             updated = True
         if str(seg.get("description") or "").strip() != row["description"]:
             seg["description"] = row["description"]

--- a/app/core/config_package/org_leg_library.py
+++ b/app/core/config_package/org_leg_library.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import shutil
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional, Sequence
 
 from app.core.config_package.legs import allocate_next_leg_id, leg_row_from_entry
 from app.core.config_package.segment_recipes import (
@@ -223,4 +223,260 @@ def publish_package_leg_to_org_library(config_id: str, leg_id: str) -> Dict[str,
         "file": dest_name,
         "leg_label": entry.get("seg_label"),
         "location_count": len(entry.get("locations") or []),
+    }
+
+
+def create_org_leg(
+    gpx_bytes: bytes,
+    filename: str,
+    *,
+    leg_label: str = "",
+    start_label: str = "",
+    end_label: str = "",
+    width_m: float = 3,
+    schema: str = "on_course_open",
+    direction: str = "uni",
+    flow_type: str = "none",
+    flow_notes: str = "",
+    description: str = "",
+    locations: Optional[List[Dict[str, Any]]] = None,
+) -> Dict[str, Any]:
+    """Create a new leg in the org library from GPX."""
+    from app.utils.constants import DEFAULT_FLOW_TYPE
+    from app.core.config_package.legs import (
+        _LEG_ID_RE,
+        _default_endpoint_labels,
+        _find_leg_index,
+        _normalize_flow_notes,
+        _normalize_flow_type,
+        _normalize_leg_description,
+        _normalize_locations,
+        _normalize_segment_direction,
+        _normalize_segment_schema,
+        _slugify,
+        _validate_leg_entry,
+    )
+
+    org_dir = get_org_legs_dir()
+    org_dir.mkdir(parents=True, exist_ok=True)
+    manifest = load_org_leg_manifest()
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    new_id = allocate_next_leg_id(legs)
+    if not _LEG_ID_RE.match(new_id):
+        raise ValueError("leg_id must be two or three digits (e.g. 01, 12)")
+    if _find_leg_index(legs, new_id) >= 0:
+        raise ValueError(f"Leg id already exists: {new_id}")
+
+    label = (leg_label or Path(filename).stem.replace("_", " ")).strip() or f"Leg {new_id}"
+    safe_name = f"{new_id}_{_slugify(label)}.gpx"
+    dest = org_dir / safe_name
+    dest.write_bytes(gpx_bytes)
+    parsed = parse_leg_gpx(dest)
+
+    s_label = start_label.strip() or _default_endpoint_labels(label, parsed)[0]
+    e_label = end_label.strip() or _default_endpoint_labels(label, parsed)[1]
+    entry = {
+        "id": new_id,
+        "file": safe_name,
+        "seg_label": label,
+        "start_label": s_label,
+        "end_label": e_label,
+        "width_m": width_m,
+        "schema": _normalize_segment_schema(schema),
+        "direction": _normalize_segment_direction(direction),
+        "flow_type": _normalize_flow_type(flow_type or DEFAULT_FLOW_TYPE),
+        "flow_notes": _normalize_flow_notes(flow_notes),
+        "description": _normalize_leg_description(
+            (description or "").strip() or _normalize_flow_notes(flow_notes)
+        ),
+        "locations": _normalize_locations(locations),
+    }
+    _validate_leg_entry(entry)
+    legs.append(entry)
+    set_manifest_legs(manifest, legs)
+    save_org_leg_manifest(manifest)
+    return get_org_leg_library_state()
+
+
+def get_org_leg_library_state() -> Dict[str, Any]:
+    """API state for org leg library management UI."""
+    legs = list_org_legs()
+    return {
+        "leg_source": "org",
+        "library_dir": str(get_org_legs_dir()),
+        "has_library": bool(legs),
+        "legs": legs,
+    }
+
+
+def import_gpx_files_to_org_library(uploads: Sequence[tuple]) -> Dict[str, Any]:
+    """Import GPX (+ optional leg export JSON) into the org leg library."""
+    from app.core.config_package.legs import (
+        apply_leg_exports_to_manifest,
+        leg_id_from_export_filename,
+        parse_leg_export_json_bytes,
+    )
+    from app.core.config_package.segment_recipes import sync_manifest_legs_from_gpx
+
+    org_dir = get_org_legs_dir()
+    org_dir.mkdir(parents=True, exist_ok=True)
+    saved_gpx: List[str] = []
+    exports_by_leg_id: Dict[str, Dict[str, Any]] = {}
+    exports_by_gpx_file: Dict[str, Dict[str, Any]] = {}
+    for name, data in uploads:
+        safe = Path(name).name
+        lower = safe.lower()
+        if lower.endswith(".json"):
+            leg_export = parse_leg_export_json_bytes(data)
+            if not leg_export:
+                continue
+            leg_id = (
+                str(leg_export.get("id") or "").strip()
+                or leg_id_from_export_filename(safe)
+                or ""
+            )
+            if leg_id:
+                exports_by_leg_id[leg_id] = leg_export
+            gpx_file = str(leg_export.get("gpx_file") or "").strip()
+            if gpx_file:
+                exports_by_gpx_file[gpx_file] = leg_export
+            (org_dir / safe).write_bytes(data)
+            continue
+        if not lower.endswith(".gpx"):
+            continue
+        (org_dir / safe).write_bytes(data)
+        saved_gpx.append(safe)
+    if not saved_gpx:
+        raise ValueError("No .gpx files uploaded")
+    manifest = load_org_leg_manifest()
+    manifest = sync_manifest_legs_from_gpx(org_dir, manifest)
+    manifest = apply_leg_exports_to_manifest(
+        manifest, exports_by_leg_id, exports_by_gpx_file=exports_by_gpx_file
+    )
+    save_org_leg_manifest(manifest)
+    return get_org_leg_library_state()
+
+
+def update_org_leg(
+    leg_id: str,
+    fields: Dict[str, Any],
+    *,
+    gpx_bytes: Optional[bytes] = None,
+    gpx_filename: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Update org leg metadata, locations, and optional GPX."""
+    from app.core.config_package.legs import (
+        _default_endpoint_labels,
+        _find_leg_index,
+        _normalize_flow_notes,
+        _normalize_flow_type,
+        _normalize_leg_description,
+        _normalize_locations,
+        _normalize_segment_direction,
+        _normalize_segment_schema,
+        _slugify,
+    )
+
+    leg_id = str(leg_id).strip()
+    org_dir = get_org_legs_dir()
+    manifest = load_org_leg_manifest()
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    idx = _find_leg_index(legs, leg_id)
+    if idx < 0:
+        raise ValueError(f"Leg not found: {leg_id}")
+
+    entry = dict(legs[idx])
+    if "leg_label" in fields or "seg_label" in fields:
+        entry["seg_label"] = str(
+            fields.get("leg_label") or fields.get("seg_label") or entry.get("seg_label") or ""
+        ).strip()
+    for key in ("start_label", "end_label", "width_m"):
+        if key in fields:
+            entry[key] = fields[key]
+    if "description" in fields:
+        entry["description"] = _normalize_leg_description(fields.get("description"))
+    if "schema" in fields:
+        entry["schema"] = _normalize_segment_schema(fields["schema"])
+    if "direction" in fields:
+        entry["direction"] = _normalize_segment_direction(fields["direction"])
+    if "flow_type" in fields:
+        entry["flow_type"] = _normalize_flow_type(fields["flow_type"])
+    if "flow_notes" in fields:
+        entry["flow_notes"] = _normalize_flow_notes(fields.get("flow_notes"))
+    if "locations" in fields:
+        entry["locations"] = _normalize_locations(fields.get("locations"))
+
+    if gpx_bytes:
+        if gpx_filename:
+            file_name = Path(str(gpx_filename)).name
+        else:
+            file_name = entry.get("file") or f"{leg_id}_{_slugify(entry.get('seg_label', ''))}.gpx"
+        dest = org_dir / Path(file_name).name
+        dest.write_bytes(gpx_bytes)
+        entry["file"] = dest.name
+        parsed = parse_leg_gpx(dest)
+        if not entry.get("start_label"):
+            entry["start_label"] = _default_endpoint_labels(entry.get("seg_label", ""), parsed)[0]
+        if not entry.get("end_label"):
+            entry["end_label"] = _default_endpoint_labels(entry.get("seg_label", ""), parsed)[1]
+
+    legs[idx] = entry
+    set_manifest_legs(manifest, legs)
+    save_org_leg_manifest(manifest)
+    return get_org_leg_library_state()
+
+
+def delete_org_leg(leg_id: str) -> Dict[str, Any]:
+    """Remove one leg from the org library."""
+    from app.core.config_package.legs import _find_leg_index
+
+    leg_id = str(leg_id).strip()
+    org_dir = get_org_legs_dir()
+    manifest = load_org_leg_manifest()
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    idx = _find_leg_index(legs, leg_id)
+    if idx < 0:
+        raise ValueError(f"Leg not found: {leg_id}")
+    entry = legs.pop(idx)
+    file_name = entry.get("file")
+    if file_name:
+        gpx_path = org_dir / str(file_name)
+        if gpx_path.is_file():
+            gpx_path.unlink()
+    set_manifest_legs(manifest, legs)
+    save_org_leg_manifest(manifest)
+    return get_org_leg_library_state()
+
+
+def get_org_leg_line_geojson(leg_id: str) -> Dict[str, Any]:
+    """GeoJSON LineString for one org leg."""
+    leg_id = str(leg_id).strip()
+    org_dir = get_org_legs_dir()
+    manifest = load_org_leg_manifest()
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    from app.core.config_package.legs import _find_leg_index
+
+    idx = _find_leg_index(legs, leg_id)
+    if idx < 0:
+        raise ValueError(f"Leg not found: {leg_id}")
+    entry = legs[idx]
+    file_name = entry.get("file")
+    if not file_name:
+        raise ValueError(f"Leg {leg_id} has no GPX file")
+    gpx_path = org_dir / str(file_name)
+    if not gpx_path.is_file():
+        raise FileNotFoundError(f"GPX not found: {file_name}")
+    parsed = parse_leg_gpx(gpx_path)
+    coords = parsed.get("coordinates") or []
+    if len(coords) < 2:
+        raise ValueError(f"Leg {leg_id} GPX has insufficient points")
+    return {
+        "type": "Feature",
+        "properties": {
+            "leg_id": leg_id,
+            "leg_label": (entry.get("seg_label") or "").strip(),
+            "start_label": (entry.get("start_label") or "").strip(),
+            "end_label": (entry.get("end_label") or "").strip(),
+        },
+        "geometry": {"type": "LineString", "coordinates": coords},
     }

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -446,13 +446,13 @@ def export_package_flow_and_gpx_files(config_id: str) -> Dict[str, Any]:
     """
     Write flow.csv and per-event GPX files into the config package folder.
 
-    Uses segment library recipes when manifest exists; otherwise builds flow.csv
-    from course.json segments only (no GPX).
+    Uses combined org/package leg library + recipes when available; otherwise
+    builds flow.csv from course.json segments only (no GPX).
     """
+    from app.core.config_package.leg_library_resolver import combined_manifest_for_apply
+
     cid = validate_config_id(config_id)
     package_path = resolve_config_package_path(cid)
-    lib_dir = package_segment_library_dir(package_path)
-    manifest_path = _manifest_path(package_path)
     event_ids = package_recipe_event_ids(cid)
     course = load_config_course(cid)
     segments = course.get("segments") or []
@@ -461,9 +461,20 @@ def export_package_flow_and_gpx_files(config_id: str) -> Dict[str, Any]:
     flow_path = package_path / "flow.csv"
     gpx_exports: List[Dict[str, str]] = []
 
-    if manifest_path.is_file():
-        bundle = export_library_to_course(lib_dir, manifest_path, event_ids=event_ids)
-        flow_csv = bundle["flow_csv"]
+    library_bundle: Optional[Dict[str, Any]] = None
+    library_dir: Optional[Path] = None
+    try:
+        lib_dir, combined = combined_manifest_for_apply(cid)
+        if manifest_legs(combined):
+            library_dir = lib_dir
+            library_bundle = export_library_to_course(
+                lib_dir, manifest=combined, event_ids=event_ids
+            )
+    except FileNotFoundError:
+        library_bundle = None
+
+    if library_bundle and library_dir is not None:
+        flow_csv = library_bundle["flow_csv"]
         flow_validation = validate_flow_csv_text(flow_csv)
         if not flow_validation.ok:
             raise ValueError(
@@ -472,8 +483,8 @@ def export_package_flow_and_gpx_files(config_id: str) -> Dict[str, Any]:
         flow_backup = _backup_export_file(flow_path)
         flow_path.write_text(flow_csv, encoding="utf-8")
 
-        manifest = bundle["manifest"]
-        legs_by_id = load_leg_library(lib_dir, manifest)
+        manifest = library_bundle["manifest"]
+        legs_by_id = load_leg_library(library_dir, manifest)
         recipes = manifest.get("recipes") or {}
         for eid in event_ids:
             key = eid if eid in recipes else eid.lower()

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -135,6 +135,7 @@ def _default_manifest(event_ids: Optional[Sequence[str]] = None) -> Dict[str, An
     return {
         "version": 1,
         "label": "",
+        "leg_source": "org",
         "legs": [],
         "recipes": {eid: [] for eid in eids},
         "flow_overrides": [],
@@ -349,32 +350,31 @@ def order_grid_from_recipes(
 
 
 def get_package_segment_library_state(config_id: str) -> Dict[str, Any]:
-    """Full library state for API: legs, recipes, lengths, warnings."""
-    cid = validate_config_id(config_id)
-    package_path = resolve_config_package_path(cid)
-    lib_dir = package_segment_library_dir(package_path)
-    manifest = load_package_segment_manifest(cid)
-    legs_meta = manifest_legs(manifest)
-    event_ids = package_recipe_event_ids(cid)
+    """Full library state for API: org or package legs, package recipes, warnings."""
+    from app.core.config_package.leg_library_resolver import resolve_leg_library
 
-    if not lib_dir.is_dir() or not legs_meta:
+    cid = validate_config_id(config_id)
+    lib_dir, leg_manifest, leg_source, pkg_manifest = resolve_leg_library(cid)
+    legs_meta = manifest_legs(leg_manifest)
+    event_ids = package_recipe_event_ids(cid)
+    recipes = pkg_manifest.get("recipes") or {}
+
+    if not legs_meta:
         return {
             "config_id": cid,
             "library_dir": str(lib_dir),
+            "leg_source": leg_source,
             "has_library": False,
             "package_events": event_ids,
-            "manifest": manifest,
+            "manifest": pkg_manifest,
             "legs": [],
-            "recipes": manifest.get("recipes") or {},
-            "order_grid": order_grid_from_recipes(
-                [], manifest.get("recipes") or {}, event_ids
-            ),
+            "recipes": recipes,
+            "order_grid": order_grid_from_recipes([], recipes, event_ids),
             "recipe_lengths_km": {eid: 0.0 for eid in event_ids},
             "stitch_warnings": [],
         }
 
-    manifest_path = _manifest_path(package_path)
-    legs_by_id = load_leg_library(lib_dir, manifest)
+    legs_by_id = load_leg_library(lib_dir, leg_manifest)
     from app.core.config_package.legs import leg_row_from_entry
 
     leg_rows: List[Dict[str, Any]] = []
@@ -385,7 +385,6 @@ def get_package_segment_library_state(config_id: str) -> Dict[str, Any]:
         loaded = legs_by_id.get(leg_id_key) or {}
         leg_rows.append(leg_row_from_entry(entry, loaded))
 
-    recipes = manifest.get("recipes") or {}
     stitch_warnings: List[str] = []
     recipe_lengths: Dict[str, float] = {}
     for eid in event_ids:
@@ -400,9 +399,10 @@ def get_package_segment_library_state(config_id: str) -> Dict[str, Any]:
     return {
         "config_id": cid,
         "library_dir": str(lib_dir),
+        "leg_source": leg_source,
         "has_library": bool(leg_rows),
         "package_events": event_ids,
-        "manifest": manifest,
+        "manifest": pkg_manifest,
         "legs": leg_rows,
         "recipes": recipes,
         "order_grid": order_grid_from_recipes(leg_rows, recipes, event_ids),
@@ -514,15 +514,18 @@ def get_event_route_preview(config_id: str, event_id: str) -> Dict[str, Any]:
     if not eid:
         raise ValueError("event_id is required")
 
-    package_path = resolve_config_package_path(cid)
-    lib_dir = package_segment_library_dir(package_path)
-    manifest_path = _manifest_path(package_path)
-    if not manifest_path.is_file():
-        raise ValueError("No segment library; import legs and save recipes first")
+    from app.core.config_package.leg_library_resolver import (
+        combined_manifest_for_apply,
+        resolve_leg_library,
+    )
 
-    manifest = load_manifest(manifest_path)
-    legs_by_id = load_leg_library(lib_dir, manifest)
-    recipes = manifest.get("recipes") or {}
+    _lib_dir, combined = combined_manifest_for_apply(cid)
+    _lib_dir2, _leg_manifest, leg_source, pkg_manifest = resolve_leg_library(cid)
+    if not manifest_legs(combined):
+        raise ValueError("No legs in library; import GPX legs to the org library first")
+
+    legs_by_id = load_leg_library(_lib_dir, combined)
+    recipes = pkg_manifest.get("recipes") or {}
     leg_ids = recipes.get(eid) or recipes.get(event_id)
     if not leg_ids:
         raise ValueError(f"No recipe for event: {eid}")
@@ -551,11 +554,14 @@ def save_package_recipes(
     order_by_event: Optional[Dict[str, Dict[str, Optional[int]]]] = None,
 ) -> Dict[str, Any]:
     """Persist recipe lists to package manifest."""
+    from app.core.config_package.leg_library_resolver import resolve_leg_library
+
     manifest = load_package_segment_manifest(config_id)
     event_ids = package_recipe_event_ids(config_id)
     if order_by_event is not None:
+        _lib_dir, leg_manifest, _source, _pkg = resolve_leg_library(config_id)
         recipes = recipes_from_order_grid(
-            manifest_legs(manifest), order_by_event, event_ids
+            manifest_legs(leg_manifest), order_by_event, event_ids
         )
     normalized: Dict[str, List[str]] = {}
     for eid in event_ids:
@@ -577,15 +583,18 @@ def apply_package_recipes(
 
     Optionally writes segments.csv via export_config_package_segments.
     """
+    from app.core.config_package.leg_library_resolver import combined_manifest_for_apply
+
     cid = validate_config_id(config_id)
     package_path = resolve_config_package_path(cid)
-    lib_dir = package_segment_library_dir(package_path)
-    manifest_path = _manifest_path(package_path)
-    if not manifest_path.is_file():
-        raise ValueError("No segment library; import or seed GPX legs first")
+    lib_dir, combined = combined_manifest_for_apply(cid)
+    if not manifest_legs(combined):
+        raise ValueError("No legs in library; import GPX legs to the org library first")
 
     event_ids = package_recipe_event_ids(cid)
-    bundle = export_library_to_course(lib_dir, manifest_path, event_ids=event_ids)
+    bundle = export_library_to_course(
+        lib_dir, manifest=combined, event_ids=event_ids
+    )
     segments = bundle["segments"]
     if not segments:
         raise ValueError("Recipes produced no segments; check leg GPX and recipe order")
@@ -630,12 +639,19 @@ def import_gpx_files_to_library(
     uploads: Sequence[tuple],
 ) -> Dict[str, Any]:
     """
-    Save uploaded GPX and optional runflow leg export JSON into segment_library/.
+    Save uploaded GPX and optional runflow leg export JSON.
+
+    Org-primary packages import into ``runflow/org/legs/``; legacy packages write
+    into ``segment_library/``.
 
     uploads: sequence of (filename, bytes).
     Pair ``{leg_id}.gpx`` with ``{leg_id}.json`` from a leg export zip (same import).
     Filenames should match manifest leg file names when updating an existing library.
     """
+    from app.core.config_package.leg_library_resolver import (
+        LEG_SOURCE_ORG,
+        effective_leg_source,
+    )
     from app.core.config_package.legs import (
         apply_leg_exports_to_manifest,
         leg_id_from_export_filename,
@@ -643,6 +659,12 @@ def import_gpx_files_to_library(
     )
 
     cid = validate_config_id(config_id)
+    pkg_manifest = load_package_segment_manifest(cid)
+    if effective_leg_source(pkg_manifest) == LEG_SOURCE_ORG:
+        from app.core.config_package.org_leg_library import import_gpx_files_to_org_library
+
+        import_gpx_files_to_org_library(uploads)
+        return get_package_segment_library_state(cid)
     package_path = resolve_config_package_path(cid)
     lib_dir = package_segment_library_dir(package_path)
     lib_dir.mkdir(parents=True, exist_ok=True)

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -573,7 +573,7 @@ def save_package_recipes(
     config_id: str,
     recipes: Dict[str, List[str]],
     *,
-    order_by_event: Optional[Dict[str, Dict[str, Optional[int]]]] = None,
+    order_by_event: Optional[Dict[str, Dict[str, Any]]] = None,
 ) -> Dict[str, Any]:
     """Persist recipe lists to package manifest."""
     from app.core.config_package.leg_library_resolver import resolve_leg_library

--- a/app/core/config_package/segment_recipes.py
+++ b/app/core/config_package/segment_recipes.py
@@ -297,15 +297,39 @@ def seed_reference_segment_library(config_id: str) -> Dict[str, Any]:
     return get_package_segment_library_state(cid)
 
 
+def parse_recipe_order_values(raw: Any) -> List[int]:
+    """
+    Parse UI order cell: single integer or comma-separated slots (e.g. ``7,16``).
+
+    Returns sorted unique positive integers.
+    """
+    if raw is None or raw == "":
+        return []
+    if isinstance(raw, (list, tuple)):
+        parts = [str(x).strip() for x in raw if str(x).strip()]
+    else:
+        parts = [p.strip() for p in str(raw).split(",") if p.strip()]
+    values: List[int] = []
+    for part in parts:
+        try:
+            n = int(part)
+        except (TypeError, ValueError):
+            continue
+        if n > 0 and n not in values:
+            values.append(n)
+    return sorted(values)
+
+
 def recipes_from_order_grid(
     legs: Sequence[Dict[str, Any]],
-    order_by_event: Dict[str, Dict[str, Optional[int]]],
+    order_by_event: Dict[str, Dict[str, Any]],
     event_ids: Optional[Sequence[str]] = None,
 ) -> Dict[str, List[str]]:
     """
     Convert UI order grid to recipe lists.
 
-    order_by_event[event][leg_id] = 1-based order or None if unused.
+    order_by_event[event][leg_id] = 1-based order, comma-separated orders
+    (``7,16``), or None if unused. The same leg id may appear multiple times.
     """
     recipes: Dict[str, List[str]] = {}
     leg_ids = [str(c.get("id", "")).strip() for c in legs if c.get("id")]
@@ -315,16 +339,9 @@ def recipes_from_order_grid(
         orders = order_by_event.get(key) or order_by_event.get(eid) or {}
         pairs: List[tuple] = []
         for cid in leg_ids:
-            raw = orders.get(cid)
-            if raw is None or raw == "":
-                continue
-            try:
-                n = int(raw)
-            except (TypeError, ValueError):
-                continue
-            if n > 0:
+            for n in parse_recipe_order_values(orders.get(cid)):
                 pairs.append((n, cid))
-        pairs.sort(key=lambda x: x[0])
+        pairs.sort(key=lambda x: (x[0], x[1]))
         recipes[eid] = [cid for _, cid in pairs]
     return recipes
 
@@ -333,18 +350,23 @@ def order_grid_from_recipes(
     legs: Sequence[Dict[str, Any]],
     recipes: Dict[str, Any],
     event_ids: Optional[Sequence[str]] = None,
-) -> Dict[str, Dict[str, Optional[int]]]:
+) -> Dict[str, Dict[str, Optional[str]]]:
     """Inverse of recipes_from_order_grid for UI."""
     leg_ids = [str(c.get("id", "")).strip() for c in legs if c.get("id")]
-    grid: Dict[str, Dict[str, Optional[int]]] = {}
+    grid: Dict[str, Dict[str, Optional[str]]] = {}
     eids = list(event_ids) if event_ids is not None else []
     for eid in eids:
         key = eid if eid in recipes else eid.lower()
         seq = recipes.get(key) or []
-        row: Dict[str, Optional[int]] = {cid: None for cid in leg_ids}
-        for i, cid in enumerate(seq, start=1):
-            if cid in row:
-                row[cid] = i
+        positions: Dict[str, List[int]] = {cid: [] for cid in leg_ids}
+        for i, raw_cid in enumerate(seq, start=1):
+            cid = str(raw_cid).strip()
+            if cid in positions:
+                positions[cid].append(i)
+        row: Dict[str, Optional[str]] = {}
+        for cid in leg_ids:
+            pos = positions.get(cid) or []
+            row[cid] = ",".join(str(p) for p in pos) if pos else None
         grid[eid] = row
     return grid
 

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -533,6 +533,13 @@ def create_config_package(
         }
     )
 
+    from app.core.config_package.segment_recipes import (
+        _default_manifest,
+        save_package_segment_manifest,
+    )
+
+    save_package_segment_manifest(config_id, _default_manifest(clean_events))
+
     logger.info("Created config package %s (%s)", config_id, clean_label)
     return {
         "config_id": config_id,

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -252,7 +252,8 @@ def save_config_course(config_id: str, course_data: Dict[str, Any]) -> Path:
     data.pop("data_dir", None)
 
     segments = data.get("segments") or []
-    if segments:
+    # Recipe-built courses already have per-event km from library apply order.
+    if segments and not data.get("segment_library_applied"):
         enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
 
     course_path = package_path / COURSE_WORKSPACE_NAME
@@ -736,7 +737,8 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
     if not segments:
         raise ValueError("Course has no segments; add segment pins before export")
 
-    enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
+    if not course.get("segment_library_applied"):
+        enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
 
     from app.core.config_package.legs import (
         refresh_location_seg_ids_from_segments,

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -230,6 +230,42 @@ def load_config_course(config_id: str) -> Dict[str, Any]:
     return data
 
 
+def _preserve_recipe_segment_kms(
+    data: Dict[str, Any], existing: Dict[str, Any]
+) -> None:
+    """
+    Recipe-applied segment kms are server-owned.
+
+    A browser tab that loaded the course before a recipe apply can save a stale
+    snapshot (old per-event kms, no segment_library_applied flag), silently
+    reverting apply results. When the on-disk course is recipe-applied, keep the
+    flag and carry over km fields from disk segments matched by seg_id.
+    """
+    if not existing.get("segment_library_applied"):
+        return
+    data["segment_library_applied"] = True
+    km_keys = ["from_km", "to_km"]
+    for eid in COURSE_EVENT_IDS:
+        eid_l = eid.lower()
+        km_keys.extend([f"{eid_l}_from_km", f"{eid_l}_to_km"])
+    by_seg_id = {
+        str(seg["seg_id"]): seg
+        for seg in existing.get("segments") or []
+        if isinstance(seg, dict) and seg.get("seg_id")
+    }
+    for seg in data.get("segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        src = by_seg_id.get(str(seg.get("seg_id", "")))
+        if not src:
+            continue
+        for key in km_keys:
+            if key in src:
+                seg[key] = src[key]
+        if src.get("leg_id") and not seg.get("leg_id"):
+            seg["leg_id"] = src["leg_id"]
+
+
 def save_config_course(config_id: str, course_data: Dict[str, Any]) -> Path:
     """
     Save course workspace to runflow/config/{config_id}/course.json.
@@ -250,6 +286,13 @@ def save_config_course(config_id: str, course_data: Dict[str, Any]) -> Path:
     data["updated"] = datetime.now(timezone.utc).isoformat()
     data.pop("events", None)
     data.pop("data_dir", None)
+
+    try:
+        existing = load_config_course(cid)
+    except (FileNotFoundError, ValueError):
+        existing = None
+    if existing:
+        _preserve_recipe_segment_kms(data, existing)
 
     segments = data.get("segments") or []
     # Recipe-built courses already have per-event km from library apply order.

--- a/app/core/course/export.py
+++ b/app/core/course/export.py
@@ -114,10 +114,36 @@ def _format_km(value: float) -> str:
     return format(round(float(value), 2), ".2f")
 
 
+def _stored_event_kms(
+    segments: List[Dict], eid: str, event_ids_lower: List[str]
+) -> Optional[List[tuple]]:
+    """
+    Stored {eid}_from_km/{eid}_to_km for recipe-built (leg_id) segments.
+
+    Recipe-built courses compute per-event kms in recipe traversal order, which
+    can differ from the segment list order (the list follows the first event's
+    recipe; another event may visit shared legs at a different point in its
+    course). Returns None unless every segment bearing the event is recipe-built
+    with stored kms — in that case list-order accumulation would corrupt them.
+    """
+    vals: List[tuple] = []
+    for seg in segments:
+        if eid not in _segment_events_set(seg, event_ids_lower):
+            vals.append((0.0, 0.0))
+            continue
+        from_key, to_key = f"{eid}_from_km", f"{eid}_to_km"
+        if not seg.get("leg_id") or from_key not in seg or to_key not in seg:
+            return None
+        vals.append((float(seg[from_key] or 0), float(seg[to_key] or 0)))
+    return vals
+
+
 def _event_cumulative_distances(segments: List[Dict], event_ids: List[str]) -> List[Dict[str, tuple]]:
     """
     For each event, compute per-segment from_km/to_km as cumulative distance along
     only the segments that include that event (so half skips segments 2/3, etc.).
+    Recipe-built segments keep their stored per-event kms (recipe traversal order);
+    other segments accumulate in list order.
     Returns list of dicts: result[i][eid] = (from_km, to_km) for segment i and event eid.
     Accumulated values are rounded to 2 decimal places to avoid float drift.
     """
@@ -125,6 +151,11 @@ def _event_cumulative_distances(segments: List[Dict], event_ids: List[str]) -> L
     result = [{} for _ in range(n)]
     event_ids_lower = [e.lower() for e in event_ids]
     for ei, eid in enumerate(event_ids_lower):
+        stored = _stored_event_kms(segments, eid, event_ids_lower)
+        if stored is not None:
+            for i, pair in enumerate(stored):
+                result[i][eid] = pair
+            continue
         accumulated = 0.0
         for i, seg in enumerate(segments):
             seg_events = _segment_events_set(seg, event_ids_lower)

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -4,7 +4,7 @@ Segment library + event recipes (reusable GPX legs and per-event recipes).
 A segment library is a set of reusable GPX legs. Event recipes list leg ids in order.
 From that we build:
   - per-event combined GPX
-  - multi-event segments.csv (one row per leg, 2026-style)
+  - multi-event segments.csv (one row per recipe occurrence, 2026-style)
   - flow.csv rows for event pairs on shared legs (#759 baseline)
 """
 
@@ -186,18 +186,91 @@ def build_event_gpx_content(
     return '<?xml version="1.0" encoding="UTF-8"?>\n' + ET.tostring(root, encoding="unicode")
 
 
+LegOccurrence = Tuple[str, int]
+
+
 def _events_for_leg(
     leg_id: str,
     recipes: Dict[str, Any],
     event_ids: Sequence[str],
 ) -> List[str]:
+    """Events whose recipe includes leg_id at least once (first occurrence)."""
+    return _events_for_leg_occurrence(leg_id, 1, recipes, event_ids)
+
+
+def _events_for_leg_occurrence(
+    leg_id: str,
+    occurrence: int,
+    recipes: Dict[str, Any],
+    event_ids: Sequence[str],
+) -> List[str]:
+    """Events whose recipe includes leg_id at least ``occurrence`` times."""
     out: List[str] = []
+    leg_id = str(leg_id).strip()
+    if not leg_id or occurrence < 1:
+        return out
     for eid in event_ids:
         key = eid if eid in recipes else eid.lower()
         seq = recipes.get(key) or []
-        if leg_id in seq:
+        count = sum(1 for raw in seq if str(raw).strip() == leg_id)
+        if count >= occurrence:
             out.append(eid.lower())
     return out
+
+
+def _build_event_occurrence_km(
+    recipes: Dict[str, Any],
+    legs_by_id: Dict[str, Dict[str, Any]],
+    event_ids: Sequence[str],
+) -> Dict[str, Dict[LegOccurrence, Tuple[float, float]]]:
+    """Per-event km window for each (leg_id, 1-based occurrence) in that recipe."""
+    result: Dict[str, Dict[LegOccurrence, Tuple[float, float]]] = {}
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        seq = recipes.get(key) or []
+        occ_counts: Dict[str, int] = {}
+        cum = 0.0
+        event_map: Dict[LegOccurrence, Tuple[float, float]] = {}
+        for raw_id in seq:
+            cid = str(raw_id).strip()
+            ch = legs_by_id.get(cid)
+            if not ch:
+                continue
+            length = float(ch["length_km"])
+            occ_counts[cid] = occ_counts.get(cid, 0) + 1
+            occ = occ_counts[cid]
+            cum += length
+            event_map[(cid, occ)] = (round(cum - length, 2), round(cum, 2))
+        result[eid.lower()] = event_map
+    return result
+
+
+def _recipe_occurrence_order(
+    legs_by_id: Dict[str, Dict[str, Any]],
+    event_ids: Sequence[str],
+    recipes: Dict[str, Any],
+) -> List[LegOccurrence]:
+    """(leg_id, occurrence) pairs in recipe traversal order (first-seen wins)."""
+    ordered: List[LegOccurrence] = []
+    seen: set[LegOccurrence] = set()
+    for eid in event_ids:
+        key = eid if eid in recipes else eid.lower()
+        occ_in_pass: Dict[str, int] = {}
+        for raw_id in recipes.get(key) or []:
+            cid = str(raw_id).strip()
+            if not cid or cid not in legs_by_id:
+                continue
+            occ_in_pass[cid] = occ_in_pass.get(cid, 0) + 1
+            occ = occ_in_pass[cid]
+            token = (cid, occ)
+            if token in seen:
+                continue
+            events = _events_for_leg_occurrence(cid, occ, recipes, event_ids)
+            if not events:
+                continue
+            seen.add(token)
+            ordered.append(token)
+    return ordered
 
 
 def _recipe_leg_order(
@@ -207,20 +280,8 @@ def _recipe_leg_order(
     recipes: Dict[str, Any],
 ) -> List[str]:
     """Leg ids in recipe traversal order (union across events, first-seen wins)."""
-    ordered: List[str] = []
-    seen: set[str] = set()
-    for eid in event_ids:
-        key = eid if eid in recipes else eid.lower()
-        for raw_id in recipes.get(key) or []:
-            cid = str(raw_id).strip()
-            if not cid or cid in seen or cid not in legs_by_id:
-                continue
-            events = _events_for_leg(cid, recipes, event_ids)
-            if not events:
-                continue
-            seen.add(cid)
-            ordered.append(cid)
-    return ordered
+    del manifest  # kept for call-site compatibility
+    return [cid for cid, _occ in _recipe_occurrence_order(legs_by_id, event_ids, recipes)]
 
 
 def build_course_segments_from_library(
@@ -229,26 +290,16 @@ def build_course_segments_from_library(
     event_ids: Optional[Sequence[str]] = None,
 ) -> List[Dict[str, Any]]:
     """
-    Build course['segments'] list: one dict per library leg (multi-event row).
+    Build course['segments'] list: one row per recipe occurrence of a leg.
 
-    Each segment has geometry length (leg length) and per-event from/to km from
-    cumulative distance along each event's recipe (2026 segments.csv model).
+    The same library leg may appear multiple times in one event's recipe (e.g.
+    out-and-back). Each passage becomes its own segment row with distinct
+    per-event km windows. Leg metadata is shared; ``leg_occurrence`` marks the
+    nth use of ``leg_id`` in the combined ordering.
     """
     event_ids = list(event_ids or COURSE_EVENT_IDS)
     recipes = manifest.get("recipes") or {}
-
-    # Per-event cumulative at each leg end (only legs in that recipe)
-    event_cum_at_leg: Dict[str, Dict[str, float]] = {e: {} for e in event_ids}
-    for eid in event_ids:
-        key = eid if eid in recipes else eid.lower()
-        seq = recipes.get(key) or []
-        cum = 0.0
-        for cid in seq:
-            ch = legs_by_id.get(cid)
-            if not ch:
-                continue
-            cum += float(ch["length_km"])
-            event_cum_at_leg[eid.lower()][cid] = round(cum, 2)
+    event_km = _build_event_occurrence_km(recipes, legs_by_id, event_ids)
 
     entries_by_id: Dict[str, Dict[str, Any]] = {
         str(entry.get("id", "")).strip(): entry
@@ -257,23 +308,26 @@ def build_course_segments_from_library(
     }
 
     segments: List[Dict[str, Any]] = []
-    segment_index = 0
-    for cid in _recipe_leg_order(manifest, legs_by_id, event_ids, recipes):
+    for segment_index, (cid, occ) in enumerate(
+        _recipe_occurrence_order(legs_by_id, event_ids, recipes), start=1
+    ):
         entry = entries_by_id.get(cid) or {}
         ch = legs_by_id.get(cid)
         if not ch:
             continue
-        events = _events_for_leg(cid, recipes, event_ids)
+        events = _events_for_leg_occurrence(cid, occ, recipes, event_ids)
         if not events:
             continue
-        segment_index += 1
         length_km = float(ch["length_km"])
         leg_description = (
             str(entry.get("description") or entry.get("flow_notes") or "").strip()
         )
+        seg_label = (entry.get("seg_label") or ch.get("name") or cid).strip()
+        if occ > 1:
+            seg_label = f"{seg_label} ({occ})"
         seg: Dict[str, Any] = {
             "seg_id": f"S{segment_index}",
-            "seg_label": (entry.get("seg_label") or ch.get("name") or cid).strip(),
+            "seg_label": seg_label,
             "from_label": (entry.get("start_label") or "").strip(),
             "to_label": (entry.get("end_label") or "").strip(),
             "width_m": entry.get("width_m", 3),
@@ -284,6 +338,7 @@ def build_course_segments_from_library(
             "description": leg_description,
             "events": events,
             "leg_id": cid,
+            "leg_occurrence": occ,
             "length_km": length_km,
             "from_km": 0.0,
             "to_km": length_km,
@@ -294,8 +349,7 @@ def build_course_segments_from_library(
                 seg[f"{el}_from_km"] = 0.0
                 seg[f"{el}_to_km"] = 0.0
                 continue
-            to_km = event_cum_at_leg[el].get(cid, 0.0)
-            from_km = round(to_km - length_km, 2)
+            from_km, to_km = event_km.get(el, {}).get((cid, occ), (0.0, 0.0))
             seg[f"{el}_from_km"] = max(0.0, from_km)
             seg[f"{el}_to_km"] = to_km
         segments.append(seg)

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -307,13 +307,15 @@ def export_library_to_course(
     library_dir: Path,
     manifest_path: Optional[Path] = None,
     *,
+    manifest: Optional[Dict[str, Any]] = None,
     event_ids: Optional[Sequence[str]] = None,
 ) -> Dict[str, Any]:
     """
     Load library + manifest and return export bundle (segments, flow csv, validation).
     """
-    manifest_path = manifest_path or (library_dir / "manifest.yaml")
-    manifest = load_manifest(manifest_path)
+    if manifest is None:
+        manifest_path = manifest_path or (library_dir / "manifest.yaml")
+        manifest = load_manifest(manifest_path)
     legs_by_id = load_leg_library(library_dir, manifest)
     event_ids = list(event_ids or COURSE_EVENT_IDS)
 

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -7,7 +7,7 @@ Issue #758: Export segments.csv from course.json into config package.
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi import APIRouter, File, Form, HTTPException, Query, Request, UploadFile, status
 from fastapi.responses import JSONResponse, Response
@@ -132,9 +132,12 @@ class RemoveLegLocationRequest(BaseModel):
 
 
 class SaveSegmentRecipesRequest(BaseModel):
-    order_by_event: Dict[str, Dict[str, Optional[int]]] = Field(
+    order_by_event: Dict[str, Dict[str, Optional[Union[int, str]]]] = Field(
         default_factory=dict,
-        description="Per event, leg id -> 1-based order (omit or null if unused)",
+        description=(
+            "Per event, leg id -> 1-based order slot or comma-separated slots "
+            "(e.g. 7,16) to reuse a leg; omit or null if unused"
+        ),
     )
     export_csv: bool = Field(
         True,

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -41,9 +41,14 @@ from app.core.config_package.legs import (
     update_package_leg_geometry,
 )
 from app.core.config_package.org_leg_library import (
+    create_org_leg,
+    delete_org_leg,
+    get_org_leg_line_geojson,
+    import_gpx_files_to_org_library,
     import_org_leg_to_package,
     list_org_legs,
     publish_package_leg_to_org_library,
+    update_org_leg,
 )
 from app.core.config_package.segment_recipes import (
     apply_package_recipes,
@@ -441,7 +446,16 @@ async def api_get_package_leg_geometry(
     """GeoJSON LineString for one leg (map display)."""
     require_auth(request)
     try:
-        feature = get_leg_line_geojson(config_id, leg_id)
+        from app.core.config_package.leg_library_resolver import (
+            LEG_SOURCE_ORG,
+            effective_leg_source,
+        )
+        from app.core.config_package.segment_recipes import load_package_segment_manifest
+
+        if effective_leg_source(load_package_segment_manifest(config_id)) == LEG_SOURCE_ORG:
+            feature = get_org_leg_line_geojson(leg_id)
+        else:
+            feature = get_leg_line_geojson(config_id, leg_id)
         return JSONResponse(content={"ok": True, "feature": feature})
     except FileNotFoundError as e:
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
@@ -574,7 +588,128 @@ async def api_list_org_legs(request: Request) -> JSONResponse:
     require_auth(request)
     try:
         legs = list_org_legs()
-        return JSONResponse(content={"ok": True, "legs": legs})
+        return JSONResponse(content={"ok": True, "legs": legs, "leg_source": "org"})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/org/legs/upload")
+async def api_upload_org_legs(
+    request: Request,
+    files: List[UploadFile] = File(...),
+) -> JSONResponse:
+    """Import GPX (+ optional leg export JSON) into the org leg library."""
+    require_auth(request)
+    try:
+        uploads = []
+        for f in files:
+            data = await f.read()
+            if data:
+                uploads.append((f.filename or "leg.gpx", data))
+        state = import_gpx_files_to_org_library(uploads)
+        return JSONResponse(content={"ok": True, **state})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/org/legs")
+async def api_create_org_leg(
+    request: Request,
+    file: UploadFile = File(...),
+    leg_label: str = Form(""),
+    start_label: str = Form(""),
+    end_label: str = Form(""),
+    width_m: float = Form(3.0),
+    schema: str = Form("on_course_open"),
+    direction: str = Form("uni"),
+    flow_type: str = Form("none"),
+    flow_notes: str = Form(""),
+    description: str = Form(""),
+) -> JSONResponse:
+    """Create an org library leg from uploaded GPX."""
+    require_auth(request)
+    try:
+        data = await file.read()
+        if not data:
+            raise ValueError("GPX file is empty")
+        state = create_org_leg(
+            data,
+            file.filename or "leg.gpx",
+            leg_label=leg_label,
+            start_label=start_label,
+            end_label=end_label,
+            width_m=width_m,
+            schema=schema,
+            direction=direction,
+            flow_type=flow_type,
+            flow_notes=flow_notes,
+            description=description,
+        )
+        return JSONResponse(content={"ok": True, **state})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.put("/api/org/legs/{leg_id}")
+async def api_update_org_leg(
+    request: Request,
+    leg_id: str,
+    body: UpdateLegRequest,
+) -> JSONResponse:
+    """Update org leg metadata and locations."""
+    require_auth(request)
+    try:
+        fields = body.model_dump(exclude_unset=True)
+        if "leg_label" in fields and fields["leg_label"] is not None:
+            fields["seg_label"] = fields.pop("leg_label")
+        state = update_org_leg(leg_id, fields)
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.delete("/api/org/legs/{leg_id}")
+async def api_delete_org_leg(request: Request, leg_id: str) -> JSONResponse:
+    """Delete one leg from the org library."""
+    require_auth(request)
+    try:
+        state = delete_org_leg(leg_id)
+        return JSONResponse(content={"ok": True, **state})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.put("/api/org/legs/{leg_id}/gpx")
+async def api_replace_org_leg_gpx(
+    request: Request,
+    leg_id: str,
+    file: UploadFile = File(...),
+) -> JSONResponse:
+    """Replace GPX geometry for an org library leg."""
+    require_auth(request)
+    try:
+        data = await file.read()
+        if not data:
+            raise ValueError("GPX file is empty")
+        state = update_org_leg(leg_id, {}, gpx_bytes=data, gpx_filename=file.filename or "leg.gpx")
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/api/org/legs/{leg_id}/geometry")
+async def api_org_leg_geometry(request: Request, leg_id: str) -> JSONResponse:
+    """GeoJSON LineString for one org leg."""
+    require_auth(request)
+    try:
+        feature = get_org_leg_line_geojson(leg_id)
+        return JSONResponse(content={"ok": True, "feature": feature})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 

--- a/app/routes/api_density.py
+++ b/app/routes/api_density.py
@@ -15,6 +15,7 @@ import logging
 import pandas as pd
 from pathlib import Path
 import json
+import re
 
 # Issue #466 Step 2: Storage consolidated to app.storage
 
@@ -26,6 +27,12 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 # Issue #466 Step 2: Removed legacy storage singleton (not needed)
+
+
+def _natural_seg_id_key(seg_id: str) -> tuple:
+    """Sort key so S2 < S10 (split into text/number parts, compare numbers numerically)."""
+    parts = re.split(r"(\d+)", str(seg_id))
+    return tuple(int(p) if p.isdigit() else p.lower() for p in parts)
 
 
 def _format_time_value(value: Any) -> Optional[str]:
@@ -433,8 +440,8 @@ async def get_density_segments(
             )
             segments_list.append(segment_record)
         
-        # Sort by seg_id
-        segments_list.sort(key=lambda x: x["seg_id"])
+        # Sort by seg_id (natural order: S1, S2, ... S10 — not lexicographic)
+        segments_list.sort(key=lambda x: _natural_seg_id_key(x["seg_id"]))
         
         response = JSONResponse(content={
             "selected_day": selected_day,

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -1080,6 +1080,21 @@ document.addEventListener('DOMContentLoaded', function () {
         return t === 'traffic' || t === 'extract';
     }
 
+    function proxyLocIdIsSet(loc) {
+        var p = loc && loc.proxy_loc_id;
+        if (p == null || p === '') return false;
+        var s = String(p).trim();
+        return s !== '' && s.toLowerCase() !== 'nan';
+    }
+
+    /** Direct timing sources only — exclude self and locations that proxy elsewhere. */
+    function isEligibleProxyTimingSource(other, selfId) {
+        var oid = locationNumericId(other);
+        if (!oid || (selfId && oid === selfId)) return false;
+        if (proxyLocIdIsSet(other)) return false;
+        return true;
+    }
+
     function locationNumericId(loc) {
         if (!loc) return 0;
         var raw = loc.id != null ? loc.id : loc.loc_id;
@@ -1100,8 +1115,8 @@ document.addEventListener('DOMContentLoaded', function () {
             return locationNumericId(a) - locationNumericId(b);
         });
         others.forEach(function (other) {
+            if (!isEligibleProxyTimingSource(other, selfId)) return;
             var oid = locationNumericId(other);
-            if (!oid || (selfId && oid === selfId)) return;
             var opt = document.createElement('option');
             opt.value = String(oid);
             var typeHint = other.loc_type ? ' (' + other.loc_type + ')' : '';
@@ -1116,10 +1131,21 @@ document.addEventListener('DOMContentLoaded', function () {
         if (pv) {
             sel.value = pv;
             if (sel.value !== pv) {
-                var missing = document.createElement('option');
-                missing.value = pv;
-                missing.textContent = pv + ' — (location not found)';
-                sel.appendChild(missing);
+                var stale = document.createElement('option');
+                stale.value = pv;
+                var staleTarget = others.find(function (other) {
+                    return String(locationNumericId(other)) === pv;
+                });
+                if (staleTarget && proxyLocIdIsSet(staleTarget)) {
+                    stale.textContent =
+                        pv +
+                        ' — ' +
+                        (staleTarget.loc_label || 'Untitled') +
+                        ' (chained proxy — pick a direct source)';
+                } else {
+                    stale.textContent = pv + ' — (location not found)';
+                }
+                sel.appendChild(stale);
                 sel.value = pv;
             }
         }
@@ -1358,6 +1384,17 @@ document.addEventListener('DOMContentLoaded', function () {
                     }
                     if (proxyNum === locationNumericId(loc)) {
                         alert('A location cannot use itself as the proxy timing source.');
+                        btnSave.disabled = false;
+                        return;
+                    }
+                    var proxyTarget = getCourseLocations().find(function (other) {
+                        return locationNumericId(other) === proxyNum;
+                    });
+                    if (proxyTarget && proxyLocIdIsSet(proxyTarget)) {
+                        alert(
+                            'Proxy timing source must be a direct timing source (not another proxied location). ' +
+                                'Choose a course/official location with a segment, or clear proxy on the target first.'
+                        );
                         btnSave.disabled = false;
                         return;
                     }
@@ -4816,7 +4853,9 @@ document.addEventListener('DOMContentLoaded', function () {
                 getResources: getPackageResources,
                 getLocationTypeLabel: getLocationTypeLabel,
                 locationNumericId: locationNumericId,
-                offCourseUsesProxyTiming: offCourseUsesProxyTiming
+                offCourseUsesProxyTiming: offCourseUsesProxyTiming,
+                proxyLocIdIsSet: proxyLocIdIsSet,
+                isEligibleProxyTimingSource: isEligibleProxyTimingSource
             });
         }
 

--- a/frontend/static/js/map/location_grid_editor.js
+++ b/frontend/static/js/map/location_grid_editor.js
@@ -52,6 +52,23 @@
         return x === 'traffic' || x === 'extract';
     }
 
+    function proxyLocIdIsSet(loc) {
+        if (deps && deps.proxyLocIdIsSet) return deps.proxyLocIdIsSet(loc);
+        var p = loc && loc.proxy_loc_id;
+        if (p == null || p === '') return false;
+        var s = String(p).trim();
+        return s !== '' && s.toLowerCase() !== 'nan';
+    }
+
+    function isEligibleProxyTimingSource(other, selfId) {
+        if (deps && deps.isEligibleProxyTimingSource) {
+            return deps.isEligibleProxyTimingSource(other, selfId);
+        }
+        var oid = locationId(other, 0);
+        if (!oid || (selfId && oid === selfId)) return false;
+        return !proxyLocIdIsSet(other);
+    }
+
     function ynDisplay(v) {
         return String(v || 'n').toLowerCase() === 'y' ? 'y' : 'n';
     }
@@ -128,6 +145,20 @@
             }
             if (hasProxy && locationId(loc, i) === parseInt(proxy, 10)) {
                 errors.push(label + ': proxy cannot reference itself');
+            }
+            if (hasProxy) {
+                var proxyNum = parseInt(proxy, 10);
+                if (!isNaN(proxyNum)) {
+                    var proxyTarget = workingLocations.find(function (other, j) {
+                        return locationId(other, j) === proxyNum;
+                    });
+                    if (proxyTarget && proxyLocIdIsSet(proxyTarget)) {
+                        errors.push(
+                            label +
+                                ': proxy timing source cannot be another proxied location (use a direct source)'
+                        );
+                    }
+                }
             }
         });
         return errors;
@@ -231,8 +262,8 @@
         sel.appendChild(none);
         var selfId = locationId(loc, rowIndex);
         workingLocations.forEach(function (other, j) {
+            if (!isEligibleProxyTimingSource(other, selfId)) return;
             var oid = locationId(other, j);
-            if (!oid || oid === selfId) return;
             var opt = document.createElement('option');
             opt.value = String(oid);
             opt.textContent =
@@ -249,10 +280,21 @@
         if (pv) {
             sel.value = pv;
             if (sel.value !== pv) {
-                var miss = document.createElement('option');
-                miss.value = pv;
-                miss.textContent = pv + ' (missing)';
-                sel.appendChild(miss);
+                var stale = document.createElement('option');
+                stale.value = pv;
+                var staleTarget = workingLocations.find(function (other, j) {
+                    return String(locationId(other, j)) === pv;
+                });
+                if (staleTarget && proxyLocIdIsSet(staleTarget)) {
+                    stale.textContent =
+                        pv +
+                        ' — ' +
+                        (staleTarget.loc_label || 'Untitled') +
+                        ' (chained proxy)';
+                } else {
+                    stale.textContent = pv + ' (missing)';
+                }
+                sel.appendChild(stale);
                 sel.value = pv;
             }
         }

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -229,6 +229,22 @@
         el.textContent = 'Stitch warnings: ' + warnings.join(' · ');
     }
 
+    function parseOrderValues(raw) {
+        if (raw == null || raw === '') return [];
+        var parts = String(raw).split(',');
+        var values = [];
+        parts.forEach(function (part) {
+            var n = parseInt(String(part).trim(), 10);
+            if (!isNaN(n) && n >= 1 && values.indexOf(n) < 0) values.push(n);
+        });
+        return values.sort(function (a, b) { return a - b; });
+    }
+
+    function formatOrderValues(values) {
+        if (!values || !values.length) return '';
+        return values.slice().sort(function (a, b) { return a - b; }).join(',');
+    }
+
     function getOrder(legId, eventId) {
         var row = orderGrid[eventId] || {};
         var v = row[legId];
@@ -238,10 +254,11 @@
     function setOrder(legId, eventId, value) {
         if (!orderGrid[eventId]) orderGrid[eventId] = {};
         var trimmed = String(value || '').trim();
-        if (!trimmed) orderGrid[eventId][legId] = null;
-        else {
-            var n = parseInt(trimmed, 10);
-            orderGrid[eventId][legId] = isNaN(n) || n < 1 ? null : n;
+        if (!trimmed) {
+            orderGrid[eventId][legId] = null;
+        } else {
+            var values = parseOrderValues(trimmed);
+            orderGrid[eventId][legId] = values.length ? formatOrderValues(values) : null;
         }
         recomputeTotalsLocal();
     }
@@ -253,10 +270,13 @@
         packageEvents().forEach(function (ev) {
             var pairs = [];
             libraryState.legs.forEach(function (ch) {
-                var o = getOrder(ch.id, ev);
-                if (o) pairs.push({ order: parseInt(o, 10), km: ch.length_km || 0 });
+                parseOrderValues(getOrder(ch.id, ev)).forEach(function (order) {
+                    pairs.push({ order: order, km: ch.length_km || 0 });
+                });
             });
-            pairs.sort(function (a, b) { return a.order - b.order; });
+            pairs.sort(function (a, b) {
+                return a.order - b.order || 0;
+            });
             lengths[ev] = Math.round(pairs.reduce(function (s, p) { return s + p.km; }, 0) * 100) / 100;
         });
         renderTotals(lengths);
@@ -2458,10 +2478,12 @@
             events.forEach(function (ev) {
                 var td = document.createElement('td');
                 var inp = document.createElement('input');
-                inp.type = 'number';
-                inp.min = '1';
-                inp.max = '99';
+                inp.type = 'text';
+                inp.inputMode = 'numeric';
+                inp.pattern = '[0-9, ]*';
                 inp.className = 'segment-recipe-order-input';
+                inp.title = 'Order slot(s), e.g. 7 or 7,16 to reuse this leg';
+                inp.placeholder = '—';
                 inp.value = getOrder(ch.id, ev);
                 inp.addEventListener('input', function () { setOrder(ch.id, ev, inp.value); });
                 td.appendChild(inp);

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -95,6 +95,51 @@
         return '/api/config/packages/' + encodeURIComponent(resolveConfigPackageId());
     }
 
+    function usesOrgLegLibrary() {
+        if (!libraryState) return true;
+        return libraryState.leg_source === 'org';
+    }
+
+    function legGeometryUrl(legId) {
+        if (usesOrgLegLibrary()) {
+            return '/api/org/legs/' + encodeURIComponent(legId) + '/geometry';
+        }
+        return apiBase() + '/segment-library/legs/' + encodeURIComponent(legId) + '/geometry';
+    }
+
+    function legDetailUrl(legId) {
+        if (usesOrgLegLibrary()) {
+            return '/api/org/legs/' + encodeURIComponent(legId);
+        }
+        return apiBase() + '/segment-library/legs/' + encodeURIComponent(legId);
+    }
+
+    function legUploadUrl() {
+        if (usesOrgLegLibrary()) {
+            return '/api/org/legs/upload';
+        }
+        return apiBase() + '/segment-library/upload';
+    }
+
+    function legCreateUrl() {
+        if (usesOrgLegLibrary()) {
+            return '/api/org/legs';
+        }
+        return apiBase() + '/segment-library/legs';
+    }
+
+    function getPackageResources() {
+        return (window.CONFIG_PACKAGE_RESOURCES || []).slice();
+    }
+
+    function afterLegLibraryMutation(data) {
+        if (usesOrgLegLibrary() || (data && data.leg_source === 'org' && !data.recipes)) {
+            return loadLibrary();
+        }
+        applyLibraryState(data);
+        return Promise.resolve();
+    }
+
     function packageEvents() {
         if (libraryState && libraryState.package_events && libraryState.package_events.length) {
             return libraryState.package_events.slice();
@@ -925,7 +970,7 @@
             return [ll[1], ll[0]];
         });
         setLegStatus('Saving route…');
-        fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(selectedLegId) + '/geometry', {
+        fetch(legGeometryUrl(selectedLegId), {
             method: 'PUT',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
@@ -1251,7 +1296,7 @@
         );
         var removedLocCount = priorLocations.length - filteredLocations.length;
         setLegStatus('Saving trimmed route…');
-        fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(selectedLegId) + '/geometry', {
+        fetch(legGeometryUrl(selectedLegId), {
             method: 'PUT',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
@@ -1601,6 +1646,72 @@
         input.style.boxSizing = 'border-box';
         content.appendChild(input);
 
+        var zoneLab = document.createElement('label');
+        zoneLab.textContent = 'Zone';
+        zoneLab.style.display = 'block';
+        zoneLab.style.marginBottom = '0.25rem';
+        content.appendChild(zoneLab);
+        var zoneInput = document.createElement('input');
+        zoneInput.type = 'text';
+        zoneInput.value = (opts.loc && opts.loc.zone) || '';
+        zoneInput.style.cssText = 'display:block;width:100%;margin-bottom:0.65rem;box-sizing:border-box;';
+        content.appendChild(zoneInput);
+
+        var bufferLab = document.createElement('label');
+        bufferLab.textContent = 'Buffer (min)';
+        bufferLab.style.display = 'block';
+        bufferLab.style.marginBottom = '0.25rem';
+        content.appendChild(bufferLab);
+        var bufferInput = document.createElement('input');
+        bufferInput.type = 'number';
+        bufferInput.min = '0';
+        bufferInput.value = (opts.loc && opts.loc.buffer != null) ? String(opts.loc.buffer) : '10';
+        bufferInput.style.cssText = 'display:block;width:100%;margin-bottom:0.65rem;box-sizing:border-box;';
+        content.appendChild(bufferInput);
+
+        var notesLab = document.createElement('label');
+        notesLab.textContent = 'Notes';
+        notesLab.style.display = 'block';
+        notesLab.style.marginBottom = '0.25rem';
+        content.appendChild(notesLab);
+        var notesInput = document.createElement('textarea');
+        notesInput.rows = 2;
+        notesInput.value = (opts.loc && opts.loc.notes) || '';
+        notesInput.style.cssText = 'display:block;width:100%;margin-bottom:0.65rem;box-sizing:border-box;resize:vertical;';
+        content.appendChild(notesInput);
+
+        var resourceInputs = {};
+        getPackageResources().forEach(function (res) {
+            var rLab = document.createElement('label');
+            rLab.textContent = (res.label || res.code) + ' count';
+            rLab.style.display = 'block';
+            rLab.style.marginBottom = '0.25rem';
+            content.appendChild(rLab);
+            var rInp = document.createElement('input');
+            rInp.type = 'number';
+            rInp.min = '0';
+            var existing = 0;
+            if (opts.loc && opts.loc.resources && opts.loc.resources[res.code] != null) {
+                existing = parseInt(opts.loc.resources[res.code], 10) || 0;
+            }
+            rInp.value = String(existing);
+            rInp.style.cssText = 'display:block;width:100%;margin-bottom:0.65rem;box-sizing:border-box;';
+            resourceInputs[res.code] = rInp;
+            content.appendChild(rInp);
+        });
+
+        function applyOpsFields(target) {
+            target.zone = zoneInput.value.trim();
+            var buf = parseInt(bufferInput.value, 10);
+            target.buffer = isNaN(buf) ? 10 : Math.max(0, buf);
+            target.notes = notesInput.value.trim();
+            target.resources = {};
+            Object.keys(resourceInputs).forEach(function (code) {
+                var n = parseInt(resourceInputs[code].value, 10);
+                target.resources[code] = isNaN(n) || n < 0 ? 0 : n;
+            });
+        }
+
         var btnRow = document.createElement('div');
         btnRow.style.display = 'flex';
         btnRow.style.flexWrap = 'wrap';
@@ -1661,13 +1772,15 @@
                     placeLat = snapped.lat;
                     placeLon = snapped.lon;
                 }
-                pendingLegLocations.push({
+                var newLoc = {
                     loc_label: locLabel,
                     loc_type: locType,
                     lat: Math.round(placeLat * 1e6) / 1e6,
                     lon: Math.round(placeLon * 1e6) / 1e6,
                     placement: legLocationPlacement(locType)
-                });
+                };
+                applyOpsFields(newLoc);
+                pendingLegLocations.push(newLoc);
                 map.closePopup();
                 redrawLegLocationMarkers(getSelectedLeg());
                 setLegStatus(
@@ -1682,11 +1795,13 @@
             if (mode === 'edit-pending') {
                 var pIdx = opts.pendingIndex;
                 if (pIdx == null || pIdx < 0 || pIdx >= pendingLegLocations.length) return;
-                pendingLegLocations[pIdx] = applyLegLocationLabelType(
+                var pendingLoc = applyLegLocationLabelType(
                     pendingLegLocations[pIdx],
                     locLabel,
                     locType
                 );
+                applyOpsFields(pendingLoc);
+                pendingLegLocations[pIdx] = pendingLoc;
                 closeAndRedraw();
                 setLegStatus('Unsaved location updated.');
                 return;
@@ -1698,11 +1813,13 @@
                 if (!leg || locIndex == null || !selectedLegId) return;
                 var locations = (leg.locations || []).slice();
                 if (locIndex < 0 || locIndex >= locations.length) return;
-                locations[locIndex] = applyLegLocationLabelType(
+                var savedLoc = applyLegLocationLabelType(
                     locations[locIndex],
                     locLabel,
                     locType
                 );
+                applyOpsFields(savedLoc);
+                locations[locIndex] = savedLoc;
                 setLegStatus('Saving location…');
                 saveLegLocations(selectedLegId, locations)
                     .then(function () {
@@ -1856,7 +1973,7 @@
                 setLegStatus(
                     'Locations saved on leg ' +
                         selectedLegId +
-                        '. Open the Course tab to assign resources and segment details.'
+                        '. Apply recipes to sync locations (with resources) to the Course tab.'
                 );
             });
     }
@@ -1912,7 +2029,7 @@
     }
 
     function saveLegEndpoints(legId, startLabel, endLabel) {
-        return fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legId), {
+        return fetch(legDetailUrl(legId), {
             method: 'PUT',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
@@ -1921,7 +2038,7 @@
             .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                applyLibraryState(payload.data);
+                return afterLegLibraryMutation(payload.data);
             });
     }
 
@@ -1940,7 +2057,7 @@
             var next = window.prompt('Place name:', label || '');
             if (next == null) return;
             var fields = role === 'start' ? { start_label: next } : { end_label: next };
-            fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legId), {
+            fetch(legDetailUrl(legId), {
                 method: 'PUT',
                 credentials: 'same-origin',
                 headers: { 'Content-Type': 'application/json' },
@@ -1949,7 +2066,7 @@
                 .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
                 .then(function (payload) {
                     if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                    applyLibraryState(payload.data);
+                    return afterLegLibraryMutation(payload.data);
                 })
                 .catch(function (err) { setLegStatus(err.message || String(err), true); });
         });
@@ -1981,7 +2098,7 @@
         var requestId = legGeometryRequestId;
         clearLegMapLayers();
         updateLegActionButtons();
-        fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legId) + '/geometry', { credentials: 'same-origin' })
+        fetch(legGeometryUrl(legId), { credentials: 'same-origin' })
             .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
             .then(function (payload) {
                 if (requestId !== legGeometryRequestId || selectedLegId !== legId) {
@@ -2112,21 +2229,6 @@
         refreshOrgLibraryModal();
     }
 
-    function refreshOrgLibraryPublishSelect() {
-        var sel = document.getElementById('org-leg-publish-select');
-        if (!sel) return;
-        var legs = (libraryState && libraryState.legs) || [];
-        sel.innerHTML = '';
-        legs.forEach(function (leg) {
-            var opt = document.createElement('option');
-            opt.value = leg.id;
-            opt.textContent = leg.id + ' — ' + ((leg.leg_label || '').trim() || 'Leg');
-            sel.appendChild(opt);
-        });
-        var pubBtn = document.getElementById('btn-org-leg-publish');
-        if (pubBtn) pubBtn.disabled = !legs.length;
-    }
-
     function renderOrgLibraryTable(orgLegs) {
         var empty = document.getElementById('org-leg-library-empty');
         var wrap = document.getElementById('org-leg-library-table-wrap');
@@ -2153,22 +2255,11 @@
                 td.textContent = text;
                 tr.appendChild(td);
             });
-            var actionTd = document.createElement('td');
-            var btn = document.createElement('button');
-            btn.type = 'button';
-            btn.className = 'course-btn';
-            btn.textContent = 'Add to package';
-            btn.addEventListener('click', function () {
-                importOrgLegToPackage(orgId);
-            });
-            actionTd.appendChild(btn);
-            tr.appendChild(actionTd);
             tbody.appendChild(tr);
         });
     }
 
     function refreshOrgLibraryModal() {
-        refreshOrgLibraryPublishSelect();
         setOrgLibraryStatus('Loading org library…');
         fetch('/api/org/legs', { credentials: 'same-origin' })
             .then(function (r) {
@@ -2180,63 +2271,6 @@
             .then(function (data) {
                 renderOrgLibraryTable(data.legs || []);
                 setOrgLibraryStatus('');
-            })
-            .catch(function (err) {
-                setOrgLibraryStatus(err.message || String(err), true);
-            });
-    }
-
-    function importOrgLegToPackage(orgLegId) {
-        setOrgLibraryStatus('Adding org leg ' + orgLegId + '…');
-        fetch(
-            apiBase() + '/segment-library/import-org-leg/' + encodeURIComponent(orgLegId),
-            { method: 'POST', credentials: 'same-origin' }
-        )
-            .then(function (r) {
-                return r.json().then(function (d) {
-                    if (!r.ok) throw new Error(formatApiError(r, d));
-                    return d;
-                });
-            })
-            .then(function (data) {
-                libraryState = data;
-                renderLegsTable();
-                renderRecipeTable();
-                setOrgLibraryStatus(
-                    'Added org leg ' + orgLegId + ' as package leg ' +
-                        (data.imported_package_leg_id || '') + '.'
-                );
-                setLegStatus('Imported org leg ' + orgLegId + '.');
-            })
-            .catch(function (err) {
-                setOrgLibraryStatus(err.message || String(err), true);
-            });
-    }
-
-    function publishLegToOrgLibrary() {
-        var sel = document.getElementById('org-leg-publish-select');
-        var legId = sel && sel.value;
-        if (!legId) {
-            setOrgLibraryStatus('Select a package leg to publish.', true);
-            return;
-        }
-        setOrgLibraryStatus('Publishing leg ' + legId + '…');
-        fetch(
-            apiBase() + '/segment-library/legs/' + encodeURIComponent(legId) + '/publish-to-org',
-            { method: 'POST', credentials: 'same-origin' }
-        )
-            .then(function (r) {
-                return r.json().then(function (d) {
-                    if (!r.ok) throw new Error(formatApiError(r, d));
-                    return d;
-                });
-            })
-            .then(function (data) {
-                setOrgLibraryStatus(
-                    'Published as org leg ' + (data.org_leg_id || '') +
-                        ' (' + (data.leg_label || '') + ').'
-                );
-                refreshOrgLibraryModal();
             })
             .catch(function (err) {
                 setOrgLibraryStatus(err.message || String(err), true);
@@ -2279,7 +2313,7 @@
     }
 
     function saveLegLocations(legId, locations) {
-        return fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legId), {
+        return fetch(legDetailUrl(legId), {
             method: 'PUT',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
@@ -2288,7 +2322,7 @@
             .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                applyLibraryState(payload.data);
+                return afterLegLibraryMutation(payload.data);
             });
     }
 
@@ -2732,7 +2766,7 @@
 
     function deleteLeg(legId) {
         setLegStatus('Deleting leg…');
-        fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legId), {
+        fetch(legDetailUrl(legId), {
             method: 'DELETE',
             credentials: 'same-origin'
         })
@@ -2740,9 +2774,9 @@
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
                 if (selectedLegId === legId) clearLegMap();
-                applyLibraryState(payload.data);
-                setLegStatus('Leg deleted.');
+                return afterLegLibraryMutation(payload.data);
             })
+            .then(function () { setLegStatus('Leg deleted.'); })
             .catch(function (err) { setLegStatus(err.message || String(err), true); });
     }
 
@@ -2978,19 +3012,21 @@
             fd.append('flow_type', fields.flow_type);
             fd.append('description', fields.description);
             setLegStatus('Saving leg…');
-            fetch(apiBase() + '/segment-library/legs', { method: 'POST', credentials: 'same-origin', body: fd })
+            fetch(legCreateUrl(), { method: 'POST', credentials: 'same-origin', body: fd })
                 .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
                 .then(function (payload) {
                     if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                    applyLibraryState(payload.data);
+                    return afterLegLibraryMutation(payload.data);
+                })
+                .then(function () {
                     closeLegEditor();
-                    setLegStatus('Leg added. Select it in the table to view on the map.');
+                    setLegStatus('Leg added to the organization library. Select it in the table to view on the map.');
                 })
                 .catch(function (err) { setLegStatus(err.message || String(err), true); });
             return;
         }
         setLegStatus('Saving leg…');
-        fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legEditorLegId), {
+        fetch(legDetailUrl(legEditorLegId), {
             method: 'PUT',
             credentials: 'same-origin',
             headers: { 'Content-Type': 'application/json' },
@@ -2999,7 +3035,9 @@
             .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                applyLibraryState(payload.data);
+                return afterLegLibraryMutation(payload.data);
+            })
+            .then(function () {
                 closeLegEditor();
                 setLegStatus('Leg saved.');
             })
@@ -3010,7 +3048,10 @@
         var fd = new FormData();
         fd.append('file', file);
         setLegStatus('Updating GPX…');
-        fetch(apiBase() + '/segment-library/legs/' + encodeURIComponent(legId) + '/gpx', {
+        var gpxUrl = usesOrgLegLibrary()
+            ? '/api/org/legs/' + encodeURIComponent(legId) + '/gpx'
+            : apiBase() + '/segment-library/legs/' + encodeURIComponent(legId) + '/gpx';
+        fetch(gpxUrl, {
             method: 'PUT',
             credentials: 'same-origin',
             body: fd
@@ -3018,9 +3059,9 @@
             .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                applyLibraryState(payload.data);
-                setLegStatus('GPX updated.');
+                return afterLegLibraryMutation(payload.data);
             })
+            .then(function () { setLegStatus('GPX updated.'); })
             .catch(function (err) { setLegStatus(err.message || String(err), true); });
     }
 
@@ -3034,16 +3075,20 @@
             if (n.endsWith('.json')) hasJson = true;
         }
         setLegStatus('Importing leg file' + (files.length > 1 ? 's' : '') + '…');
-        fetch(apiBase() + '/segment-library/upload', { method: 'POST', credentials: 'same-origin', body: fd })
+        fetch(legUploadUrl(), { method: 'POST', credentials: 'same-origin', body: fd })
             .then(function (r) { return r.json().then(function (d) { return { res: r, data: d }; }); })
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
-                applyLibraryState(payload.data);
-                var count = (payload.data.legs || []).length;
+                return afterLegLibraryMutation(payload.data).then(function () {
+                    return payload.data;
+                });
+            })
+            .then(function (data) {
+                var count = (data.legs || []).length;
                 var msg =
                     'Imported ' +
                     count +
-                    ' leg(s). Select a leg to view on the map.';
+                    ' leg(s) to the organization library. Select a leg to view on the map.';
                 if (!hasJson) {
                     msg +=
                         ' Tip: include the .json from a leg export zip to restore locations and metadata.';
@@ -3118,8 +3163,6 @@
         if (orgLibDone) orgLibDone.addEventListener('click', closeOrgLibraryModal);
         var orgLibBackdrop = document.querySelector('#org-leg-library-modal .course-location-modal-backdrop');
         if (orgLibBackdrop) orgLibBackdrop.addEventListener('click', closeOrgLibraryModal);
-        var orgPublishBtn = document.getElementById('btn-org-leg-publish');
-        if (orgPublishBtn) orgPublishBtn.addEventListener('click', publishLegToOrgLibrary);
         if (bulkInput) {
             bulkInput.addEventListener('change', function () {
                 uploadGpxBulk(bulkInput.files);

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -300,7 +300,7 @@
             {% if cloud_mode %}
             <li><a href="/dashboard" {% if request.url and request.url.path == "/dashboard" %}class="active"{% endif %}>Dashboard</a></li>
             <li><a href="/locations" {% if request.url and request.url.path == "/locations" %}class="active"{% endif %}>Locations</a></li>
-            <li><a href="/locsheets" {% if request.url and request.url.path == "/locsheets" %}class="active"{% endif %}>Loc Sheets</a></li>
+            {# Loc Sheets (/locsheets) hidden from nav; one-pagers linked from Locations UI — route kept for now #}
             <li><a href="/logout" style="color: #e74c3c;">Logout</a></li>
             {% else %}
             <li><a href="/dashboard" {% if request.url and request.url.path == "/dashboard" %}class="active"{% endif %}>Dashboard</a></li>
@@ -308,7 +308,7 @@
             <li><a href="/density" {% if request.url and request.url.path == "/density" %}class="active"{% endif %}>Density</a></li>
             <li><a href="/flow" {% if request.url and request.url.path == "/flow" %}class="active"{% endif %}>Flow</a></li>
             <li><a href="/locations" {% if request.url and request.url.path == "/locations" %}class="active"{% endif %}>Locations</a></li>
-            <li><a href="/locsheets" {% if request.url and request.url.path == "/locsheets" %}class="active"{% endif %}>Loc Sheets</a></li>
+            {# Loc Sheets (/locsheets) hidden from nav; one-pagers linked from Locations UI — route kept for now #}
             <li><a href="/reports" {% if request.url and request.url.path == "/reports" %}class="active"{% endif %}>Reports</a></li>
             <li><a href="/analysis" {% if request.url and request.url.path == "/analysis" %}class="active"{% endif %}>Analysis</a></li>
             <li><a href="/config" {% if request.url and request.url.path == "/config" %}class="active"{% endif %}>Race Configuration</a></li>

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -192,8 +192,8 @@
         if (currentSort.column) {
             sortedSegments = sortSegments(segments, currentSort.column, currentSort.direction);
         } else {
-            // Default sort by seg_id
-            sortedSegments = [...segments].sort((a, b) => (a.seg_id || '').localeCompare(b.seg_id || ''));
+            // Default sort by seg_id (numeric-aware: S2 before S10)
+            sortedSegments = [...segments].sort((a, b) => (a.seg_id || '').localeCompare(b.seg_id || '', undefined, { numeric: true }));
         }
         
         sortedSegments.forEach(segment => {

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -74,19 +74,19 @@
         </section>
         <section class="content-card course-derived-section" id="course-legs-card">
             <div class="card-header">
-                <h4 class="card-title">Course legs</h4>
+                <h4 class="card-title">Organization leg library</h4>
                 <div class="card-actions course-planner-toolbar config-legs-table-toolbar">
                 <input type="file" id="segment-library-gpx-input" accept=".gpx,.json" multiple style="display: none;" />
-                <button type="button" id="btn-import-gpx" class="course-btn" title="Import GPX routes and optional leg export JSON (locations + metadata)">Import legs…</button>
-                <button type="button" id="btn-org-leg-library" class="course-btn" title="Add legs from your organization library or publish legs for reuse">Org library…</button>
+                <button type="button" id="btn-import-gpx" class="course-btn" title="Import third-party GPX (+ optional leg export JSON) into the organization leg library">Import legs…</button>
+                <button type="button" id="btn-org-leg-library" class="course-btn" title="View legs stored outside this package (runflow/org/legs)">Leg library…</button>
                 <button type="button" id="btn-export-all-legs" class="course-btn" disabled title="Download all legs (GPX + metadata + locations per leg)">Export legs…</button>
                 <button type="button" id="btn-draw-leg-map" class="course-btn" disabled title="Coming soon: draw a new leg on the map">Draw leg on map</button>
                 </div>
             </div>
             <p class="card-help course-derived-empty">
-                <strong>Import legs…</strong> uploads GPX (+ optional JSON). <strong>Org library…</strong> reuses legs shared across races.
-                Select a leg in the table (<strong>Edit</strong> for details). After <strong>Apply recipes</strong>, locations sync to the
-                <button type="button" id="btn-go-to-recipes" class="course-link-btn">Course</button> tab — <strong>ID</strong> stays stable; <strong>Key</strong> is the internal anchor.
+                Legs live in the <strong>organization library</strong> (outside this package). <strong>Import legs…</strong> adds GPX from a third-party tool.
+                Place locations (with resources) on each leg, then assign legs to events via <strong>Event recipes</strong>.
+                <strong>Apply recipes</strong> builds the course on the <button type="button" id="btn-go-to-recipes" class="course-link-btn">Course</button> tab.
             </p>
             <p id="course-legs-status" class="course-derived-empty" style="display: none;"></p>
             <div id="course-legs-table-wrap" class="config-legs-table-region" style="display: none;">
@@ -345,12 +345,12 @@
         </div>
         <div class="course-location-modal-body">
             <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;">
-                Shared legs live outside this package. <strong>Add to package</strong> copies a leg here with a new package ID.
-                <strong>Publish to org</strong> saves the selected package leg for other races.
+                Legs are stored at <code>runflow/org/legs/</code> and shared across all config packages.
+                Use <strong>Import legs…</strong> on the Legs tab to add GPX files here.
             </p>
             <p id="org-leg-library-status" class="course-derived-empty" style="display: none;"></p>
             <h5 class="course-derived-heading" style="margin: 0.5rem 0;">Org legs</h5>
-            <div id="org-leg-library-empty" class="card-help course-derived-empty">No org legs yet. Publish a leg from this package below.</div>
+            <div id="org-leg-library-empty" class="card-help course-derived-empty">No org legs yet. Use <strong>Import legs…</strong> on the Legs tab to add GPX files.</div>
             <div id="org-leg-library-table-wrap" class="scrollable-table-container course-derived-table-scroll" style="display: none; max-height: 220px;">
                 <table class="table-sticky-header course-planner-table" style="width: 100%; font-size: 0.875rem;">
                     <thead>
@@ -359,17 +359,10 @@
                             <th>Label</th>
                             <th>km</th>
                             <th>Locs</th>
-                            <th></th>
                         </tr>
                     </thead>
                     <tbody id="org-leg-library-tbody"></tbody>
                 </table>
-            </div>
-            <h5 class="course-derived-heading" style="margin: 1rem 0 0.5rem 0;">Publish from this package</h5>
-            <div style="display: flex; flex-wrap: wrap; gap: 0.5rem; align-items: center;">
-                <label for="org-leg-publish-select" style="font-size: 0.875rem;">Package leg</label>
-                <select id="org-leg-publish-select" class="course-input" style="min-width: 12rem;"></select>
-                <button type="button" id="btn-org-leg-publish" class="course-btn">Publish to org library</button>
             </div>
         </div>
         <div class="course-location-modal-footer">

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -182,7 +182,7 @@
         </div>
         <div class="course-location-modal-body">
             <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;">
-                Assign <strong>order numbers</strong> (1, 2, 3…) per event to build each distance from your legs. Then <em>Save recipes &amp; export</em> for <code>segments.csv</code> and per-event GPX.
+                Assign <strong>order numbers</strong> (1, 2, 3…) per event to build each distance from your legs. Reuse a leg by entering multiple slots (e.g. <code>7,16</code>). Then <em>Save recipes &amp; export</em> for <code>segments.csv</code> and per-event GPX.
             </p>
             <p id="segment-recipes-status" class="course-derived-empty" style="display: none;"></p>
             <div id="segment-recipes-totals" style="display: none; margin-bottom: 0.5rem; font-size: 0.875rem;">

--- a/scripts/migrate_leg_locations.py
+++ b/scripts/migrate_leg_locations.py
@@ -1,0 +1,395 @@
+#!/usr/bin/env python3
+"""
+Copy leg-scoped locations (and resources) from a legacy package segment_library
+into org legs used by an org-primary config package.
+
+Matches legs by explicit map and/or nearest GPX geometry. Run inside Docker:
+
+  python scripts/migrate_leg_locations.py \\
+    --source K6F4cn3dM4TCzNQEDxJBeD \\
+    --target QhVdbSZKvjQ4cEGvPDddtb \\
+    --apply
+"""
+
+from __future__ import annotations
+
+import argparse
+import copy
+import json
+import math
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import yaml
+
+from app.core.config_package.org_leg_library import (
+    load_org_leg_manifest,
+    save_org_leg_manifest,
+)
+from app.core.config_package.segment_recipes import apply_package_recipes
+from app.core.config_package.storage import (
+    get_config_root,
+    load_config_course,
+    load_config_manifest,
+    resolve_config_package_path,
+    save_config_course,
+    save_config_manifest,
+)
+from app.core.locations.schema import count_column, ensure_manifest_resources, normalize_location_record
+from app.utils.constants import COURSE_EVENT_IDS
+from app.core.course.segment_library import manifest_legs, parse_leg_gpx, set_manifest_legs
+from app.core.config_package.legs import _normalize_locations
+from app.utils.run_id import get_runflow_root
+
+# High-confidence K6 leg id -> org leg id (length/label verified manually).
+EXPLICIT_K6_TO_ORG: Dict[str, str] = {
+    "01": "12",  # Start to Friel
+    "02": "05",  # Friel to 10k Turn
+    "05": "06",  # Friel to Station At Barker
+    "06": "13",  # Station to Gibson Trail (short)
+    "08": "09",  # Gibson Trail to Bridge at Mill
+    "14": "03",  # Bridge Mill to Half Turn
+    "15": "10",  # Half Turn to Bridge at Mill
+    "13": "11",  # Half Turn to Full Turn (chase)
+}
+
+_LOC_FIELDS = (
+    "loc_label",
+    "loc_type",
+    "lat",
+    "lon",
+    "placement",
+    "location_key",
+    "notes",
+    "buffer",
+    "interval",
+    "zone",
+    "equipment",
+    "contact",
+    "proxy_loc_id",
+    "day",
+    "onepage",
+    "resources",
+)
+
+_COURSE_MERGE_FIELDS = _LOC_FIELDS + tuple(COURSE_EVENT_IDS)
+
+
+def _haversine_m(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
+    r = 6371000.0
+    d_lat = math.radians(lat2 - lat1)
+    d_lon = math.radians(lon2 - lon1)
+    a = (
+        math.sin(d_lat / 2) ** 2
+        + math.cos(math.radians(lat1))
+        * math.cos(math.radians(lat2))
+        * math.sin(d_lon / 2) ** 2
+    )
+    return r * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _point_to_route_m(lon: float, lat: float, coords: List[List[float]]) -> float:
+    if not coords:
+        return float("inf")
+    best = float("inf")
+    for lon2, lat2 in coords:
+        best = min(best, _haversine_m(lon, lat, lon2, lat2))
+    for i in range(len(coords) - 1):
+        lon_a, lat_a = coords[i]
+        lon_b, lat_b = coords[i + 1]
+        for t in (0.25, 0.5, 0.75):
+            lon_m = lon_a + (lon_b - lon_a) * t
+            lat_m = lat_a + (lat_b - lat_a) * t
+            best = min(best, _haversine_m(lon, lat, lon_m, lat_m))
+    return best
+
+
+def _load_source_legs(source_id: str) -> List[Dict[str, Any]]:
+    lib = get_config_root() / source_id / "segment_library"
+    manifest = yaml.safe_load((lib / "manifest.yaml").read_text(encoding="utf-8"))
+    rows: List[Dict[str, Any]] = []
+    for entry in manifest_legs(manifest):
+        gpx = lib / str(entry["file"])
+        parsed = parse_leg_gpx(gpx) if gpx.is_file() else {}
+        rows.append(
+            {
+                "id": str(entry["id"]).strip(),
+                "seg_label": str(entry.get("seg_label") or "").strip(),
+                "locations": copy.deepcopy(entry.get("locations") or []),
+                "coords": parsed.get("coordinates") or [],
+            }
+        )
+    return rows
+
+
+def _load_org_legs() -> Tuple[Dict[str, Any], List[Dict[str, Any]]]:
+    org_dir = get_runflow_root() / "org" / "legs"
+    manifest = load_org_leg_manifest()
+    legs: List[Dict[str, Any]] = []
+    for entry in manifest_legs(manifest):
+        gpx = org_dir / str(entry["file"])
+        parsed = parse_leg_gpx(gpx) if gpx.is_file() else {}
+        legs.append(
+            {
+                "entry": copy.deepcopy(entry),
+                "id": str(entry["id"]).strip(),
+                "coords": parsed.get("coordinates") or [],
+            }
+        )
+    return manifest, legs
+
+
+def _loc_key(loc: Dict[str, Any]) -> Tuple:
+    return (
+        round(float(loc.get("lat") or 0), 5),
+        round(float(loc.get("lon") or 0), 5),
+        str(loc.get("loc_label") or "").strip().lower(),
+    )
+
+
+def _trim_loc(loc: Dict[str, Any]) -> Dict[str, Any]:
+    out = {k: copy.deepcopy(loc[k]) for k in _LOC_FIELDS if k in loc}
+    return out
+
+
+def _enrich_loc_from_course(
+    loc: Dict[str, Any],
+    course_by_key: Dict[Tuple, Dict[str, Any]],
+    resource_codes: List[str],
+) -> Dict[str, Any]:
+    """Overlay ops metadata from source course.json (resource counts live there, not in leg manifest)."""
+    src = course_by_key.get(_loc_key(loc))
+    if not src:
+        return loc
+    out = copy.deepcopy(loc)
+    for field in _COURSE_MERGE_FIELDS:
+        if field in src and src[field] not in (None, ""):
+            out[field] = copy.deepcopy(src[field])
+    for code in resource_codes:
+        col = count_column(code)
+        if col in src and src[col] not in (None, ""):
+            out[col] = src[col]
+    if isinstance(src.get("resources"), dict):
+        out["resources"] = copy.deepcopy(src["resources"])
+    normalize_location_record(out, resource_codes, index=0)
+    return out
+
+
+def merge_course_location_metadata(source_id: str, target_id: str) -> Dict[str, Any]:
+    """Copy resource counts and ops fields from source course.json onto target course locations."""
+    src_course = load_config_course(source_id)
+    tgt_course = load_config_course(target_id)
+    tgt_manifest = load_config_manifest(target_id)
+    resource_codes = [r["code"] for r in ensure_manifest_resources(tgt_manifest)]
+
+    src_by_key = {
+        _loc_key(loc): loc
+        for loc in (src_course.get("locations") or [])
+        if isinstance(loc, dict)
+    }
+
+    merged = 0
+    unmatched: List[str] = []
+    for loc in tgt_course.get("locations") or []:
+        if not isinstance(loc, dict):
+            continue
+        src = src_by_key.get(_loc_key(loc))
+        if not src:
+            unmatched.append(str(loc.get("loc_label") or ""))
+            continue
+        for field in _COURSE_MERGE_FIELDS:
+            if field in src and src[field] not in (None, ""):
+                loc[field] = copy.deepcopy(src[field])
+        for code in resource_codes:
+            col = count_column(code)
+            if col in src and src[col] not in (None, ""):
+                loc[col] = src[col]
+        if isinstance(src.get("resources"), dict):
+            loc["resources"] = copy.deepcopy(src["resources"])
+        idx = max(0, int(loc.get("id", 1)) - 1)
+        normalize_location_record(loc, resource_codes, index=idx)
+        merged += 1
+
+    save_config_course(target_id, tgt_course)
+    return {
+        "course_locations_merged": merged,
+        "course_unmatched": len(unmatched),
+        "unmatched_labels": unmatched[:10],
+    }
+
+
+def _nearest_org_leg(
+    loc: Dict[str, Any],
+    org_legs: List[Dict[str, Any]],
+) -> Tuple[Optional[str], float]:
+    lat = float(loc.get("lat") or 0)
+    lon = float(loc.get("lon") or 0)
+    placement = str(loc.get("placement") or "along").strip().lower()
+    limit_m = 900.0 if placement == "off" or loc.get("loc_type") == "traffic" else 350.0
+    best_id: Optional[str] = None
+    best_d = float("inf")
+    for leg in org_legs:
+        d = _point_to_route_m(lon, lat, leg["coords"])
+        if d < best_d:
+            best_d = d
+            best_id = leg["id"]
+    if best_d > limit_m:
+        return None, best_d
+    return best_id, best_d
+
+
+def migrate(
+    source_id: str,
+    target_id: str,
+    *,
+    apply: bool = False,
+    dry_run: bool = False,
+    course_only: bool = False,
+) -> Dict[str, Any]:
+    if course_only:
+        course_result = merge_course_location_metadata(source_id, target_id)
+        if apply:
+            from app.core.config_package.legs import sync_leg_location_metadata_from_course
+
+            sync_leg_location_metadata_from_course(target_id)
+            course_result["synced_org_legs"] = True
+        return course_result
+
+    source_legs = _load_source_legs(source_id)
+    src_course = load_config_course(source_id)
+    src_manifest = load_config_manifest(source_id)
+    resource_codes = [r["code"] for r in ensure_manifest_resources(src_manifest)]
+    course_by_key = {
+        _loc_key(loc): loc
+        for loc in (src_course.get("locations") or [])
+        if isinstance(loc, dict)
+    }
+    org_manifest, org_legs = _load_org_legs()
+    org_by_id = {leg["id"]: leg for leg in org_legs}
+
+    assigned: Dict[str, List[Dict[str, Any]]] = {leg["id"]: [] for leg in org_legs}
+    seen: Dict[str, set] = {leg["id"]: set() for leg in org_legs}
+    report: Dict[str, Any] = {
+        "explicit": [],
+        "geometry": [],
+        "skipped": [],
+        "unmapped_source_legs": [],
+    }
+
+    for src in source_legs:
+        src_id = src["id"]
+        locs = src["locations"]
+        if not locs:
+            continue
+        org_id = EXPLICIT_K6_TO_ORG.get(src_id)
+        mode = "explicit"
+        for loc in locs:
+            trimmed = _trim_loc(loc)
+            if not trimmed:
+                continue
+            target_org = org_id
+            dist_m = 0.0
+            if not target_org:
+                mode = "geometry"
+                target_org, dist_m = _nearest_org_leg(trimmed, org_legs)
+            if not target_org:
+                report["skipped"].append(
+                    {
+                        "source_leg": src_id,
+                        "label": trimmed.get("loc_label"),
+                        "reason": f"no org leg within tolerance ({dist_m:.0f}m)",
+                    }
+                )
+                continue
+            enriched = _enrich_loc_from_course(trimmed, course_by_key, resource_codes)
+            key = _loc_key(enriched)
+            if key in seen[target_org]:
+                continue
+            seen[target_org].add(key)
+            assigned[target_org].append(enriched)
+            bucket = report["explicit"] if mode == "explicit" else report["geometry"]
+            bucket.append(
+                {
+                    "source_leg": src_id,
+                    "org_leg": target_org,
+                    "label": trimmed.get("loc_label"),
+                    "dist_m": round(dist_m, 1),
+                }
+            )
+        if not org_id and locs:
+            report["unmapped_source_legs"].append(
+                {"source_leg": src_id, "seg_label": src["seg_label"], "loc_count": len(locs)}
+            )
+
+    if dry_run:
+        counts = {oid: len(locs) for oid, locs in assigned.items() if locs}
+        report["org_location_counts"] = counts
+        report["total"] = sum(counts.values())
+        return report
+
+    for leg in org_legs:
+        oid = leg["id"]
+        new_locs = assigned.get(oid) or []
+        if not new_locs:
+            continue
+        entry = leg["entry"]
+        entry["locations"] = _normalize_locations(new_locs)
+        org_by_id[oid]["entry"] = entry
+
+    updated_entries = [org_by_id[leg["id"]]["entry"] for leg in org_legs]
+    set_manifest_legs(org_manifest, updated_entries)
+    save_org_leg_manifest(org_manifest)
+
+    # Copy resource registry from source package to target.
+    src_manifest = load_config_manifest(source_id)
+    tgt_path = resolve_config_package_path(target_id)
+    tgt_manifest = load_config_manifest(target_id)
+    tgt_manifest["resources"] = copy.deepcopy(src_manifest.get("resources") or [])
+    save_config_manifest(tgt_path, tgt_manifest)
+
+    result = {
+        "org_legs_updated": [oid for oid, locs in assigned.items() if locs],
+        "location_counts": {oid: len(locs) for oid, locs in assigned.items() if locs},
+        "total_locations": sum(len(locs) for locs in assigned.values()),
+        "resources_copied": len(tgt_manifest.get("resources") or []),
+        "report": report,
+    }
+
+    course_result = merge_course_location_metadata(source_id, target_id)
+    result["course_merge"] = course_result
+
+    if apply:
+        from app.core.config_package.legs import sync_leg_location_metadata_from_course
+
+        sync_leg_location_metadata_from_course(target_id)
+        apply_package_recipes(target_id, export_csv=True)
+        result["applied"] = True
+        result["synced_org_legs"] = True
+
+    return result
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Migrate leg locations to org library")
+    parser.add_argument("--source", required=True, help="Source config_id (legacy package legs)")
+    parser.add_argument("--target", required=True, help="Target config_id (org-primary package)")
+    parser.add_argument("--apply", action="store_true", help="Apply recipes after migration")
+    parser.add_argument("--dry-run", action="store_true", help="Report only; do not write")
+    parser.add_argument(
+        "--course-only",
+        action="store_true",
+        help="Merge course.json metadata only (skip org leg reassignment)",
+    )
+    args = parser.parse_args()
+    out = migrate(
+        args.source,
+        args.target,
+        apply=args.apply,
+        dry_run=args.dry_run,
+        course_only=args.course_only,
+    )
+    print(json.dumps(out, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/unit/test_config_package_course.py
+++ b/tests/unit/test_config_package_course.py
@@ -19,7 +19,7 @@ def test_load_config_course_missing_file(tmp_path, monkeypatch):
         "app.core.config_package.storage.get_config_root",
         lambda: tmp_path,
     )
-    result = create_config_package("Pkg", "")
+    result = create_config_package("Pkg", "", package_events=["full"])
     config_id = result["config_id"]
     (tmp_path / config_id / "course.json").unlink()
 
@@ -41,7 +41,7 @@ def test_save_load_round_trip(tmp_path, monkeypatch):
         "app.core.config_package.storage.get_config_root",
         lambda: tmp_path,
     )
-    result = create_config_package("Course RT", "round trip")
+    result = create_config_package("Course RT", "round trip", package_events=["full"])
     config_id = result["config_id"]
 
     course = load_config_course(config_id)
@@ -75,6 +75,50 @@ def test_save_load_round_trip(tmp_path, monkeypatch):
     )
     assert on_disk["config_id"] == config_id
     assert "events" not in on_disk
+
+
+def test_save_preserves_recipe_kms_from_stale_client(tmp_path, monkeypatch):
+    """A stale client save must not revert recipe-applied per-event kms or drop the flag."""
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    result = create_config_package("Recipe Pkg", "", package_events=["full", "half"])
+    config_id = result["config_id"]
+
+    # Simulate recipe apply: course on disk has flag + correct per-event kms.
+    course = load_config_course(config_id)
+    course["segment_library_applied"] = True
+    course["segments"] = [
+        {
+            "seg_id": "S10",
+            "label": "Gibson",
+            "leg_id": "09",
+            "from_km": 23.9,
+            "to_km": 29.67,
+            "events": ["full", "half"],
+            "full_from_km": 23.9,
+            "full_to_km": 29.67,
+            "half_from_km": 5.06,
+            "half_to_km": 10.83,
+        }
+    ]
+    save_config_course(config_id, course)
+
+    # Stale browser snapshot: no flag, old corrupted kms, but a new label edit.
+    stale = load_config_course(config_id)
+    stale.pop("segment_library_applied", None)
+    stale["segments"][0].update(
+        {"half_from_km": 6.62, "half_to_km": 12.39, "label": "Gibson (edited)"}
+    )
+    save_config_course(config_id, stale)
+
+    reloaded = load_config_course(config_id)
+    seg = reloaded["segments"][0]
+    assert reloaded["segment_library_applied"] is True
+    assert seg["half_from_km"] == 5.06
+    assert seg["half_to_km"] == 10.83
+    assert seg["label"] == "Gibson (edited)"
 
 
 def test_validate_config_course_rejects_id_mismatch():

--- a/tests/unit/test_leg_library_resolver.py
+++ b/tests/unit/test_leg_library_resolver.py
@@ -302,3 +302,36 @@ def test_export_after_apply_org_primary_keeps_segments(tmp_path, monkeypatch):
     assert exported["segment_count"] >= 1
     course = load_config_course(config_id)
     assert len(course.get("segments") or []) >= 1
+
+
+def test_export_org_primary_writes_flow_and_gpx(tmp_path, monkeypatch):
+    """Org-primary packages must export flow.csv + GPX from org legs, not empty package library."""
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(tmp_path)
+
+    result = create_config_package(
+        "Pkg", "", event_day="sun", package_events=["full", "half"]
+    )
+    config_id = result["config_id"]
+    package_path = tmp_path / "config" / config_id
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"], "half": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+
+    applied = apply_package_recipes(config_id, export_csv=True)
+    flow_path = package_path / "flow.csv"
+    assert flow_path.is_file()
+    flow_lines = flow_path.read_text(encoding="utf-8").strip().splitlines()
+    assert len(flow_lines) >= 2, "shared-leg cross-event flow rows expected"
+    assert "full" in flow_lines[1] and "half" in flow_lines[1]
+    assert (package_path / "full.gpx").is_file()
+    assert (package_path / "half.gpx").is_file()
+    assert applied["flow_csv_path"] == str(flow_path)
+    assert {g["event_id"] for g in applied.get("gpx_files") or []} == {"full", "half"}

--- a/tests/unit/test_leg_library_resolver.py
+++ b/tests/unit/test_leg_library_resolver.py
@@ -16,7 +16,11 @@ from app.core.config_package.segment_recipes import (
     get_package_segment_library_state,
     save_package_segment_manifest,
 )
-from app.core.config_package.storage import create_config_package, load_config_course
+from app.core.config_package.storage import (
+    create_config_package,
+    export_config_package_segments,
+    load_config_course,
+)
 
 _GPX = """<?xml version="1.0"?>
 <gpx xmlns="http://www.topografix.com/GPX/1/1">
@@ -223,3 +227,28 @@ def test_merge_org_leg_locations_carry_resources(tmp_path, monkeypatch):
     _lib_dir, combined = combined_manifest_for_apply(config_id)
     assert combined["recipes"]["full"] == ["05"]
     assert {leg["id"] for leg in combined["legs"]} == {"05", "06"}
+
+
+def test_export_after_apply_org_primary_keeps_segments(tmp_path, monkeypatch):
+    """Regression: export must not drop segments when legs live in org library."""
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(tmp_path)
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+
+    apply_package_recipes(config_id, export_csv=False)
+    exported = export_config_package_segments(config_id)
+    assert exported["segment_count"] >= 1
+    course = load_config_course(config_id)
+    assert len(course.get("segments") or []) >= 1

--- a/tests/unit/test_leg_library_resolver.py
+++ b/tests/unit/test_leg_library_resolver.py
@@ -1,5 +1,6 @@
 """Tests for org-primary leg library resolution (Issue #780)."""
 
+import pytest
 import yaml
 
 from app.core.config_package.leg_library_resolver import (
@@ -227,6 +228,55 @@ def test_merge_org_leg_locations_carry_resources(tmp_path, monkeypatch):
     _lib_dir, combined = combined_manifest_for_apply(config_id)
     assert combined["recipes"]["full"] == ["05"]
     assert {leg["id"] for leg in combined["legs"]} == {"05", "06"}
+
+
+def test_apply_preserves_half_recipe_km_order(tmp_path, monkeypatch):
+    """Half-only legs must not inherit cumulative km from global segment row order."""
+    _patch_roots(tmp_path, monkeypatch)
+    org_dir = tmp_path / "org" / "legs"
+    org_dir.mkdir(parents=True)
+    gpx = _GPX
+    legs_spec = [
+        ("12", "start.gpx", 2.71),
+        ("06", "mid.gpx", 2.32),
+        ("13", "connector.gpx", 0.03),
+        ("09", "long.gpx", 5.77),
+        ("14", "finish.gpx", 0.2),
+    ]
+    manifest_legs_list = []
+    for leg_id, fname, _km in legs_spec:
+        (org_dir / fname).write_text(gpx, encoding="utf-8")
+        manifest_legs_list.append(
+            {"id": leg_id, "file": fname, "seg_label": f"Leg {leg_id}"}
+        )
+    (org_dir / "manifest.yaml").write_text(
+        yaml.safe_dump({"legs": manifest_legs_list}),
+        encoding="utf-8",
+    )
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["half"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"half": ["12", "06", "13", "09", "14"]},
+            "flow_overrides": [],
+        },
+    )
+
+    apply_package_recipes(config_id, export_csv=True)
+    course = load_config_course(config_id)
+    assert course.get("segment_library_applied") is True
+    by_leg = {s["leg_id"]: s for s in course["segments"]}
+    # Leg 13 is 3rd in half recipe (after 12, 06), not after finish leg 14.
+    assert by_leg["06"]["half_from_km"] < by_leg["13"]["half_from_km"]
+    assert by_leg["13"]["half_to_km"] < by_leg["14"]["half_from_km"]
+    assert by_leg["14"]["half_to_km"] == max(
+        s["half_to_km"] for s in course["segments"] if s.get("half_to_km")
+    )
 
 
 def test_export_after_apply_org_primary_keeps_segments(tmp_path, monkeypatch):

--- a/tests/unit/test_leg_library_resolver.py
+++ b/tests/unit/test_leg_library_resolver.py
@@ -1,0 +1,225 @@
+"""Tests for org-primary leg library resolution (Issue #780)."""
+
+import yaml
+
+from app.core.config_package.leg_library_resolver import (
+    LEG_SOURCE_ORG,
+    LEG_SOURCE_PACKAGE,
+    combined_manifest_for_apply,
+    effective_leg_source,
+    recipe_leg_ids_from_package,
+    resolve_leg_library,
+)
+from app.core.config_package.legs import merge_leg_locations_into_course
+from app.core.config_package.segment_recipes import (
+    apply_package_recipes,
+    get_package_segment_library_state,
+    save_package_segment_manifest,
+)
+from app.core.config_package.storage import create_config_package, load_config_course
+
+_GPX = """<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><name>Org trail</name><trkseg>
+    <trkpt lat="45.96" lon="-66.64"/>
+    <trkpt lat="45.97" lon="-66.63"/>
+  </trkseg></trk>
+</gpx>"""
+
+
+def _seed_org_leg(tmp_path, *, legs=None):
+    org_dir = tmp_path / "org" / "legs"
+    org_dir.mkdir(parents=True)
+    if legs is None:
+        legs = [
+            {
+                "leg_id": "05",
+                "label": "Org trail",
+                "loc_label": "Water",
+                "loc_type": "water",
+                "resources": None,
+            }
+        ]
+    manifest_legs = []
+    for spec in legs:
+        leg_id = spec["leg_id"]
+        gpx_name = f"{leg_id}_org_trail.gpx"
+        (org_dir / gpx_name).write_text(_GPX, encoding="utf-8")
+        loc = {
+            "loc_label": spec.get("loc_label", "Water"),
+            "loc_type": spec.get("loc_type", "water"),
+            "lat": 45.961,
+            "lon": -66.642,
+            "placement": "along",
+            "zone": spec.get("zone", "A1"),
+            "buffer": spec.get("buffer", 30),
+            "notes": spec.get("notes", "Carry cups"),
+        }
+        resources = spec.get("resources")
+        if resources is not None:
+            loc["resources"] = resources
+        manifest_legs.append(
+            {
+                "id": leg_id,
+                "file": gpx_name,
+                "seg_label": spec.get("label", "Org trail"),
+                "start_label": "Start",
+                "end_label": "End",
+                "locations": [loc],
+            }
+        )
+    (org_dir / "manifest.yaml").write_text(
+        yaml.safe_dump({"legs": manifest_legs}),
+        encoding="utf-8",
+    )
+
+
+def _patch_roots(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path / "config",
+    )
+    monkeypatch.setattr(
+        "app.core.config_package.org_leg_library.get_runflow_root",
+        lambda: tmp_path,
+    )
+
+
+def test_effective_leg_source_defaults_to_org():
+    assert effective_leg_source({}) == LEG_SOURCE_ORG
+    assert effective_leg_source({"recipes": {"full": []}}) == LEG_SOURCE_ORG
+
+
+def test_effective_leg_source_legacy_package_with_legs():
+    manifest = {"legs": [{"id": "01", "file": "01.gpx"}]}
+    assert effective_leg_source(manifest) == LEG_SOURCE_PACKAGE
+
+
+def test_effective_leg_source_explicit_org_overrides_empty_legs():
+    manifest = {"leg_source": "org", "legs": []}
+    assert effective_leg_source(manifest) == LEG_SOURCE_ORG
+
+
+def test_resolve_leg_library_org_primary(tmp_path, monkeypatch):
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(tmp_path)
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+
+    lib_dir, leg_manifest, source, _pkg = resolve_leg_library(config_id)
+    assert source == LEG_SOURCE_ORG
+    assert lib_dir == tmp_path / "org" / "legs"
+    assert leg_manifest["legs"][0]["id"] == "05"
+
+
+def test_get_package_segment_library_state_lists_org_legs(tmp_path, monkeypatch):
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(tmp_path)
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+
+    state = get_package_segment_library_state(config_id)
+    assert state["leg_source"] == LEG_SOURCE_ORG
+    assert len(state["legs"]) == 1
+    assert state["legs"][0]["id"] == "05"
+    assert state["recipes"]["full"] == ["05"]
+
+
+def test_apply_package_recipes_uses_org_legs(tmp_path, monkeypatch):
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(tmp_path)
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+
+    applied = apply_package_recipes(config_id, export_csv=False)
+    assert applied["segment_count"] >= 1
+    course = load_config_course(config_id)
+    assert course.get("segment_library_applied") is True
+    leg_ids = {s.get("leg_id") for s in course.get("segments") or []}
+    assert "05" in leg_ids
+
+
+def test_merge_org_leg_locations_carry_resources(tmp_path, monkeypatch):
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(
+        tmp_path,
+        legs=[
+            {
+                "leg_id": "05",
+                "label": "Org trail",
+                "resources": {"water_volunteers": {"count": 4, "label": "Water crew"}},
+            },
+            {
+                "leg_id": "06",
+                "label": "Unused leg",
+                "loc_label": "Aid",
+                "loc_type": "aid",
+            },
+        ],
+    )
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+
+    apply_package_recipes(config_id, export_csv=False)
+    course = load_config_course(config_id)
+    water = next(
+        loc for loc in (course.get("locations") or []) if loc.get("loc_type") == "water"
+    )
+    assert water.get("zone") == "A1"
+    assert water.get("buffer") == 30
+    assert water.get("notes") == "Carry cups"
+    assert water["resources"]["water_volunteers"]["count"] == 4
+
+    assert recipe_leg_ids_from_package(config_id) == {"05"}
+    leg_sources = {
+        loc.get("leg_id") for loc in course.get("locations") or [] if loc.get("source") == "leg"
+    }
+    assert leg_sources == {"05"}
+
+    _lib_dir, combined = combined_manifest_for_apply(config_id)
+    assert combined["recipes"]["full"] == ["05"]
+    assert {leg["id"] for leg in combined["legs"]} == {"05", "06"}

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -1044,6 +1044,10 @@ def test_import_gpx_with_leg_export_json(tmp_path, monkeypatch):
         "app.core.config_package.storage.get_config_root",
         lambda: tmp_path,
     )
+    monkeypatch.setattr(
+        "app.core.config_package.org_leg_library.get_runflow_root",
+        lambda: tmp_path,
+    )
     result = create_config_package("Import JSON", "", event_day="sun", package_events=["full"])
     config_id = result["config_id"]
     gpx_body = """<?xml version="1.0"?>

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -101,6 +101,34 @@ def test_export_bundle_writes_csv():
     assert "event_a" in bundle["flow_csv"]
 
 
+def test_build_course_segments_leg_reuse(manifest, legs_by_id):
+    """Same library leg twice in one event recipe → two segment rows."""
+    recipes = {
+        "full": ["01", "05", "02", "05"],
+        "half": ["01", "05"],
+        "10k": ["01", "05"],
+    }
+    manifest = dict(manifest)
+    manifest["recipes"] = recipes
+    legs = dict(legs_by_id)
+    if "05" not in legs:
+        legs["05"] = {**legs["02"], "id": "05", "length_km": 1.59}
+    segments = build_course_segments_from_library(
+        manifest, legs, event_ids=["full", "half", "10k"]
+    )
+    leg05 = [s for s in segments if s["leg_id"] == "05"]
+    assert len(leg05) == 2
+    assert leg05[0]["leg_occurrence"] == 1
+    assert leg05[1]["leg_occurrence"] == 2
+    assert set(leg05[0]["events"]) == {"full", "half", "10k"}
+    assert leg05[1]["events"] == ["full"]
+    assert leg05[0]["full_to_km"] < leg05[1]["full_from_km"]
+    length = float(leg05[0]["length_km"])
+    assert leg05[0]["half_to_km"] == pytest.approx(leg05[0]["half_from_km"] + length, abs=0.05)
+    assert leg05[1]["half_from_km"] == 0.0
+    assert leg05[1]["half_to_km"] == 0.0
+
+
 def test_build_course_segments_follows_recipe_order_not_manifest_order(manifest, legs_by_id):
     """Leg ids after 15 in manifest must not push recipe-middle legs to the end."""
     recipes = {

--- a/tests/unit/test_segment_recipes_package.py
+++ b/tests/unit/test_segment_recipes_package.py
@@ -5,6 +5,7 @@ import pytest
 from app.core.config_package.segment_recipes import (
     _leg_id_from_filename,
     order_grid_from_recipes,
+    parse_recipe_order_values,
     recipes_from_order_grid,
     sync_manifest_legs_from_gpx,
 )
@@ -71,14 +72,45 @@ def test_sync_manifest_legs_preserves_id_by_filename(tmp_path):
     assert legs[0]["file"] == "16_return.gpx"
 
 
+def test_parse_recipe_order_values():
+    assert parse_recipe_order_values("7,16") == [7, 16]
+    assert parse_recipe_order_values(" 8 ") == [8]
+    assert parse_recipe_order_values("") == []
+    assert parse_recipe_order_values("7,7,16") == [7, 16]
+
+
+def test_recipes_from_order_grid_leg_reuse():
+    legs = [{"id": "05"}, {"id": "02"}, {"id": "01"}]
+    grid = {
+        "full": {"01": 1, "05": "7,16", "02": 8},
+        "half": {"01": 1, "05": 8},
+        "10k": {"01": 1, "05": 5},
+    }
+    recipes = recipes_from_order_grid(legs, grid, ["full", "half", "10k"])
+    assert recipes["full"] == ["01", "05", "02", "05"]
+    assert recipes["half"] == ["01", "05"]
+    assert recipes["10k"] == ["01", "05"]
+
+
+def test_order_grid_roundtrip_with_reuse():
+    legs = [{"id": "a"}, {"id": "b"}]
+    recipes = {"full": ["a", "b", "a"], "half": ["a"], "10k": []}
+    events = ["full", "half", "10k"]
+    grid = order_grid_from_recipes(legs, recipes, events)
+    assert grid["full"]["a"] == "1,3"
+    assert grid["full"]["b"] == "2"
+    back = recipes_from_order_grid(legs, grid, events)
+    assert back == recipes
+
+
 def test_order_grid_roundtrip():
     legs = [{"id": "a"}, {"id": "b"}, {"id": "c"}]
     recipes = {"full": ["a", "c"], "half": ["b"], "10k": ["a", "b", "c"]}
     events = ["full", "half", "10k"]
     grid = order_grid_from_recipes(legs, recipes, events)
-    assert grid["full"]["a"] == 1
-    assert grid["full"]["c"] == 2
+    assert grid["full"]["a"] == "1"
+    assert grid["full"]["c"] == "2"
     assert grid["full"]["b"] is None
-    assert grid["half"]["b"] == 1
+    assert grid["half"]["b"] == "1"
     back = recipes_from_order_grid(legs, grid, events)
     assert back == recipes


### PR DESCRIPTION
## Summary

Promotes the org leg library to the primary source for package recipes/apply (#780), and fixes a chain of data-integrity bugs that corrupted per-event segment kms and broke the Locations/Density UIs.

### Leg platform (org-primary)
- Org leg library is the primary source for recipes and apply; package libraries remain a fallback (`leg_library_resolver`).
- Same library leg can appear multiple times across event recipes.
- Recipe export no longer wipes segments on leg metadata sync; `loc_label` edits sync back to the org manifest when org library is primary.
- One-time migration script for leg location metadata (`scripts/migrate_leg_locations.py`).

### Data integrity
- Per-event from/to kms for recipe-built segments are preserved in recipe traversal order instead of being recomputed in segment list order (fixes a 1.1 km course gap on Gibson Trail / S10 for the half event).
- Recipe-applied segment kms are now server-owned: a stale browser tab saving the course can no longer silently revert apply results (`save_config_course` carries over km fields + `segment_library_applied` from disk).

### UI artifacts robustness
- `segments.geojson` schema resolution falls back to the segments.csv `schema` column for segments with no density bins (short connectors, e.g. 30 m S18).
- Segment map PNG generation skips segments without density metrics instead of failing the whole UI artifact phase.

### UX
- Natural sort of segment IDs (S2 before S10) in the density API and flow table.
- Proxy timing dropdowns exclude chained proxy locations and flag stale selections; saves with a chained proxy are blocked with a clear message.
- Loc Sheets hidden from nav (one-pagers are hyperlinked from the Locations table; route kept).

## Test plan
- [x] Unit tests pass (leg library resolver, course storage incl. stale-client save preservation, segment recipes, export).
- [x] End-to-end analysis run (`3PQGFGML4BproS6pBXRbXV`) verified: full course renders with no gap (S9 → S18 → S10 continuous), heatmaps/captions/locations reports generated, proxy locations resolve.

## Next
Next round of work: optimizing the flow configuration inputs (deferred `fz_runners` / flow zone config issues).