### PR TITLE
Corridor pairing for opposing-pass legs + leg-to-course location sync fixes (#785)

### DIFF
--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -74,6 +74,11 @@ _LEG_LOC_PRESERVE_FIELDS = (
     "resources",
 )
 
+# Physical placement is authored on the Legs tab; merges must take these from
+# the leg manifest, never preserve stale course.json copies (pin moves were
+# silently ignored otherwise).
+_LEG_OWNED_PLACEMENT_FIELDS = ("lat", "lon", "placement")
+
 _LEG_LOC_EXPORT_FIELDS = _LEG_LOC_PRESERVE_FIELDS
 
 _LEG_ID_RE = re.compile(r"^\d{2,3}$")
@@ -136,6 +141,59 @@ def _validate_leg_entry(entry: Dict[str, Any]) -> None:
 
 def _normalize_flow_notes(notes: Any) -> str:
     return str(notes or "").strip()[:500]
+
+
+def apply_leg_pairing(
+    legs: List[Dict[str, Any]], leg_id: str, target_id: Any
+) -> bool:
+    """
+    Set or clear the symmetric corridor pairing between two legs (Issue #785).
+
+    ``paired_with`` marks two directional legs as the same physical corridor
+    traversed in opposite directions. The relationship is 1:1 and symmetric:
+    setting it on one leg writes the reciprocal on the target, and clearing
+    either side clears both. Mutates ``legs`` entries in place.
+
+    Returns True when any entry changed.
+    """
+    leg_id = str(leg_id).strip()
+    new_id = str(target_id or "").strip()
+    by_id: Dict[str, Dict[str, Any]] = {}
+    for entry in legs:
+        if isinstance(entry, dict) and str(entry.get("id", "")).strip():
+            by_id[str(entry["id"]).strip()] = entry
+    entry = by_id.get(leg_id)
+    if entry is None:
+        raise ValueError(f"Leg not found: {leg_id}")
+    old_id = str(entry.get("paired_with") or "").strip()
+    if new_id == old_id:
+        return False
+    if new_id:
+        if new_id == leg_id:
+            raise ValueError("A leg cannot be paired with itself")
+        target = by_id.get(new_id)
+        if target is None:
+            raise ValueError(f"Paired leg not found: {new_id}")
+        target_pair = str(target.get("paired_with") or "").strip()
+        if target_pair and target_pair != leg_id:
+            raise ValueError(
+                f"Leg {new_id} is already paired with leg {target_pair}; "
+                "clear that pairing first"
+            )
+    # Clear the old reciprocal before re-pairing.
+    if old_id:
+        old_target = by_id.get(old_id)
+        if (
+            old_target is not None
+            and str(old_target.get("paired_with") or "").strip() == leg_id
+        ):
+            old_target.pop("paired_with", None)
+    if new_id:
+        entry["paired_with"] = new_id
+        by_id[new_id]["paired_with"] = leg_id
+    else:
+        entry.pop("paired_with", None)
+    return True
 
 
 def _slugify(text: str) -> str:
@@ -262,6 +320,7 @@ def leg_row_from_entry(
         "direction": entry.get("direction", "uni"),
         "flow_type": entry.get("flow_type", DEFAULT_FLOW_TYPE),
         "flow_notes": (entry.get("flow_notes") or "").strip(),
+        "paired_with": str(entry.get("paired_with") or "").strip(),
         "description": _leg_description(entry),
         "locations": locations,
         "location_count": len(locations),
@@ -418,6 +477,8 @@ def update_package_leg(
     if any(key in fields for key in authoring_keys):
         _validate_leg_entry(entry)
     legs[idx] = entry
+    if "paired_with" in fields:
+        apply_leg_pairing(legs, leg_id, fields.get("paired_with"))
     set_manifest_legs(manifest, legs)
     save_package_segment_manifest(cid, manifest)
     try:
@@ -1111,6 +1172,8 @@ def merge_leg_locations_into_course(config_id: str) -> None:
                 else:
                     row["id"] = allocate_location_id(used_ids)
                 for field in _LEG_LOC_PRESERVE_FIELDS:
+                    if field in _LEG_OWNED_PLACEMENT_FIELDS:
+                        continue
                     if field not in prev:
                         continue
                     val = prev[field]

--- a/app/core/config_package/org_leg_library.py
+++ b/app/core/config_package/org_leg_library.py
@@ -7,6 +7,7 @@ package ``segment_library/``. Packages import copies with freshly allocated ids.
 
 from __future__ import annotations
 
+import logging
 import shutil
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Sequence
@@ -25,8 +26,27 @@ from app.core.course.segment_library import (
 )
 from app.utils.run_id import get_runflow_root
 
+logger = logging.getLogger(__name__)
+
 ORG_LEGS_DIRNAME = "legs"
 MANIFEST_YAML = "manifest.yaml"
+
+# Org leg fields whose edits must be reflected in each package's course.json
+# (locations/labels re-merge leg placements; metadata re-syncs segments).
+_PACKAGE_SYNC_FIELDS = (
+    "locations",
+    "start_label",
+    "end_label",
+    "leg_label",
+    "seg_label",
+    "description",
+    "width_m",
+    "schema",
+    "direction",
+    "flow_type",
+    "flow_notes",
+    "paired_with",
+)
 
 
 def get_org_legs_dir() -> Path:
@@ -375,6 +395,7 @@ def update_org_leg(
         _normalize_segment_direction,
         _normalize_segment_schema,
         _slugify,
+        apply_leg_pairing,
     )
 
     leg_id = str(leg_id).strip()
@@ -421,9 +442,47 @@ def update_org_leg(
             entry["end_label"] = _default_endpoint_labels(entry.get("seg_label", ""), parsed)[1]
 
     legs[idx] = entry
+    if "paired_with" in fields:
+        apply_leg_pairing(legs, leg_id, fields.get("paired_with"))
     set_manifest_legs(manifest, legs)
     save_org_leg_manifest(manifest)
+    if any(key in fields for key in _PACKAGE_SYNC_FIELDS):
+        sync_org_leg_changes_into_packages()
     return get_org_leg_library_state()
+
+
+def sync_org_leg_changes_into_packages() -> None:
+    """
+    Propagate org leg edits into course.json for org-sourced packages.
+
+    The Legs tab saves to the org manifest only; without this, a moved
+    location pin (or label/metadata change) stays stale in each package's
+    combined course until the next recipe apply. Packages without applied
+    recipes are skipped by ``sync_leg_locations_if_applied``.
+    """
+    from app.core.config_package.leg_library_resolver import (
+        LEG_SOURCE_ORG,
+        effective_leg_source,
+    )
+    from app.core.config_package.legs import sync_leg_locations_if_applied
+    from app.core.config_package.storage import list_config_packages
+
+    for pkg in list_config_packages():
+        cid = str(pkg.get("config_id") or "").strip()
+        if not cid:
+            continue
+        try:
+            pkg_manifest = load_package_segment_manifest(cid)
+        except (FileNotFoundError, ValueError):
+            continue
+        if effective_leg_source(pkg_manifest) != LEG_SOURCE_ORG:
+            continue
+        try:
+            sync_leg_locations_if_applied(cid)
+        except Exception:
+            logger.warning(
+                "Failed to sync org leg change into package %s", cid, exc_info=True
+            )
 
 
 def delete_org_leg(leg_id: str) -> Dict[str, Any]:

--- a/app/core/course/flow_csv.py
+++ b/app/core/course/flow_csv.py
@@ -96,6 +96,61 @@ def _segment_km_window(seg: Dict[str, Any], event_id: str) -> Tuple[float, float
     return from_km, to_km
 
 
+def _corridor_pairs(
+    segments: Sequence[Dict[str, Any]],
+) -> List[Tuple[Dict[str, Any], Dict[str, Any]]]:
+    """
+    Segment pairs that traverse the same physical corridor in opposite
+    directions (Issue #785).
+
+    Two sources:
+    - Explicit leg pairing: leg metadata ``paired_with`` links two directional
+      legs (out vs back over one trail).
+    - Self-pairing: the same leg appears more than once in a recipe
+      (``leg_occurrence`` 1, 2, ...) — implicitly its own paired pass.
+
+    Returns ordered (first, second) pairs deduped by seg_id.
+    """
+    seg_list = [s for s in segments if str(s.get("seg_id", "")).strip()]
+    by_leg: Dict[str, List[Dict[str, Any]]] = {}
+    for seg in seg_list:
+        leg = str(seg.get("leg_id") or "").strip()
+        if leg:
+            by_leg.setdefault(leg, []).append(seg)
+
+    pairs: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+    seen: set = set()
+
+    def add_pair(a: Dict[str, Any], b: Dict[str, Any]) -> None:
+        key = tuple(sorted([str(a["seg_id"]), str(b["seg_id"])]))
+        if key in seen or key[0] == key[1]:
+            return
+        seen.add(key)
+        pairs.append((a, b))
+
+    for seg in seg_list:
+        mate_leg = str(seg.get("paired_with") or "").strip()
+        if not mate_leg:
+            continue
+        for mate in by_leg.get(mate_leg, []):
+            add_pair(seg, mate)
+
+    for segs in by_leg.values():
+        if len(segs) >= 2:
+            ordered = sorted(segs, key=lambda s: int(s.get("leg_occurrence") or 1))
+            for a, b in combinations(ordered, 2):
+                add_pair(a, b)
+
+    return pairs
+
+
+def corridor_flow_id(
+    seg_id_a: str, seg_id_b: str, event_a: str, event_b: str
+) -> str:
+    """Stable flow_id for generated opposing-pass corridor rows."""
+    return f"{seg_id_a}_{seg_id_b}_{event_a}_{event_b}"
+
+
 def _normalize_override(override: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not isinstance(override, dict):
         return None
@@ -260,6 +315,49 @@ def build_flow_csv_from_segments(
                     "auto_generated": True,
                 }
             )
+
+    # Issue #785: opposing-pass rows for corridor pairs (paired legs and
+    # repeated-leg out-and-backs). Each event window on one pass is compared
+    # against each event window on the opposing pass — including same-event
+    # out/back interactions, which have distinct km windows by construction.
+    for seg_x, seg_y in _corridor_pairs(segments):
+        x_id = str(seg_x["seg_id"]).strip()
+        y_id = str(seg_y["seg_id"]).strip()
+        x_label = str(seg_x.get("seg_label", "")).strip()
+        y_label = str(seg_y.get("seg_label", "")).strip()
+        pair_label = f"{x_label} / {y_label}" if x_label != y_label else x_label
+        active_x = _segment_active_events(seg_x, event_ids)
+        active_y = _segment_active_events(seg_y, event_ids)
+        for event_a in active_x:
+            for event_b in active_y:
+                from_a, to_a = _segment_km_window(seg_x, event_a)
+                from_b, to_b = _segment_km_window(seg_y, event_b)
+                if to_a <= from_a or to_b <= from_b:
+                    continue
+                if event_a == event_b and _km_ranges_identical(
+                    from_a, to_a, from_b, to_b
+                ):
+                    continue
+                append_row(
+                    {
+                        "flow_id": corridor_flow_id(x_id, y_id, event_a, event_b),
+                        "seg_id": x_id,
+                        "seg_label": pair_label,
+                        "event_a": event_a,
+                        "event_b": event_b,
+                        "from_km_a": from_a,
+                        "to_km_a": to_a,
+                        "from_km_b": from_b,
+                        "to_km_b": to_b,
+                        "flow_type": "counterflow",
+                        "direction": "bi",
+                        "notes": (
+                            f"Opposing passes on shared corridor "
+                            f"({x_id} vs {y_id})."
+                        ),
+                        "auto_generated": True,
+                    }
+                )
 
     out = io.StringIO()
     writer = csv.writer(out)

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -125,6 +125,69 @@ def validate_recipe_stitch(
     return warnings
 
 
+def validate_corridor_pairings(
+    legs_by_id: Dict[str, Dict[str, Any]],
+    recipes: Dict[str, Any],
+    *,
+    tolerance_m: float = STITCH_TOLERANCE_M,
+) -> List[str]:
+    """
+    Warnings for corridor pairings (Issue #785): dangling or asymmetric
+    ``paired_with`` references, pairs whose legs don't look like reverses of
+    each other, and pairs inert because a leg is unused in every recipe.
+    """
+    warnings: List[str] = []
+    used_legs: set = set()
+    for seq in (recipes or {}).values():
+        if isinstance(seq, list):
+            used_legs.update(str(x).strip() for x in seq if str(x or "").strip())
+
+    checked: set = set()
+    for leg_id, leg in legs_by_id.items():
+        mate_id = str(leg.get("paired_with") or "").strip()
+        if not mate_id:
+            continue
+        mate = legs_by_id.get(mate_id)
+        if mate is None:
+            warnings.append(
+                f"Leg {leg_id} is paired with unknown leg {mate_id}"
+            )
+            continue
+        mate_pair = str(mate.get("paired_with") or "").strip()
+        if mate_pair != leg_id:
+            warnings.append(
+                f"Asymmetric pairing: leg {leg_id} pairs with {mate_id}, "
+                f"but {mate_id} pairs with {mate_pair or 'nothing'}"
+            )
+        key = tuple(sorted([leg_id, mate_id]))
+        if key in checked:
+            continue
+        checked.add(key)
+        if leg_id not in used_legs or mate_id not in used_legs:
+            unused = [x for x in key if x not in used_legs]
+            warnings.append(
+                f"Corridor pairing {key[0]}/{key[1]} is inactive: "
+                f"leg(s) {', '.join(unused)} not used in any event recipe"
+            )
+        # Paired legs should be approximate reverses: A start ≈ B end, A end ≈ B start.
+        try:
+            gap_se = _haversine_m(
+                leg["start"][0], leg["start"][1], mate["end"][0], mate["end"][1]
+            )
+            gap_es = _haversine_m(
+                leg["end"][0], leg["end"][1], mate["start"][0], mate["start"][1]
+            )
+        except (KeyError, IndexError, TypeError):
+            continue
+        if gap_se > tolerance_m or gap_es > tolerance_m:
+            warnings.append(
+                f"Corridor pairing {key[0]}/{key[1]}: leg endpoints are not "
+                f"reverses of each other "
+                f"(start↔end gaps {gap_se:.0f}m / {gap_es:.0f}m)"
+            )
+    return warnings
+
+
 def load_leg_library(library_dir: Path, manifest: Dict[str, Any]) -> Dict[str, Dict[str, Any]]:
     """Load all legs from manifest into memory."""
     out: Dict[str, Dict[str, Any]] = {}
@@ -334,6 +397,7 @@ def build_course_segments_from_library(
             "schema": entry.get("schema", "on_course_open"),
             "direction": entry.get("direction", "uni"),
             "flow_type": (entry.get("flow_type") or "none").strip().lower(),
+            "paired_with": str(entry.get("paired_with") or "").strip(),
             "flow_notes": leg_description,
             "description": leg_description,
             "events": events,
@@ -381,6 +445,7 @@ def export_library_to_course(
         stitch_warnings.extend(
             validate_recipe_stitch(library_dir, seq, legs_by_id)
         )
+    stitch_warnings.extend(validate_corridor_pairings(legs_by_id, recipes))
 
     segments = build_course_segments_from_library(manifest, legs_by_id, event_ids)
     course = {"segments": segments, "name": manifest.get("label", "")}

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -25,6 +25,7 @@ from app.io.loader import load_locations, load_runners, load_segments
 from app.core.gpx.processor import load_all_courses, GPXCourse
 from app.utils.constants import (
     LOCATION_SNAP_THRESHOLD_M,
+    LOCATION_SEGMENT_CLAMP_M,
     LOCATION_SETUP_BUFFER_MINUTES,
     SECONDS_PER_MINUTE,
     METERS_PER_KM,
@@ -615,11 +616,14 @@ def calculate_arrival_times_for_location(
                         # Convert to absolute course distance: from_km + distance_along_segment
                         absolute_distance_km = from_km + seg_distance_relative_km
                         
-                        # Verify it's within segment bounds
-                        if from_km <= absolute_distance_km <= to_km:
-                            seg_distance_km = absolute_distance_km
+                        # Verify it's within segment bounds. Boundary pins (turnarounds,
+                        # corridor junctions) can land metres past an end — clamp within
+                        # LOCATION_SEGMENT_CLAMP_M instead of failing to midpoint fallback.
+                        clamp_km = LOCATION_SEGMENT_CLAMP_M / METERS_PER_KM
+                        if (from_km - clamp_km) <= absolute_distance_km <= (to_km + clamp_km):
+                            seg_distance_km = max(from_km, min(absolute_distance_km, to_km))
                             logger.info(
-                                f"Location {location.get('loc_id')} ({event}): Projected onto segment {seg_id} centerline: {absolute_distance_km:.3f}km (from_km={from_km:.3f} + seg_dist={seg_distance_relative_km:.3f}km)"
+                                f"Location {location.get('loc_id')} ({event}): Projected onto segment {seg_id} centerline: {seg_distance_km:.3f}km (from_km={from_km:.3f} + seg_dist={seg_distance_relative_km:.3f}km)"
                             )
                         else:
                             logger.debug(

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -115,6 +115,7 @@ class UpdateLegRequest(BaseModel):
     direction: Optional[str] = None
     flow_type: Optional[str] = None
     flow_notes: Optional[str] = None
+    paired_with: Optional[str] = None
     description: Optional[str] = None
     locations: Optional[List[Dict[str, Any]]] = None
 

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -200,6 +200,11 @@ RUN_ID_MIN_LENGTH = 10
 # Location Report Configuration (Issue #277)
 LOCATION_SNAP_THRESHOLD_M = 50.0  # Maximum distance for snapping location to segment
 LOCATION_SETUP_BUFFER_MINUTES = 45  # Minutes before earliest runner start for loc_start
+# Issue #785 follow-up: locations pinned at segment boundaries (turnarounds,
+# corridor junctions) project a few metres past the segment's km range and were
+# falling back to the segment midpoint. Projections within this distance of a
+# segment end are clamped to the boundary and accepted.
+LOCATION_SEGMENT_CLAMP_M = 50.0
 
 # Course Mapping location types (Issue #732 / #747) — alphabetical for UI dropdown
 LOCATION_TYPE_CHOICES = [

--- a/app/validation/location_projection.py
+++ b/app/validation/location_projection.py
@@ -20,7 +20,11 @@ from app.location_report import project_point_to_course
 from shapely.geometry import LineString, Point
 from pyproj import Transformer
 
-from app.utils.constants import LOCATION_SNAP_THRESHOLD_M, METERS_PER_KM
+from app.utils.constants import (
+    LOCATION_SEGMENT_CLAMP_M,
+    LOCATION_SNAP_THRESHOLD_M,
+    METERS_PER_KM,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -163,7 +167,10 @@ def validate_location_projections(
                         seg_distance_relative_km = seg_distance_m / METERS_PER_KM
                         absolute_distance_km = from_km + seg_distance_relative_km
                         
-                        if from_km <= absolute_distance_km <= to_km:
+                        # Match location_report: clamp boundary-pin projections
+                        # within LOCATION_SEGMENT_CLAMP_M of a segment end.
+                        clamp_km = LOCATION_SEGMENT_CLAMP_M / METERS_PER_KM
+                        if (from_km - clamp_km) <= absolute_distance_km <= (to_km + clamp_km):
                             projection_success = True
                         else:
                             projection_error_km = abs(absolute_distance_km - (from_km + to_km) / 2.0)

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -3613,6 +3613,9 @@ document.addEventListener('DOMContentLoaded', function () {
             window.courseMappingMap.removeLayer(locationsLayer);
             locationsLayer = null;
         }
+        // Legs tab shows its own (editable) leg pins; course-level copies of the
+        // same locations would render as confusing duplicates on the shared map.
+        if (shouldSkipCourseMapRefresh()) return;
         if (!currentCourse || !Array.isArray(currentCourse.locations) || currentCourse.locations.length === 0) return;
         locationsLayer = L.layerGroup();
         currentCourse.locations.forEach(function (loc, i) {
@@ -4874,6 +4877,12 @@ document.addEventListener('DOMContentLoaded', function () {
             saveAll: saveConfigPackageWorkspace,
             syncHeaderFromMeta: syncCourseHeaderFromPackageMeta,
             reloadCourse: loadConfigPackageCourse,
+            removeLocationPins: function () {
+                if (locationsLayer && window.courseMappingMap) {
+                    window.courseMappingMap.removeLayer(locationsLayer);
+                    locationsLayer = null;
+                }
+            },
             enrichCourseSegmentsFromLegLibrary: enrichCourseSegmentsFromLegLibrary,
             hasCombinedCourse: function () {
                 return !!(

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -2396,6 +2396,7 @@
                 schemaLabelForValue(ch.schema),
                 directionLabelForValue(ch.direction),
                 flowTypeLabelForValue(ch.flow_type),
+                (ch.paired_with || '—'),
                 String(ch.location_count != null ? ch.location_count : (ch.locations || []).length)
             ].forEach(function (text) {
                 var td = document.createElement('td');
@@ -2918,6 +2919,20 @@
             return sel;
         }
 
+        /** Other legs eligible as a corridor pair: not self, not already paired elsewhere. */
+        function pairedLegChoices(selfId, currentValue) {
+            var current = String(currentValue || '').trim();
+            var choices = [{ value: '', label: 'None' }];
+            ((libraryState && libraryState.legs) || []).forEach(function (other) {
+                var oid = String(other.id || '').trim();
+                if (!oid || oid === String(selfId)) return;
+                var otherPair = String(other.paired_with || '').trim();
+                if (otherPair && otherPair !== String(selfId) && oid !== current) return;
+                choices.push({ value: oid, label: oid + ' — ' + (other.leg_label || oid) });
+            });
+            return choices;
+        }
+
         addField('Leg label', 'leg-label', leg.leg_label);
         addField('Start place', 'leg-start-label', leg.start_label);
         addField('End place', 'leg-end-label', leg.end_label);
@@ -2925,6 +2940,16 @@
         addSelectField('Schema', 'leg-schema', leg.schema || 'on_course_open', segmentSchemaChoices());
         addSelectField('Direction', 'leg-direction', leg.direction || 'uni', segmentDirectionChoices());
         addSelectField('Flow type', 'leg-flow-type', leg.flow_type || 'none', flowTypeChoices());
+        if (!isNew) {
+            var pairSel = addSelectField(
+                'Paired leg (same corridor, opposite direction)',
+                'leg-paired-with',
+                leg.paired_with || '',
+                pairedLegChoices(leg.id, leg.paired_with)
+            );
+            pairSel.title = 'Marks two directional legs as one physical corridor. '
+                + 'Generates opposing-pass (counterflow) flow rows on apply.';
+        }
 
         var notesWrap = document.createElement('div');
         notesWrap.style.marginBottom = '0.65rem';
@@ -2986,7 +3011,7 @@
     }
 
     function collectLegFields() {
-        return {
+        var fields = {
             leg_label: (document.getElementById('leg-label') || {}).value || '',
             start_label: (document.getElementById('leg-start-label') || {}).value || '',
             end_label: (document.getElementById('leg-end-label') || {}).value || '',
@@ -2996,6 +3021,11 @@
             flow_type: ((document.getElementById('leg-flow-type') || {}).value || 'none').trim(),
             description: ((document.getElementById('leg-description') || {}).value || '').trim()
         };
+        var pairedSel = document.getElementById('leg-paired-with');
+        if (pairedSel) {
+            fields.paired_with = (pairedSel.value || '').trim();
+        }
+        return fields;
     }
 
     function validateLegFields(fields) {
@@ -3305,6 +3335,11 @@
         closeRecipesModal: closeRecipesModal,
         resolveLegLabelsForSegment: resolveLegLabelsForSegment,
         onLegsTabShown: function () {
+            // Drop course-level location pins left over from the Course tab;
+            // the Legs tab draws its own editable pins for the same locations.
+            if (window.configPackageCourse && window.configPackageCourse.removeLocationPins) {
+                window.configPackageCourse.removeLocationPins();
+            }
             bindLegMapControls();
             attachLegsTableBoundsFilter();
             if (window.courseMappingMap) {

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -103,6 +103,7 @@
                                 <th>Schema</th>
                                 <th>Dir</th>
                                 <th>Flow</th>
+                                <th title="Corridor pairing: this leg shares physical space with the paired leg in the opposite direction">Pair</th>
                                 <th>Locs</th>
                                 <th class="course-map-action-cell">Actions</th>
                             </tr>

--- a/tests/unit/test_corridor_pairing.py
+++ b/tests/unit/test_corridor_pairing.py
@@ -1,0 +1,108 @@
+"""Unit tests for corridor pairing (Issue #785)."""
+
+import pytest
+
+from app.core.config_package.legs import apply_leg_pairing
+from app.core.course.segment_library import validate_corridor_pairings
+
+
+def _legs():
+    return [
+        {"id": "09", "seg_label": "Bridge to Half Turn"},
+        {"id": "13", "seg_label": "Half Turn to Bridge"},
+        {"id": "01", "seg_label": "Start leg"},
+    ]
+
+
+def test_pairing_sets_both_sides():
+    legs = _legs()
+    changed = apply_leg_pairing(legs, "09", "13")
+    assert changed is True
+    assert legs[0]["paired_with"] == "13"
+    assert legs[1]["paired_with"] == "09"
+    assert "paired_with" not in legs[2]
+
+
+def test_pairing_clear_removes_both_sides():
+    legs = _legs()
+    apply_leg_pairing(legs, "09", "13")
+    changed = apply_leg_pairing(legs, "13", "")
+    assert changed is True
+    assert "paired_with" not in legs[0]
+    assert "paired_with" not in legs[1]
+
+
+def test_repairing_clears_old_reciprocal():
+    legs = _legs()
+    apply_leg_pairing(legs, "09", "13")
+    apply_leg_pairing(legs, "09", "01")
+    assert legs[0]["paired_with"] == "01"
+    assert legs[2]["paired_with"] == "09"
+    assert "paired_with" not in legs[1]
+
+
+def test_pairing_noop_returns_false():
+    legs = _legs()
+    apply_leg_pairing(legs, "09", "13")
+    assert apply_leg_pairing(legs, "09", "13") is False
+
+
+def test_pairing_rejects_self():
+    with pytest.raises(ValueError, match="itself"):
+        apply_leg_pairing(_legs(), "09", "09")
+
+
+def test_pairing_rejects_unknown_target():
+    with pytest.raises(ValueError, match="not found"):
+        apply_leg_pairing(_legs(), "09", "99")
+
+
+def test_pairing_rejects_target_paired_elsewhere():
+    legs = _legs()
+    apply_leg_pairing(legs, "09", "13")
+    with pytest.raises(ValueError, match="already paired"):
+        apply_leg_pairing(legs, "01", "13")
+
+
+def _legs_by_id(reverse_geometry=True):
+    # Leg 09: A -> B; leg 13 reversed (B -> A) or not depending on flag.
+    a = [-66.640, 45.950]
+    b = [-66.620, 45.960]
+    legs = {
+        "09": {"id": "09", "paired_with": "13", "start": a, "end": b},
+        "13": {"id": "13", "paired_with": "09", "start": b if reverse_geometry else a,
+               "end": a if reverse_geometry else b},
+    }
+    return legs
+
+
+def test_validate_pairings_clean():
+    warnings = validate_corridor_pairings(
+        _legs_by_id(), {"full": ["09", "13"]}
+    )
+    assert warnings == []
+
+
+def test_validate_pairings_inactive_when_leg_unused():
+    warnings = validate_corridor_pairings(_legs_by_id(), {"full": ["09"]})
+    assert any("inactive" in w and "13" in w for w in warnings)
+
+
+def test_validate_pairings_flags_non_reversed_geometry():
+    warnings = validate_corridor_pairings(
+        _legs_by_id(reverse_geometry=False), {"full": ["09", "13"]}
+    )
+    assert any("not" in w and "reverses" in w for w in warnings)
+
+
+def test_validate_pairings_flags_dangling_reference():
+    legs = {"09": {"id": "09", "paired_with": "77", "start": [0, 0], "end": [1, 1]}}
+    warnings = validate_corridor_pairings(legs, {"full": ["09"]})
+    assert any("unknown leg 77" in w for w in warnings)
+
+
+def test_validate_pairings_flags_asymmetric():
+    legs = _legs_by_id()
+    legs["13"]["paired_with"] = ""
+    warnings = validate_corridor_pairings(legs, {"full": ["09", "13"]})
+    assert any("Asymmetric" in w for w in warnings)

--- a/tests/unit/test_flow_csv.py
+++ b/tests/unit/test_flow_csv.py
@@ -7,6 +7,7 @@ import pytest
 
 from app.core.course.flow_csv import (
     build_flow_csv_from_segments,
+    corridor_flow_id,
     default_flow_id,
     parse_flow_csv_text,
     validate_flow_csv,
@@ -16,6 +17,124 @@ from app.core.course.flow_csv import (
 
 def _parse(csv_text: str):
     return parse_flow_csv_text(csv_text)
+
+
+def _corridor_segments():
+    """Out-and-back corridor: leg 09 outbound (S11) paired with leg 13 return (S14)."""
+    return [
+        {
+            "seg_id": "S11",
+            "seg_label": "Bridge At Mill To Half Turn",
+            "direction": "uni",
+            "leg_id": "09",
+            "paired_with": "13",
+            "events": ["full", "half"],
+            "full_from_km": 29.67,
+            "full_to_km": 32.24,
+            "half_from_km": 10.83,
+            "half_to_km": 13.4,
+        },
+        {
+            "seg_id": "S14",
+            "seg_label": "Half Turn To Bridge At Mill",
+            "direction": "uni",
+            "leg_id": "13",
+            "paired_with": "09",
+            "events": ["full", "half"],
+            "full_from_km": 33.82,
+            "full_to_km": 36.4,
+            "half_from_km": 13.4,
+            "half_to_km": 15.98,
+        },
+    ]
+
+
+def test_paired_legs_emit_opposing_pass_rows():
+    csv_text = build_flow_csv_from_segments(_corridor_segments(), ["full", "half"])
+    rows = _parse(csv_text)
+    corridor = [r for r in rows if r["flow_id"].startswith("S11_S14_")]
+    # full×full, full×half, half×full, half×half across the two passes
+    assert len(corridor) == 4
+    assert all(r["flow_type"] == "counterflow" for r in corridor)
+    assert all(r["direction"] == "bi" for r in corridor)
+    # C2-style same-event out/back row with distinct windows
+    ff = next(r for r in corridor if r["event_a"] == "full" and r["event_b"] == "full")
+    assert (float(ff["from_km_a"]), float(ff["to_km_a"])) == (29.67, 32.24)
+    assert (float(ff["from_km_b"]), float(ff["to_km_b"])) == (33.82, 36.4)
+    assert ff["flow_id"] == corridor_flow_id("S11", "S14", "full", "full")
+    # Per-leg same-direction rows still present and unchanged
+    assert any(r["flow_id"] == "S11_full_half" for r in rows)
+    assert any(r["flow_id"] == "S14_full_half" for r in rows)
+    # Generated CSV passes validation
+    result = validate_flow_csv_text(csv_text)
+    assert result.ok, result.errors
+
+
+def test_self_paired_leg_occurrences_emit_corridor_rows():
+    segments = [
+        {
+            "seg_id": "S2",
+            "seg_label": "Friel To 10k Turn",
+            "direction": "uni",
+            "leg_id": "04",
+            "leg_occurrence": 1,
+            "events": ["10k"],
+            "10k_from_km": 2.7,
+            "10k_to_km": 4.3,
+        },
+        {
+            "seg_id": "S5",
+            "seg_label": "Friel To 10k Turn (2)",
+            "direction": "uni",
+            "leg_id": "04",
+            "leg_occurrence": 2,
+            "events": ["10k"],
+            "10k_from_km": 4.3,
+            "10k_to_km": 5.9,
+        },
+    ]
+    rows = _parse(build_flow_csv_from_segments(segments, ["full", "10k"]))
+    corridor = [r for r in rows if r["flow_id"].startswith("S2_S5_")]
+    assert len(corridor) == 1
+    row = corridor[0]
+    assert (row["event_a"], row["event_b"]) == ("10k", "10k")
+    assert row["flow_type"] == "counterflow"
+    assert (float(row["from_km_a"]), float(row["to_km_a"])) == (2.7, 4.3)
+    assert (float(row["from_km_b"]), float(row["to_km_b"])) == (4.3, 5.9)
+
+
+def test_unpaired_segments_output_unchanged():
+    segments = [
+        {
+            "seg_id": "S1",
+            "seg_label": "Shared start",
+            "direction": "uni",
+            "leg_id": "01",
+            "events": ["full", "half"],
+            "full_from_km": 0,
+            "full_to_km": 2.0,
+            "half_from_km": 0,
+            "half_to_km": 2.0,
+        }
+    ]
+    with_pairing_support = build_flow_csv_from_segments(segments, ["full", "half"])
+    rows = _parse(with_pairing_support)
+    assert len(rows) == 1
+    assert rows[0]["flow_id"] == "S1_full_half"
+
+
+def test_corridor_skips_events_not_on_pass():
+    segments = _corridor_segments()
+    # Half only runs the outbound pass
+    segments[1]["events"] = ["full"]
+    segments[1]["half_from_km"] = 0.0
+    segments[1]["half_to_km"] = 0.0
+    rows = _parse(build_flow_csv_from_segments(segments, ["full", "half"]))
+    corridor = [r for r in rows if r["flow_id"].startswith("S11_S14_")]
+    assert {(r["event_a"], r["event_b"]) for r in corridor} == {
+        ("full", "full"),
+        ("half", "full"),
+    }
 
 
 def test_cross_event_only_by_default():

--- a/tests/unit/test_leg_library_resolver.py
+++ b/tests/unit/test_leg_library_resolver.py
@@ -12,6 +12,7 @@ from app.core.config_package.leg_library_resolver import (
     resolve_leg_library,
 )
 from app.core.config_package.legs import merge_leg_locations_into_course
+from app.core.config_package.org_leg_library import update_org_leg
 from app.core.config_package.segment_recipes import (
     apply_package_recipes,
     get_package_segment_library_state,
@@ -335,3 +336,59 @@ def test_export_org_primary_writes_flow_and_gpx(tmp_path, monkeypatch):
     assert (package_path / "half.gpx").is_file()
     assert applied["flow_csv_path"] == str(flow_path)
     assert {g["event_id"] for g in applied.get("gpx_files") or []} == {"full", "half"}
+
+
+def test_update_org_leg_location_syncs_into_applied_packages(tmp_path, monkeypatch):
+    """A leg pin move on the Legs tab must land in course.json without a re-apply."""
+    _patch_roots(tmp_path, monkeypatch)
+    _seed_org_leg(tmp_path)
+
+    result = create_config_package("Pkg", "", event_day="sun", package_events=["full"])
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": ["05"]},
+            "flow_overrides": [],
+        },
+    )
+    apply_package_recipes(config_id, export_csv=False)
+
+    # A second package that never applied recipes must be left untouched.
+    untouched = create_config_package(
+        "No recipes", "", event_day="sun", package_events=["full"]
+    )
+
+    course = load_config_course(config_id)
+    water = next(
+        loc for loc in course["locations"] if loc.get("loc_type") == "water"
+    )
+    assert water["lat"] == pytest.approx(45.961)
+
+    update_org_leg(
+        "05",
+        {
+            "locations": [
+                {
+                    "loc_label": "Water",
+                    "loc_type": "water",
+                    "lat": 45.9655,
+                    "lon": -66.6355,
+                    "placement": "along",
+                }
+            ]
+        },
+    )
+
+    course = load_config_course(config_id)
+    water = next(
+        loc for loc in course["locations"] if loc.get("loc_type") == "water"
+    )
+    assert water["lat"] == pytest.approx(45.9655)
+    assert water["lon"] == pytest.approx(-66.6355)
+
+    untouched_course = load_config_course(untouched["config_id"])
+    assert not untouched_course.get("locations")


### PR DESCRIPTION
## Summary

- **Corridor pairing (Issue #785):** legs can declare a symmetric `paired_with` partner (or self-pair via repeated recipe occurrences). The flow generator emits `counterflow,bi` rows for opposing passes over the same physical corridor — restoring the 2026_final-style C2/H/J overlap insight that was missing from generated `flow.csv`. Includes leg editor "Paired leg" dropdown, a Pair column in the legs table, and apply-time validation warnings (dangling, asymmetric, unused, non-reversed geometry pairings).
- **Leg → course location sync:** org leg edits now fan out into `course.json` for all org-sourced packages with applied recipes, and merges treat `lat`/`lon`/`placement` as leg-owned. Previously a pin moved on the Legs tab never reached the course copy (stale coordinates always won the merge), which surfaced as duplicate "two yellow pins" on the shared map. The Legs tab also no longer renders course-level pin duplicates.
- **Boundary-pin projection clamp:** location projections within `LOCATION_SEGMENT_CLAMP_M` (50 m, configurable in `app/utils/constants.py`) of a segment end are clamped into bounds instead of falling back to segment-midpoint timing. The remaining turn-point warnings are km bookkeeping drift, tracked separately in #786.

## Testing

- 80 unit tests pass across corridor pairing, flow CSV, leg library resolver, package legs, config course, org leg library, and course export suites (incl. new `test_corridor_pairing.py` and org-leg sync regression test).
- End-user UI verification on package `QhVd...ddtb`: pairings 03/10 and 08/11 configured, recipe applied, package exported, and generated `flow.csv` corridor rows verified via analysis run `GEJtRqZdAVu72PfUyHsa5F`.

Made with [Cursor](https://cursor.com)