### PR TITLE
Dashboard run management, all-legs map overview, run context headers, docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,58 @@
 # Changelog
 
+## [v2.0.8] - 2026-06-10
+
+### Summary
+- **Leg-based race configuration is now the primary authoring workflow**: organization leg library, event recipes, locations on legs (Issues #755, #769, #780)
+- **Issue #785 Complete**: Corridor pairing — paired directional legs generate opposing-pass counterflow flow rows
+- Leg → course location sync fixes, recipe km protection, and location projection hardening
+- Dashboard run history management (edit/delete runs), all-legs map overview, and run context on report pages
+
+### New Features
+
+#### Organization Leg Library & Event Recipes (Issues #755, #769, #780, PRs #776–#784)
+- **Race Configuration workspace**: Legs / Course / Runners tabs per config package
+- **Org-primary leg library**: legs live in `runflow/org/legs/` and are shared across packages; new packages default to `leg_source: org`
+- **Leg authoring**: import third-party GPX, trim/reshape routes, edit metadata (width, schema, direction, flow type), export legs with metadata and locations
+- **Event recipes**: ordered leg lists per event; the same leg can appear in multiple recipes and multiple times in one recipe (out-and-back)
+- **Apply recipes**: builds combined course with per-event `from_km`/`to_km`, stitched per-event GPX, generated `flow.csv`, and synced locations
+- **Locations on legs**: pins placed on legs (course/water/official snap to route; aid/traffic/extract free), synced into the combined course with stable crew-facing `loc_id` and `location_key`
+- **Locations operations grid**: zones, resources, timing, notes edited at course level and preserved across re-applies
+
+#### Corridor Pairing (Issue #785, PR #787)
+- **`paired_with` on legs**: declare that two directional legs share the same physical corridor in opposite directions; symmetric save via UI dropdown with a Pair column in the legs table
+- **Opposing-pass flow rows**: generated `flow.csv` emits `counterflow,bi` rows for all event combinations across paired passes — including same-event out/back overlaps (restores hand-crafted 2026-style corridor insight)
+- **Self-pairing**: a leg appearing twice in one recipe is treated as an implicit corridor pair
+- **Apply-time validation**: warnings for dangling, asymmetric, unused, or non-reversed-geometry pairings
+
+#### Dashboard Run History Management
+- **Actions column** on the Run History table with edit/delete icon buttons (same pattern as Race Configuration)
+- **Edit**: change a run's description in place; updates both `runflow/analysis/index.json` and the run's `analysis.json`
+- **Delete**: remove any individual run (folder + index entry) with double confirmation — unlike `prune_runs --keep N`, runs in the middle of history can be removed; the run referenced by `latest.json` is protected
+- **API**: new `PATCH /api/runs/{run_id}` and `DELETE /api/runs/{run_id}` endpoints
+
+#### Legs Map Overview
+- **All leg routes drawn by default**: the Legs map shows every leg as a muted background line (new bulk `GET .../segment-library/leg-geometries` endpoint), with hover labels; clicking a route selects that leg
+- Previously the map appeared empty until a leg was selected (what looked like an all-legs view before was leaked course-level pins, removed by the duplicate-pin fix)
+
+#### Run Context on Report Pages
+- Segments, Density, Flow, and Locations pages show the selected run's **ID / Description / Date** under the page heading (shared `partials/run_context.html`)
+
+### Bug Fixes
+- **Leg → course location sync (PR #787)**: org leg edits now propagate into `course.json` for all org-sourced packages; pin moves on the Legs tab no longer require a recipe re-apply. Merges treat `lat`/`lon`/`placement` as leg-owned, and the Legs tab no longer renders duplicate course-level pins
+- **Recipe km protection (PR #784)**: recipe-applied per-event segment kilometres are server-owned; stale browser saves can no longer corrupt `course.json`
+- **Per-event km export (PR #784)**: recipe-built segments use stored per-event `from_km`/`to_km` instead of recomputing (fixes course gaps in Locations UI)
+- **Location projection clamp (PR #787)**: boundary pins (turnarounds, junctions) projecting within `LOCATION_SEGMENT_CLAMP_M` (50 m, configurable in `app/utils/constants.py`) of a segment end are clamped into bounds instead of falling back to midpoint timing
+- **Proxy chain guardrails (PR #784)**: proxy location dropdowns exclude locations that are themselves proxied
+- **Natural segment ordering (PR #784)**: density/flow tables sort S2 before S10
+- **UI artifact resilience (PR #784)**: segment map PNG generation skips segments without density metrics instead of failing the run
+
+### UI Changes
+- **Loc Sheets removed from navigation**: one-pagers are linked from the Locations UI (route kept)
+
+### Known Issues
+- **#786**: segment km bookkeeping drifts from stitched course geometry (~100 m mid-course), which can still fail centerline projection for pins at turn points
+
 ## [v2.0.6] - 2026-01-12
 
 ### Summary

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -467,6 +467,52 @@ async def api_get_package_leg_geometry(
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
 
 
+@router.get("/api/config/packages/{config_id}/segment-library/leg-geometries")
+async def api_get_package_leg_geometries(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """GeoJSON FeatureCollection of all leg routes (legs map background layer)."""
+    require_auth(request)
+    try:
+        from app.core.config_package.leg_library_resolver import (
+            LEG_SOURCE_ORG,
+            effective_leg_source,
+        )
+        from app.core.config_package.org_leg_library import load_org_leg_manifest
+        from app.core.config_package.segment_recipes import (
+            load_package_segment_manifest,
+        )
+        from app.core.course.segment_library import manifest_legs
+
+        manifest = load_package_segment_manifest(config_id)
+        if effective_leg_source(manifest) == LEG_SOURCE_ORG:
+            legs = manifest_legs(load_org_leg_manifest())
+
+            def geom_for(leg_id: str):
+                return get_org_leg_line_geojson(leg_id)
+        else:
+            legs = manifest_legs(manifest)
+
+            def geom_for(leg_id: str):
+                return get_leg_line_geojson(config_id, leg_id)
+
+        features = []
+        for entry in legs:
+            leg_id = str(entry.get("id") or "").strip()
+            if not leg_id:
+                continue
+            try:
+                features.append(geom_for(leg_id))
+            except (FileNotFoundError, ValueError):
+                continue
+        return JSONResponse(
+            content={"ok": True, "type": "FeatureCollection", "features": features}
+        )
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
 @router.post("/api/config/packages/{config_id}/segment-library/sync-leg-locations")
 async def api_sync_leg_locations_to_course(
     request: Request,

--- a/app/routes/api_dashboard.py
+++ b/app/routes/api_dashboard.py
@@ -8,15 +8,19 @@ Epic: RF-FE-002 | Issue: #279 | Step: 6
 Architecture: Option 3 - Hybrid Approach
 """
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
+from pydantic import BaseModel
 from typing import Dict, Any, List, Optional
 from pathlib import Path
 import json
 import logging
+import re
+import shutil
 from datetime import datetime
 
 from app.common.config import load_rulebook, load_reporting
+from app.utils.auth import require_auth
 from app.utils.run_id import get_latest_run_id, resolve_selected_day
 from app.storage import create_runflow_storage
 from app.utils.metadata import get_run_index
@@ -618,3 +622,145 @@ async def get_run_summary(run_id: str):
     except Exception as e:
         logger.error(f"Error getting run summary for {run_id}: {e}")
         raise HTTPException(status_code=500, detail=f"Error loading run summary: {str(e)}")
+
+
+# ---------------------------------------------------------------------------
+# Run history management (Dashboard Actions column)
+# ---------------------------------------------------------------------------
+
+_RUN_ID_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+class UpdateRunRequest(BaseModel):
+    description: Optional[str] = None
+
+
+def _validated_run_id(run_id: str) -> str:
+    run_id = str(run_id or "").strip()
+    if not run_id or not _RUN_ID_RE.match(run_id):
+        raise HTTPException(status_code=400, detail=f"Invalid run_id: {run_id}")
+    return run_id
+
+
+def _analysis_index_path() -> Path:
+    from app.utils.run_id import get_runflow_root
+
+    return get_runflow_root() / "analysis" / "index.json"
+
+
+def _load_analysis_index() -> List[Dict[str, Any]]:
+    index_path = _analysis_index_path()
+    if not index_path.exists():
+        raise HTTPException(status_code=404, detail="index.json not found")
+    entries = json.loads(index_path.read_text(encoding="utf-8"))
+    if not isinstance(entries, list):
+        raise HTTPException(status_code=500, detail="index.json is not a JSON array")
+    return entries
+
+
+def _write_analysis_index(entries: List[Dict[str, Any]]) -> None:
+    index_path = _analysis_index_path()
+    temp_path = index_path.with_suffix(".json.tmp")
+    temp_path.write_text(
+        json.dumps(entries, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+    temp_path.replace(index_path)
+
+
+def _latest_run_id() -> Optional[str]:
+    from app.utils.run_id import get_runflow_root
+
+    latest_path = get_runflow_root() / "analysis" / "latest.json"
+    if not latest_path.exists():
+        return None
+    try:
+        return json.loads(latest_path.read_text(encoding="utf-8")).get("run_id")
+    except Exception:
+        return None
+
+
+@router.patch("/api/runs/{run_id}")
+async def update_run_metadata(request: Request, run_id: str, payload: UpdateRunRequest):
+    """
+    Update editable run history fields (description).
+
+    Writes to both runflow/analysis/index.json and the run's analysis.json,
+    since the Dashboard run list prefers the description in analysis.json.
+    """
+    require_auth(request)
+    run_id = _validated_run_id(run_id)
+    if payload.description is None:
+        raise HTTPException(status_code=400, detail="No editable fields provided")
+    description = str(payload.description).strip()
+    if not description:
+        raise HTTPException(status_code=400, detail="Description cannot be empty")
+
+    entries = _load_analysis_index()
+    entry = next((e for e in entries if e.get("run_id") == run_id), None)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found in index")
+    entry["description"] = description
+    _write_analysis_index(entries)
+
+    from app.utils.run_id import get_run_directory
+
+    analysis_path = get_run_directory(run_id) / "analysis.json"
+    if analysis_path.exists():
+        try:
+            data = json.loads(analysis_path.read_text(encoding="utf-8"))
+            data["description"] = description
+            temp_path = analysis_path.with_suffix(".json.tmp")
+            temp_path.write_text(
+                json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+            )
+            temp_path.replace(analysis_path)
+        except Exception as e:
+            logger.warning(f"Could not update analysis.json for {run_id}: {e}")
+
+    logger.info(f"Updated run {run_id} description to: {description!r}")
+    return JSONResponse(content={"ok": True, "run_id": run_id, "description": description})
+
+
+@router.delete("/api/runs/{run_id}")
+async def delete_run(request: Request, run_id: str):
+    """
+    Delete one run from history: removes the run folder and its index.json entry.
+
+    The run referenced by latest.json cannot be deleted (mirrors prune_runs guard).
+    """
+    require_auth(request)
+    run_id = _validated_run_id(run_id)
+
+    latest = _latest_run_id()
+    if latest and latest == run_id:
+        raise HTTPException(
+            status_code=400,
+            detail="Cannot delete the latest run (latest.json points to it). Run a newer analysis first.",
+        )
+
+    entries = _load_analysis_index()
+    remaining = [e for e in entries if e.get("run_id") != run_id]
+    in_index = len(remaining) != len(entries)
+
+    from app.utils.run_id import get_run_directory
+
+    run_dir = get_run_directory(run_id)
+    folder_deleted = False
+    if run_dir.exists():
+        try:
+            shutil.rmtree(run_dir)
+            folder_deleted = True
+        except Exception as e:
+            logger.error(f"Failed to delete run folder {run_dir}: {e}")
+            raise HTTPException(status_code=500, detail=f"Failed to delete run folder: {e}")
+
+    if not in_index and not folder_deleted:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+
+    if in_index:
+        _write_analysis_index(remaining)
+
+    logger.info(f"Deleted run {run_id} (folder_deleted={folder_deleted}, index_updated={in_index})")
+    return JSONResponse(
+        content={"ok": True, "run_id": run_id, "folder_deleted": folder_deleted}
+    )

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,7 +1,7 @@
 # Run-Density Documentation
 
-**Version:** v2.0.2+  
-**Last Updated:** 2025-12-26  
+**Version:** v2.0.8  
+**Last Updated:** 2026-06-10  
 **Architecture:** Local-only, UUID-based runflow structure, API-driven configuration where all analysis parameters are provided via API. 
 
 This documentation is organized by audience and topic for easy navigation.
@@ -12,16 +12,18 @@ This documentation is organized by audience and topic for easy navigation.
 
 ### 👥 For Users (Race Organizers, Operational Planners)
 
-**Focus:** Using the API to request analyses and understand results
+**Focus:** Building race configuration, requesting analyses, and understanding results
 
 | Document | Purpose |
 |----------|---------|
-| [API User Guide](user-guide/api-user-guide.md) | **START HERE** - Complete API usage guide |
+| [Race Configuration Guide](user-guide/race-configuration.md) | **START HERE** - Leg-based course authoring (leg library, event recipes, corridor pairing, locations) |
+| [API User Guide](user-guide/api-user-guide.md) | Complete API usage guide |
+| [Course Mapping Guide](user-guide/course-mapping.md) | Legacy draw-the-line course authoring (simple races) |
 | [Cloud Container Guide](user-guide/cloud-container.md) | Skinny cloud Locations UI (read-only) |
 
 **Quick Start:**
-1. Read [API User Guide](user-guide/api-user-guide.md) for complete API usage
-2. Review example requests and common use cases
+1. Build your config package with the [Race Configuration Guide](user-guide/race-configuration.md)
+2. Read [API User Guide](user-guide/api-user-guide.md) for running analyses
 3. Understand error handling and validation
 
 ---
@@ -34,6 +36,7 @@ This documentation is organized by audience and topic for easy navigation.
 |----------|---------|
 | [Developer Guide](dev-guides/developer-guide.md) | **START HERE** - Complete v2 developer guide |
 | [Docker Development](dev-guides/docker-dev.md) | Docker development workflow |
+| [Leg Library & Corridor Pairing](dev-guides/segment-library-2027.md) | Leg platform internals (org library, recipes, pairing, sync) |
 | [Quick Reference](reference/quick-reference.md) | Variable names, terminology, standards (v2.0.2+) |
 | [Data Sources](dev-guides/data-sources.md) | Data source specifications (v2.0.2+) |
 | [Testing Guide](testing/testing-guide.md) | Comprehensive testing guide |
@@ -75,13 +78,16 @@ docs/
 ├── README.md (this file)              # Documentation index
 │
 ├── user-guide/                        # User Documentation
-│   └── api-user-guide.md              # Complete API usage guide
+│   ├── race-configuration.md          # Leg-based course authoring (recommended)
+│   ├── course-mapping.md              # Legacy draw-the-line authoring
+│   ├── api-user-guide.md              # Complete API usage guide
 │   └── cloud-container.md             # Cloud (skinny) Locations UI
 │
 ├── dev-guides/                        # Developer Documentation
 │   ├── ai-developer-guide.md          # AI assistant onboarding and rules
 │   ├── developer-guide.md             # Complete developer guide
 │   ├── docker-dev.md                  # Docker development workflow
+│   ├── segment-library-2027.md        # Leg library, recipes & corridor pairing internals
 │   └── data-sources.md                # Data source specifications
 │
 ├── testing/                           # Testing Documentation
@@ -139,6 +145,20 @@ Covers:
 - Configuration and environment variables
 - File structure and volume mounts
 - Troubleshooting guides
+
+---
+
+#### [Race Configuration Guide](user-guide/race-configuration.md)
+**Audience:** Users (Race Organizers, Course Mappers)  
+**Purpose:** Leg-based course authoring workflow  
+**Updated:** 2026-06
+
+Covers:
+- Organization leg library (import, edit, export GPX legs)
+- Event recipes and applying them to build the combined course
+- Corridor pairing for opposing-pass flow analysis
+- Locations on legs, proxy timing, and operations editing
+- direction/flow type selection guidance
 
 ---
 
@@ -227,19 +247,27 @@ Covers:
 ## 🆘 Getting Help
 
 **Questions about:**
+- **Building a course/config package?** → See [Race Configuration Guide](user-guide/race-configuration.md)
 - **API usage?** → See [API User Guide](user-guide/api-user-guide.md)
 - **Development workflow?** → See [Docker Development](dev-guides/docker-dev.md)
 - **Code standards?** → See [AI Developer Guide](dev-guides/ai-developer-guide.md)
-- **Field names?** → See [Quick Reference](reference/QUICK_REFERENCE.md)
-- **Architecture?** → See [Developer Guide v2](dev-guides/developer-guide-v2.md)
+- **Field names?** → See [Quick Reference](reference/quick-reference.md)
+- **Architecture?** → See [Developer Guide](dev-guides/developer-guide.md)
+- **Leg library internals?** → See [Leg Library & Corridor Pairing](dev-guides/segment-library-2027.md)
 - **Testing?** → See [Testing Guide](testing/testing-guide.md)
 
 ---
 
 ## 🔄 Document Lifecycle
 
-### Recently Updated (v2.0.2+ - December 2025)
-- ✅ `dev-guides/ai-developer-guide.md` - NEW consolidated AI assistant guide
+### Recently Updated (June 2026 — leg platform & corridor pairing)
+- ✅ `user-guide/race-configuration.md` - NEW leg-based course authoring guide
+- ✅ `dev-guides/segment-library-2027.md` - Rewritten for implemented leg platform (org library, pairing, sync)
+- ✅ `user-guide/course-mapping.md` - Marked as legacy workflow; points to Race Configuration
+- ✅ `CHANGELOG.md` - Unreleased section for leg platform, corridor pairing (#785), and sync fixes
+
+### Previously Updated (v2.0.2+ - December 2025)
+- ✅ `dev-guides/ai-developer-guide.md` - Consolidated AI assistant guide
 - ✅ `user-guide/api-user-guide.md` - Complete API usage guide
 - ✅ `dev-guides/developer-guide.md` - Complete developer guide
 - ✅ `dev-guides/docker-dev.md` - Version 3.1
@@ -253,5 +281,5 @@ Covers:
 
 ---
 
-**Last Updated:** 2025-12-26  
+**Last Updated:** 2026-06-10  
 **Maintained By:** Development Team

--- a/docs/dev-guides/segment-library-2027.md
+++ b/docs/dev-guides/segment-library-2027.md
@@ -1,161 +1,128 @@
-# Segment library & event recipes (2027 planning)
+# Leg library, event recipes & corridor pairing (developer guide)
 
-**Status:** Prototype in `app/core/course/segment_library.py`  
-**Reference data:** `cursor/reference-legs/` (sample GPX legs + combined `00_*.gpx`)  
-**Epic:** #755 · Related: #767 (planner), #759 (flow review)
+**Status:** Implemented (org-primary since #780/#783; corridor pairing since #785)
+**Last updated:** 2026-06
+**Epics/issues:** #755 (library), #780 (org-primary), #785 (corridor pairing), #786 (km drift — open)
+**User guide:** [Race Configuration](../user-guide/race-configuration.md)
 
 ---
 
 ## Goal
 
-Use a **map/GPX workflow** to produce analysis-ready config **without hand-editing** `segments.csv`, `flow.csv`, or `locations.csv` for each new year (e.g. 2027).
+Use a **map/GPX workflow** to produce analysis-ready config **without hand-editing** `segments.csv`, `flow.csv`, or `locations.csv` for each new year.
 
 | Output | Role in analysis |
 |--------|------------------|
-| **segments.csv** | **Multi-event rows** — one row per *shared* course leg; `full`/`half`/`10k` flags; per-event `*_from_km` / `*_to_km` for density |
-| **flow.csv** | **Event pairs** on shared legs; uses *each event’s* km on that leg (can differ on same `seg_id` in advanced cases) |
-| **locations.csv** | Points with **per-event** flags and km; first/last runner times pool arrivals across all flagged events |
-| **`{event}.gpx`** | Per-event geometry for GPX projection and location distance |
+| **segments.csv** | Multi-event rows — one row per leg occurrence; `full`/`half`/`10k` flags; per-event `*_from_km` / `*_to_km` for density |
+| **flow.csv** | Event pairs on shared legs + corridor opposing-pass rows; uses *each event's* km windows |
+| **locations.csv** | Points with per-event flags, `seg_id`, zones, resources, proxy timing |
+| **`{event}.gpx`** | Per-event geometry stitched from recipe order |
 
 ---
 
-## Model (leg library)
+## Data model
 
-### 1. Segment library
+### Org leg library (primary)
 
-- Each file `01_start_friel.gpx`, `02_friel_10kturn.gpx`, … is one **leg**.
-- Legs stitch end-to-end (endpoint tolerance ~80 m).
-- Metadata in `cursor/reference-legs/manifest.yaml`: `seg_label`, width, schema, direction.
+- Legs live in `runflow/org/legs/` — one GPX per leg + `manifest.yaml` (id, file, `seg_label`, `start_label`/`end_label`, `width_m`, `schema`, `direction`, `flow_type`, `flow_notes`, `paired_with`, `locations[]`).
+- New packages default to `leg_source: org` (`effective_leg_source` in `leg_library_resolver.py`); legacy packages with local legs stay package-scoped.
+- Package manifests (`{package}/segment_library/manifest.yaml`) hold **recipes** and `flow_overrides`; legs come from the org manifest via `resolve_leg_library()` / `combined_manifest_for_apply()`.
 
-### 2. Event recipes
+### Event recipes
 
-Ordered list of leg ids per event:
+Ordered list of leg ids per event, stored in the **package** manifest:
 
 ```yaml
 recipes:
-  10k: [01, 02, 04, 05, 06, 12]
-  half: [01, 05, 08, 10, 11, 12]
-  full: [01, 02, 03, 04, 05, 06, 07, 08, 09, 10, 11, 12]
+  10k: ["01", "02", "04", "05", "06", "12"]
+  half: ["01", "05", "08", "10", "11", "12"]
+  full: ["01", "02", ..., "12"]
 ```
 
-- **Combine** = concatenate leg GPX in recipe order.
-- Verify `recipe_lengths_km` against `00_{event}.gpx` after edits.
+- The same leg may appear in multiple recipes (shared segments) and **multiple times in one recipe** (out-and-back over one leg → distinct `seg_id` per occurrence).
+- Apply = stitch leg GPX in recipe order (endpoint tolerance `STITCH_TOLERANCE_M`), compute per-event cumulative kms, build `course.json` segments + locations, generate flow.
 
-### 3. Export `segments.csv` (multi-event — required)
+### Corridor pairing (#785)
 
-**One row per leg**, not per event:
+`paired_with` on a leg declares that another leg covers the **same physical corridor in the opposite direction**.
 
-| Column | Source |
-|--------|--------|
-| `seg_id`, `seg_label`, … | Leg metadata |
-| `full`, `half`, `10k`, … | `y` if leg appears in that event’s recipe |
-| `full_from_km`, `full_to_km`, … | Cumulative distance along **that event’s recipe only** |
-| `0` / `n` | Events that skip the leg |
+- **Symmetric by construction:** `apply_leg_pairing()` (`app/core/config_package/legs.py`) sets/clears both sides and clears stale reciprocals. Wired into `update_package_leg` and `update_org_leg` when `paired_with` is in the update fields.
+- **Self-pairing is implicit:** the same leg appearing twice in one recipe is treated as a corridor pair between the two occurrences (`leg_occurrence` in `flow_csv.py`).
+- **Validation:** `validate_corridor_pairings()` (`app/core/course/segment_library.py`) emits warnings (dangling, asymmetric, unused-in-recipes, geometry-not-reversed) appended to stitch warnings at apply time.
 
-This matches **2026_final** (e.g. A1 used by Full+Half+10K with aligned early km; B1 Full+10K only with `half` = n).
+---
 
-Density (`get_shared_segments`, bins) uses these flags — **shared segments must stay on one row**.
+## Flow generation
 
-### 4. Export `flow.csv` (re-planned)
+**Generator:** `build_flow_csv_from_segments()` in `app/core/course/flow_csv.py`.
 
-**Generator:** `build_flow_csv_from_segments()` in `segment_library.py`.
-
-For each segment row where **2+ events** are active:
-
-- Emit **cross-event** pairs only (`full/half`, `full/10k`, `half/10k`) with a unique `flow_id` per row.
-- Same-event rows (out/back, lap, slow/fast) come from manifest `flow_overrides` when A/B km windows differ.
-- Do **not** auto-generate `event_a == event_b` rows when A/B km ranges are identical.
-- `from_km_a` / `to_km_a` = segment’s `{event_a}_from_km` / `{event_a}_to_km`; same for event B.
-- Default `flow_type`: `overtake`; `none` supported via overrides. Bidirectional per-minute CSVs use `flow_id`.
-
-**Not** the old stub in `build_flow_csv()` (one row per segment, same event A/B).
+1. **Cross-event pairs** on each shared segment (2+ events active): `overtake` rows with each event's own km window; unique `flow_id` per row.
+2. **Corridor pairs** (`_corridor_pairs()`): for explicitly paired legs and self-paired occurrences, emit `counterflow,bi` rows for **all** event combinations across the two passes — including same-event (e.g. full outbound vs full return). Events not present on a pass are skipped.
+3. Same-event rows with identical A/B km windows are never auto-generated; `flow_overrides` in the manifest still supported for exceptions.
 
 **Pipeline:** `app/core/v2/flow.py` — `flow.csv` is authoritative; pairs must exist for requested events or analysis fails (#553).
 
-**Follow-up (#759):** Review grid for exceptions (e.g. 2026 `B1a` — same `seg_label`, different km windows for late overlaps). Auto-generate baseline; human adds override rows.
+---
 
-### 5. Locations (re-planned)
+## Leg ↔ course synchronization
 
-Locations are **like segments + flow**: multi-event, analysis uses **all** eligible events at a point.
+Two copies of leg data exist: the leg manifest (authoring) and the package `course.json` (combined course, feeds exports). Sync rules:
 
-**Current analysis** (`app/location_report.py`):
+| Direction | Mechanism | Triggers |
+|-----------|-----------|----------|
+| Leg → course | `merge_leg_locations_into_course()` + `sync_leg_metadata_into_course()` (`legs.py`) | Apply recipes; any package-leg update; **any org-leg update** fans out via `sync_org_leg_changes_into_packages()` (`org_leg_library.py`) to every org-sourced package with applied recipes |
+| Course → leg | `sync_leg_location_metadata_from_course()` | Locations grid (operations editor) saves |
 
-1. Read `locations.csv` flags (`full`, `half`, `10k`, …).
-2. For each eligible event, compute arrival times from:
-   - Listed `seg_id`(s) on the location, **or**
-   - Nearest segment + GPX projection using `{event}.gpx`.
-3. Uses `{event}_from_km` / distance on segment for `pace × distance + start`.
-4. **`first_runner` / `last_runner`** = min/max over **combined** arrival list across events (cross-event staffing window).
+**Field ownership** during leg → course merge:
 
-**Planned authoring (no hand km):**
+- **Leg-owned:** `lat`, `lon`, `placement` (`_LEG_OWNED_PLACEMENT_FIELDS`) — pin moves on the Legs tab always win; stale course copies never override them.
+- **Course-owned (preserved):** crew-facing `id` (`loc_id`), resources, zone, notes, buffer, interval, contact, proxy settings, etc. (`_LEG_LOC_PRESERVE_FIELDS` minus placement). Identity is matched by `location_key` / `leg_loc_key`.
 
-| Step | Action |
-|------|--------|
-| 1 | Place location on map (or import lat/lon). |
-| 2 | System projects point onto each **recipe-built** `{event}.gpx` → event km at location. |
-| 3 | Set event flags from segment membership (suggest API exists: `suggest_location_events`). |
-| 4 | Export `locations.csv` with `full_from_km`, `half_from_km`, `10k_from_km`, … |
+**Server-owned recipe kms:** `_preserve_recipe_segment_kms()` (`storage.py::save_config_course`) prevents stale client saves from overwriting recipe-applied per-event `from_km`/`to_km` and the `segment_library_applied` flag.
 
-**Dependency:** Per-event GPX from recipes must exist before location export (same as analysis).
-
-**Not** tied to single `course.json` LineString.
+**UI note:** the Legs and Course tabs share one Leaflet map. Course-level location pins are removed while the Legs tab is active (`removeLocationPins` in `course_mapping.js`, called from `onLegsTabShown`) to avoid duplicate-pin confusion.
 
 ---
 
-## What’s implemented now
+## Location projection tolerances
 
-```bash
-# In repo root (Docker or venv with app deps):
-python3 -c "
-from pathlib import Path
-from app.core.course.segment_library import export_library_to_course, write_package_exports
-b = export_library_to_course(Path('cursor/reference-legs'))
-print('10k km', b['recipe_lengths_km'])
-print('flow rows', b['flow_csv'].count(chr(10)))
-write_package_exports(Path('/tmp/fm_reference_legs_test'), Path('cursor/reference-legs'))
-"
-```
+`app/utils/constants.py`:
 
-```bash
-pytest tests/unit/test_segment_library.py -q
-```
+| Constant | Default | Use |
+|----------|---------|-----|
+| `LOCATION_SNAP_THRESHOLD_M` | 50 | Max pin → segment-centerline distance for projection and for `find_nearest_segment` discovery |
+| `LOCATION_SEGMENT_CLAMP_M` | 50 | Boundary pins projecting metres past a segment end are clamped into bounds instead of falling back to midpoint |
 
-Files:
-
-- `cursor/reference-legs/manifest.yaml` — legs + recipes (edit recipes here)
-- `app/core/course/segment_library.py` — load, stitch, segments, flow, package write
-- `tests/unit/test_segment_library.py`
+Known limitation: recipe-bookkept kms vs stitched-GPX traced distance drift up to ~110 m mid-course, which can still fail projection for pins at turn points — see **#786** for the planned reconciliation (record traced kms at export).
 
 ---
 
-## UI roadmap (after library API stable)
-
-| Tab | Purpose |
-|-----|---------|
-| **Library** | Import GPX legs; endpoint validation |
-| **Recipes** | Order legs per event; length vs `00_*` check |
-| **Segments & flow** | Preview tables; export |
-| **Locations** | Pins + auto km + event flags |
-| **Publish** | Write package + `analyze_ready` |
-
-Deprecate single-line-only planner as **primary** 2027 path; keep for simple races.
-
----
-
-## Open issues
-
-1. **Full recipe tuning** — manifest `full` recipe ~40–44 km; validate against `00_full.gpx` (41.76 km).
-2. **Flow exceptions** — `B1a`-style rows need override UI or manifest entries.
-3. **Package API** — `POST /api/config/packages/{id}/import-library` (not wired yet).
-4. **#767** — Align waypoint planner with leg ids instead of vertex indices.
-
----
-
-## Related code
+## Key modules
 
 | Module | Use |
 |--------|-----|
-| `app/core/course/export.py` | `build_segments_csv`, `_event_cumulative_distances` |
-| `app/core/v2/flow.py` | Consumes `flow.csv` + `segments.csv` |
-| `app/location_report.py` | Consumes `locations.csv` + GPX + segments |
-| `app/core/config_package/storage.py` | `package_readiness` needs all three CSVs |
+| `app/core/course/segment_library.py` | Load/stitch legs, build segments, corridor pairing validation, package export |
+| `app/core/course/flow_csv.py` | Flow generation incl. corridor opposing-pass rows |
+| `app/core/course/export.py` | `build_segments_csv`, per-event cumulative kms (uses stored recipe kms) |
+| `app/core/config_package/legs.py` | Package leg CRUD, pairing, leg↔course sync, location merge |
+| `app/core/config_package/org_leg_library.py` | Org leg CRUD, import/export, package fan-out sync |
+| `app/core/config_package/leg_library_resolver.py` | Org vs package leg source resolution |
+| `app/core/config_package/segment_recipes.py` | Recipe persistence, apply |
+| `app/routes/api_config_packages.py` | REST endpoints (`/api/org/legs/*`, `/api/config/packages/{id}/segment-library/*`) |
+| `frontend/static/js/map/segment_recipes.js` | Legs tab UI (leg editor, pairing dropdown, locations) |
+| `frontend/static/js/map/course_mapping.js` | Course tab UI (recipes, segments/locations tables, pins) |
+
+## Tests
+
+```bash
+pytest tests/unit/test_segment_library.py tests/unit/test_corridor_pairing.py \
+       tests/unit/test_flow_csv.py tests/unit/test_leg_library_resolver.py \
+       tests/unit/test_package_legs.py tests/unit/test_org_leg_library.py -q
+```
+
+Notable regression coverage:
+
+- `test_corridor_pairing.py` — symmetric pairing, validation warnings
+- `test_flow_csv.py` — paired/self-paired opposing-pass rows; unpaired output unchanged
+- `test_leg_library_resolver.py` — org-primary resolution; org leg edits sync into applied packages without re-apply
+- `test_config_package_course.py` — recipe kms protected from stale client saves

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -225,6 +225,10 @@ The following constants have been **removed** - values now come from API request
 - Default segment width: varies by segment (see segments.csv)
 - Minimum segment length: 50m
 
+**Location projection (`app/utils/constants.py`):**
+- `LOCATION_SNAP_THRESHOLD_M` (50 m): max pin → segment-centerline distance for projection and nearest-segment discovery
+- `LOCATION_SEGMENT_CLAMP_M` (50 m): boundary pins projecting metres past a segment end are clamped into bounds instead of falling back to segment-midpoint timing (see issue #786 for the km-drift limitation)
+
 **Density:**
 - LOS thresholds: See `config/density_rulebook.yml`
 - Flag thresholds: See `config/density_rulebook.yml`

--- a/docs/user-guide/course-mapping.md
+++ b/docs/user-guide/course-mapping.md
@@ -1,7 +1,9 @@
 # Course Mapping User Guide
 
 **Audience:** Race organizers, course mappers, and operational staff  
-**Last updated:** 2026-02
+**Last updated:** 2026-06
+
+> **Recommended workflow:** Most courses are now built from reusable GPX **legs** with event recipes on the **Race Configuration** page — see the [Race Configuration User Guide](race-configuration.md). The draw-the-line workflow below remains supported for simple races and legacy courses.
 
 ---
 

--- a/docs/user-guide/race-configuration.md
+++ b/docs/user-guide/race-configuration.md
@@ -1,0 +1,173 @@
+# Race Configuration User Guide (Leg-Based Workflow)
+
+**Audience:** Race organizers, course mappers, and operational staff
+**Last updated:** 2026-06
+
+This guide covers the **Race Configuration** page — the recommended way to build analysis-ready config packages from reusable GPX **legs**. For the legacy draw-the-line workflow, see [Course Mapping](course-mapping.md).
+
+---
+
+## Overview
+
+Instead of drawing one long course line, you build a course from **legs**: short GPX sections (e.g. "Bridge at Mill → Half Turn") stored in your **organization leg library**. Each event (Full, Half, 10K) gets a **recipe** — an ordered list of legs. Applying recipes builds the combined course and generates **segments.csv**, **flow.csv**, **locations.csv**, and per-event **GPX** automatically. No hand-editing of CSVs.
+
+**Key benefits:**
+
+- Legs are reusable across years and packages — fix a leg once, every package that uses it benefits.
+- Out-and-back sections become two explicit directional legs, so flow analysis can model opposing traffic correctly (see [Corridor pairing](#corridor-pairing)).
+- Locations (water stops, officials, aid) live **on legs**, so they come along automatically when a leg is used.
+
+---
+
+## Where to find it
+
+Open **Race Configuration** from the main menu and select (or create) a config package. The workspace has three tabs:
+
+| Tab | Purpose |
+|-----|---------|
+| **Legs** | Manage the organization leg library, edit leg metadata, place locations on legs |
+| **Course** | Event recipes, combined course preview, segments and locations tables, apply + export |
+| **Runners** | Runner files for the package events |
+
+---
+
+## The Legs tab
+
+### Leg map
+
+Pan and zoom to filter the legs table below the map. Select a leg in the table to highlight its route (purple line). Toolbar actions:
+
+| Action | What it does |
+|--------|--------------|
+| **Trim route** | Drag the start or end of the selected leg along its route |
+| **Reshape route** | Simplify the route, then drag yellow anchors to nudge it |
+| **Add Locations** | Click the map to place location pins on the selected leg |
+
+### Organization leg library
+
+Legs live in the **organization library** (`runflow/org/legs/`), outside any single package, so they are shared across packages.
+
+| Button | What it does |
+|--------|--------------|
+| **Import legs…** | Import third-party GPX files (e.g. from a route planner) as new legs |
+| **Leg library…** | Browse all org legs, including ones not used by this package |
+| **Export legs…** | Download all legs (GPX + metadata + locations per leg) |
+
+The legs table shows each leg's ID, label, endpoints, length, width, schema, direction, flow type, **Pair** (corridor pairing partner), and location count. Use the **edit** action to open the leg editor.
+
+### Leg editor fields
+
+| Field | Meaning |
+|-------|---------|
+| **Label / Start / End** | Names used in segment labels and endpoint matching |
+| **Width (m)** | Usable course width for density (e.g. 1.5 for a trail lane, 3.0 for a full trail) |
+| **Schema** | Density LOS schema for the leg |
+| **Direction** | `uni` (one direction of travel) or `bi` (two-way traffic on the leg itself) |
+| **Flow type** | Default interaction type: `overtake`, `counterflow`, `merge`, or `none` |
+| **Paired leg** | The leg covering the **same physical corridor in the opposite direction** (see below) |
+
+### Choosing direction and flow type
+
+The simple rules:
+
+- **direction** answers: do the streams on this leg move the same way or opposite ways?
+- **flow type** answers: what kind of interaction risk is this?
+
+| Situation | flow type | direction |
+|-----------|-----------|-----------|
+| Events share the leg moving the **same way** (catching/passing) | `overtake` | `uni` |
+| Streams physically **meet head-on** on this one leg | `counterflow` | `bi` |
+| One stream **joins** another | `merge` | `uni` |
+| Keep the leg but don't analyze interaction risk | `none` | per geometry |
+
+> **Out-and-back corridors:** do *not* mark a single directional leg `bi` just because the trail carries traffic both ways at different km. Instead split it into two directional legs and **pair** them.
+
+---
+
+## Corridor pairing
+
+When a course goes out and back along the same physical trail, you have two legs — e.g. leg 03 "Bridge at Mill → Half Turn" and leg 10 "Half Turn → Bridge at Mill". Each is one direction of travel, but runners on both occupy the **same physical space** at the same time. Corridor pairing tells the system about that relationship.
+
+### How to pair
+
+1. Open the **leg editor** for either leg.
+2. Set **Paired leg (same corridor, opposite direction)** to the partner leg.
+3. Save. Pairing is **symmetric** — the partner leg is updated automatically, and the **Pair** column shows the link on both rows.
+
+To unpair, clear the dropdown on either leg.
+
+### What pairing generates
+
+When recipes are applied, the flow generator emits **opposing-pass flow rows** (`counterflow`, `bi`) for every event combination that crosses the paired corridor — including **same-event** pairs (e.g. Full outbound km 25.1–27.7 vs Full return km 33.8–36.4). These restore the high-value overlap insight that previously required hand-crafted flow rows (out/back corridors, late chase overlaps).
+
+Same-direction `overtake` rows on each individual leg are still generated as usual; pairing **adds** the cross-corridor rows, it doesn't replace anything.
+
+### Self-pairing (automatic)
+
+If the **same leg appears twice in one recipe** (e.g. a single bidirectional connector used out and back), the system treats the two occurrences as an implicit corridor pair — no configuration needed.
+
+### Pairing validation
+
+When recipes are applied, the system warns (without blocking) if:
+
+- a leg's pair references a leg that doesn't exist (**dangling**),
+- pairing isn't symmetric (e.g. edited by hand),
+- a paired leg is not used in any recipe (the pair is inert),
+- the two legs' geometries don't look like reversed passes of the same corridor.
+
+---
+
+## Locations on legs
+
+Place pins on the **Legs tab** with **Add Locations** (select a leg first). Location types:
+
+| Type | Snaps to route? | Typical use |
+|------|------------------|-------------|
+| **course** | Yes | Timed checkpoints |
+| **water** | Yes | Water stops |
+| **official** | Yes | Turnarounds, officials |
+| **aid** | No | Aid stations beside the course |
+| **traffic** | No | Traffic control points |
+| **extract** | No | Extraction points |
+
+**The Legs tab owns pin positions.** Dragging a pin on the Legs tab is saved immediately and synced into the package course automatically — no re-apply needed. Operational details (zones, resources, notes, proxy timing) are edited at the **course level** (Locations table → **Edit operations…**) and survive re-applies.
+
+**Proxy locations:** off-course locations can take their timing from an on-course **proxy** location. The proxy dropdown only offers locations that have their own timing (you cannot chain a proxy to another proxied location).
+
+---
+
+## The Course tab
+
+1. **Edit event recipes** — set the ordered list of legs per event. The same leg can appear in multiple recipes (shared segments) and twice in one recipe (out-and-back over the same leg).
+2. **Apply recipes** — builds the combined course: segments with per-event `from_km`/`to_km`, locations (synced from legs), and generated flow pairs. Review any stitch or pairing warnings shown after apply.
+3. Review the **Segments** and **Locations (combined course)** tables. Location **ID** is the stable crew-facing `loc_id`; **Key** keeps identity across re-applies.
+4. **Export package** — writes `segments.csv`, `flow.csv`, `locations.csv`, and per-event GPX to the package folder, ready for analysis.
+
+> **Note:** per-event segment kilometres are **server-owned** once recipes are applied. They are recomputed from recipes on each apply and protected against accidental overwrites from stale browser tabs.
+
+---
+
+## What gets exported
+
+| File | Contents |
+|------|----------|
+| **segments.csv** | One row per leg occurrence with event flags and per-event `from_km`/`to_km` |
+| **flow.csv** | Cross-event `overtake` rows on shared legs + `counterflow` rows for corridor pairs |
+| **locations.csv** | All locations with per-event flags, `seg_id`, zones, resources, proxy timing |
+| **`{event}.gpx`** | Per-event course geometry stitched from that event's recipe |
+
+---
+
+## Common issues
+
+**"I see two pins for the same location."**
+Course-level pin copies are hidden on the Legs tab; if you still see duplicates after editing, refresh the page. Pin positions are owned by the leg — the course copy follows automatically.
+
+**"Should an out-and-back leg be counterflow/bi?"**
+No — keep each directional leg `overtake`/`uni` (or as its same-direction interaction warrants) and **pair** the two legs. The system generates the counterflow rows from the pairing.
+
+**"My paired legs produce no counterflow rows."**
+Both legs must appear in at least one recipe of events being analyzed, and the events' passes must overlap in time. Check the apply warnings for inert pairings.
+
+**"A location at a turnaround gets odd first/last runner times."**
+Turn-point pins sit at segment boundaries and can be affected by small distance bookkeeping differences (see issue #786). Keep the pin physically accurate; do not nudge it to compensate.

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -37,6 +37,10 @@
     var legBoundsCache = {};
     var legsTableBoundsFilter = null;
     var coursePreviewBoundsFilter = null;
+    /** Background layer showing every leg route on the legs map. */
+    var allLegRoutesLayer = null;
+    var allLegRoutesFetchSeq = 0;
+    var ALL_LEG_ROUTES_PANE = 'all-leg-routes';
 
     function schemaLabelForValue(value) {
         var v = String(value || 'on_course_open');
@@ -657,6 +661,7 @@
         renderLegsTable();
         updateLegActionButtons();
         syncLegsTableBoundsFilterItems();
+        renderAllLegRoutes();
         renderRecipeTable();
         renderTotals(data.recipe_lengths_km);
         renderWarnings(data.stitch_warnings);
@@ -848,6 +853,76 @@
             return legReshapeDraftLatLngs;
         }
         return selectedLegLatLngs;
+    }
+
+    function ensureAllLegRoutesPane(map) {
+        if (!map.getPane(ALL_LEG_ROUTES_PANE)) {
+            var pane = map.createPane(ALL_LEG_ROUTES_PANE);
+            // Below the default overlay pane (400) so the selected leg always draws on top.
+            pane.style.zIndex = 380;
+        }
+    }
+
+    function removeAllLegRoutesLayer() {
+        var map = window.courseMappingMap;
+        if (map && allLegRoutesLayer) {
+            map.removeLayer(allLegRoutesLayer);
+        }
+        allLegRoutesLayer = null;
+    }
+
+    /** Draw every leg route as a muted background line so the full network is visible without a selection. */
+    function renderAllLegRoutes() {
+        var map = window.courseMappingMap;
+        if (!map || !isConfigPackageWorkspace()) return;
+        var legs = (libraryState && libraryState.legs) || [];
+        if (!legs.length) {
+            removeAllLegRoutesLayer();
+            return;
+        }
+        allLegRoutesFetchSeq += 1;
+        var seq = allLegRoutesFetchSeq;
+        fetch(apiBase() + '/segment-library/leg-geometries', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (seq !== allLegRoutesFetchSeq || !data) return;
+                var mapNow = window.courseMappingMap;
+                if (!mapNow) return;
+                ensureAllLegRoutesPane(mapNow);
+                removeAllLegRoutesLayer();
+                var features = data.features || [];
+                if (!features.length) return;
+                var group = L.layerGroup();
+                features.forEach(function (feature) {
+                    var geom = feature.geometry || {};
+                    var coords = geom.coordinates || [];
+                    if (geom.type !== 'LineString' || coords.length < 2) return;
+                    var latlngs = coords.map(function (c) { return [c[1], c[0]]; });
+                    var props = feature.properties || {};
+                    var legId = props.leg_id;
+                    if (legId) {
+                        try {
+                            legBoundsCache[legId] = L.latLngBounds(latlngs);
+                        } catch (e) { /* ignore */ }
+                    }
+                    var line = L.polyline(latlngs, {
+                        pane: ALL_LEG_ROUTES_PANE,
+                        color: '#9b8ec4',
+                        weight: 3,
+                        opacity: 0.7
+                    });
+                    var label = String(props.leg_label || legId || '');
+                    if (label) {
+                        line.bindTooltip(label, { sticky: true });
+                    }
+                    if (legId) {
+                        line.on('click', function () { selectLegById(legId); });
+                    }
+                    group.addLayer(line);
+                });
+                allLegRoutesLayer = group.addTo(mapNow);
+            })
+            .catch(function () { /* background layer is best-effort */ });
     }
 
     function setLegRoutePolyline(latlngs) {
@@ -3342,6 +3417,7 @@
             }
             bindLegMapControls();
             attachLegsTableBoundsFilter();
+            if (!allLegRoutesLayer) renderAllLegRoutes();
             if (window.courseMappingMap) {
                 setTimeout(function () {
                     window.courseMappingMap.invalidateSize();

--- a/frontend/templates/pages/dashboard.html
+++ b/frontend/templates/pages/dashboard.html
@@ -42,14 +42,27 @@
                     <th class="table-sortable" data-sort="total_elapsed_minutes" style="text-align: center;">
                         Run Time <span class="table-sortable-indicator">↕</span>
                     </th>
+                    <th style="text-align: center;">Actions</th>
                 </tr>
             </thead>
             <tbody id="run-history-tbody">
                 <tr>
-                    <td colspan="6" class="placeholder">Loading runs...</td>
+                    <td colspan="7" class="placeholder">Loading runs...</td>
                 </tr>
             </tbody>
         </table>
+    </div>
+
+    <!-- Edit run (description only; Run ID is immutable) -->
+    <div id="run-edit-card" style="display: none; margin-top: 1rem; padding: 1rem; border: 1px solid #dee2e6; border-radius: 6px; background: #f8f9fa;">
+        <h4 style="margin: 0 0 0.75rem; color: #2c3e50;">Edit run <span id="run-edit-id" style="font-family: monospace; font-size: 0.875rem; color: #6c757d;"></span></h4>
+        <label for="run-edit-description" style="display: block; font-size: 0.875rem; margin-bottom: 0.25rem;">Description</label>
+        <input type="text" id="run-edit-description" class="filter-input" style="width: 100%; max-width: 480px;" maxlength="200">
+        <div style="margin-top: 0.75rem; display: flex; gap: 0.5rem;">
+            <button type="button" id="run-edit-save" style="padding: 0.5rem 1.25rem; background: #27ae60; color: #fff; border: 1px solid #219a52; border-radius: 4px; font-weight: 600; cursor: pointer;">Save</button>
+            <button type="button" id="run-edit-cancel" style="padding: 0.5rem 1.25rem; background: #fff; color: #2c3e50; border: 1px solid #bdc3c7; border-radius: 4px; cursor: pointer;">Cancel</button>
+        </div>
+        <div id="run-edit-status" style="margin-top: 0.5rem; font-size: 0.875rem; color: #e74c3c;"></div>
     </div>
 </div>
 
@@ -142,10 +155,44 @@
         border-color: #3498db;
         box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
     }
+
+    /* Actions column icon buttons (same look as Race Configuration table) */
+    .course-map-action-btn {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        padding: 0;
+        margin: 0 2px;
+        border: 1px solid #bdc3c7;
+        border-radius: 4px;
+        background: #fff;
+        cursor: pointer;
+        font-size: 0;
+    }
+    .course-map-action-btn:hover {
+        background: #ecf0f1;
+        border-color: #95a5a6;
+    }
+    .course-map-action-btn svg {
+        width: 16px;
+        height: 16px;
+        pointer-events: none;
+    }
+    .course-map-action-btn:disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+    #run-history-table td.course-map-action-cell {
+        text-align: center;
+        white-space: nowrap;
+    }
 </style>
 {% endblock %}
 
 {% block extra_scripts %}
+<script src="/static/js/table_actions.js?v=775b"></script>
 <script>
     // Issue #565: Enhanced Dashboard
     let runsList = [];
@@ -205,6 +252,18 @@
         
         // Setup table sorting
         setupTableSorting();
+
+        // Edit run card buttons
+        const editSave = document.getElementById('run-edit-save');
+        if (editSave) editSave.addEventListener('click', saveRunEdit);
+        const editCancel = document.getElementById('run-edit-cancel');
+        if (editCancel) editCancel.addEventListener('click', closeRunEdit);
+        const editDesc = document.getElementById('run-edit-description');
+        if (editDesc) {
+            editDesc.addEventListener('keydown', function (e) {
+                if (e.key === 'Enter') saveRunEdit();
+            });
+        }
     });
     
     // Issue #565: Run History Table functions
@@ -223,7 +282,7 @@
             .catch(error => {
                 console.error('Error loading runs list:', error);
                 document.getElementById('run-history-tbody').innerHTML = 
-                    '<tr><td colspan="6" style="padding: 2rem; text-align: center; color: #e74c3c;">Error loading runs</td></tr>';
+                    '<tr><td colspan="7" style="padding: 2rem; text-align: center; color: #e74c3c;">Error loading runs</td></tr>';
             });
     }
     
@@ -232,7 +291,7 @@
         if (!tbody) return;
         
         if (filteredRuns.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="6" style="padding: 2rem; text-align: center; color: #6c757d;">No runs found</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="7" style="padding: 2rem; text-align: center; color: #6c757d;">No runs found</td></tr>';
             return;
         }
         
@@ -280,9 +339,137 @@
                     <td style="padding: 0.75rem; border-bottom: 1px solid #dee2e6; text-align: center;">${days}</td>
                     <td style="padding: 0.75rem; border-bottom: 1px solid #dee2e6; text-align: center;">${events}</td>
                     <td style="padding: 0.75rem; border-bottom: 1px solid #dee2e6; text-align: center;">${runTime}</td>
+                    <td class="course-map-action-cell" style="padding: 0.5rem 0.75rem; border-bottom: 1px solid #dee2e6;"></td>
                 </tr>
             `;
         }).join('');
+
+        attachRunRowActions();
+    }
+
+    // Edit/delete icon buttons in the Actions column (mirrors Race Configuration table)
+    function attachRunRowActions() {
+        const ta = window.TableActions;
+        if (!ta) return;
+        document.querySelectorAll('#run-history-tbody tr[data-run-id]').forEach(tr => {
+            const runId = tr.dataset.runId;
+            const cell = tr.querySelector('.course-map-action-cell');
+            if (!cell) return;
+            cell.appendChild(
+                ta.createIconButton('edit', 'Edit run description', function (e) {
+                    e.stopPropagation();
+                    openRunEdit(runId);
+                })
+            );
+            cell.appendChild(
+                ta.createIconButton('delete', 'Delete this run from history', function (e) {
+                    e.stopPropagation();
+                    deleteRun(runId);
+                })
+            );
+        });
+    }
+
+    function openRunEdit(runId) {
+        const run = runsList.find(r => r.run_id === runId);
+        if (!run) return;
+        const card = document.getElementById('run-edit-card');
+        const idEl = document.getElementById('run-edit-id');
+        const descEl = document.getElementById('run-edit-description');
+        const statusEl = document.getElementById('run-edit-status');
+        if (!card || !descEl) return;
+        card.dataset.runId = runId;
+        if (idEl) idEl.textContent = runId;
+        descEl.value = run.description || '';
+        if (statusEl) statusEl.textContent = '';
+        card.style.display = 'block';
+        descEl.focus();
+    }
+
+    function closeRunEdit() {
+        const card = document.getElementById('run-edit-card');
+        if (card) {
+            card.style.display = 'none';
+            delete card.dataset.runId;
+        }
+    }
+
+    function saveRunEdit() {
+        const card = document.getElementById('run-edit-card');
+        const descEl = document.getElementById('run-edit-description');
+        const statusEl = document.getElementById('run-edit-status');
+        if (!card || !card.dataset.runId || !descEl) return;
+        const runId = card.dataset.runId;
+        const description = descEl.value.trim();
+        if (!description) {
+            if (statusEl) statusEl.textContent = 'Description cannot be empty.';
+            return;
+        }
+        if (statusEl) statusEl.textContent = '';
+        fetch(`/api/runs/${encodeURIComponent(runId)}`, {
+            method: 'PATCH',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ description: description })
+        })
+            .then(response => response.json().then(data => ({ response, data })))
+            .then(({ response, data }) => {
+                if (!response.ok) {
+                    throw new Error(data.detail || ('HTTP ' + response.status));
+                }
+                const run = runsList.find(r => r.run_id === runId);
+                if (run) run.description = description;
+                const filtered = filteredRuns.find(r => r.run_id === runId);
+                if (filtered) filtered.description = description;
+                renderRunHistoryTable();
+                closeRunEdit();
+                if (runId === selectedRunId) {
+                    loadRunDetail(runId);
+                }
+            })
+            .catch(error => {
+                console.error('Error saving run description:', error);
+                if (statusEl) statusEl.textContent = 'Save failed: ' + error.message;
+            });
+    }
+
+    function deleteRun(runId) {
+        const ta = window.TableActions;
+        const run = runsList.find(r => r.run_id === runId);
+        const label = run && run.description ? `run “${run.description}” (${runId})` : `run ${runId}`;
+        const confirmed = ta
+            ? ta.doubleConfirmDelete({
+                subject: label,
+                detail: 'The run folder under runflow/analysis/' + runId + '/ and its index entry will be removed.'
+            })
+            : window.confirm('Delete ' + label + '? This cannot be undone.');
+        if (!confirmed) return;
+        fetch(`/api/runs/${encodeURIComponent(runId)}`, {
+            method: 'DELETE',
+            credentials: 'same-origin'
+        })
+            .then(response => response.json().then(data => ({ response, data })))
+            .then(({ response, data }) => {
+                if (!response.ok) {
+                    throw new Error(data.detail || ('HTTP ' + response.status));
+                }
+                runsList = runsList.filter(r => r.run_id !== runId);
+                filteredRuns = filteredRuns.filter(r => r.run_id !== runId);
+                const card = document.getElementById('run-edit-card');
+                if (card && card.dataset.runId === runId) closeRunEdit();
+                renderRunHistoryTable();
+                if (runId === selectedRunId) {
+                    selectedRunId = null;
+                    localStorage.removeItem('selected_run_id');
+                    if (runsList.length > 0) {
+                        selectRun(runsList[0].run_id);
+                    }
+                }
+            })
+            .catch(error => {
+                console.error('Error deleting run:', error);
+                alert('Delete failed: ' + error.message);
+            });
     }
     
     function handleSearch(event) {

--- a/frontend/templates/pages/density.html
+++ b/frontend/templates/pages/density.html
@@ -8,6 +8,7 @@
     {% if meta %}
     {% endif %}
 </div>
+{% include "partials/run_context.html" %}
 
 
 <!-- Segment Density Table -->

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -8,6 +8,7 @@
     {% if meta %}
     {% endif %}
 </div>
+{% include "partials/run_context.html" %}
 
 <!-- Flow Overlaps -->
 <div class="card">

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -53,6 +53,7 @@
     {% if meta %}
     {% endif %}
 </div>
+{% include "partials/run_context.html" %}
 
 <!-- Map Container -->
 <div class="card">

--- a/frontend/templates/pages/segments.html
+++ b/frontend/templates/pages/segments.html
@@ -51,6 +51,7 @@
     {% if meta %}
     {% endif %}
 </div>
+{% include "partials/run_context.html" %}
 
 <!-- Map Container -->
 <div class="card">

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -1,0 +1,42 @@
+{#
+  Run Context Partial
+
+  Shows the selected run's ID, description, and date under the page heading
+  on report pages (Segments, Density, Flow, Locations).
+
+  Resolves the run client-side (URL ?run_id= → window.runflowDay → localStorage)
+  and looks up description/date from /api/runs/list.
+
+  Usage in templates (place right after the .page-header div):
+    {% include "partials/run_context.html" %}
+#}
+<div id="run-context" style="display: none; margin: -1rem 0 1.5rem; color: #555; font-size: 0.9rem; line-height: 1.5;">
+    <div><strong>ID:</strong> <span id="run-context-id"></span></div>
+    <div><strong>Description:</strong> <span id="run-context-desc"></span></div>
+    <div><strong>Date:</strong> <span id="run-context-date"></span></div>
+</div>
+<script>
+(function () {
+    function resolveRunContextRunId() {
+        var params = new URLSearchParams(window.location.search);
+        var fromUrl = (params.get('run_id') || '').trim();
+        if (fromUrl) return fromUrl;
+        if (window.runflowDay && window.runflowDay.run_id) return window.runflowDay.run_id;
+        return (localStorage.getItem('selected_run_id') || '').trim();
+    }
+    document.addEventListener('DOMContentLoaded', function () {
+        var runId = resolveRunContextRunId();
+        if (!runId) return;
+        fetch('/api/runs/list', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                var run = data && (data.runs || []).find(function (x) { return x.run_id === runId; });
+                document.getElementById('run-context-id').textContent = runId;
+                document.getElementById('run-context-desc').textContent = (run && run.description) || '—';
+                document.getElementById('run-context-date').textContent = (run && (run.formatted_date || run.created_at)) || '—';
+                document.getElementById('run-context').style.display = 'block';
+            })
+            .catch(function () { /* context line is best-effort */ });
+    });
+})();
+</script>


### PR DESCRIPTION
## Summary
- **Dashboard Run History — Actions column**: edit a run's description or delete a run (folder + `index.json` entry) directly from the table, using the same edit/delete icons as Race Configuration. New `PATCH`/`DELETE /api/runs/{run_id}` endpoints keep `index.json` and the run's `analysis.json` in sync; the run referenced by `latest.json` cannot be deleted. Unlike `prune_runs --keep N`, individual runs in the middle of history can be removed.
- **Legs map shows all legs**: new bulk `GET .../segment-library/leg-geometries` endpoint and a muted background layer drawing every leg route on the Legs map (hover for the leg name, click to select). The map previously appeared empty until a leg was selected after the duplicate-pin fix removed leaked course-level pins.
- **Run context on report pages**: Segments, Density, Flow, and Locations now show the selected run's **ID / Description / Date** under the page heading via a shared `partials/run_context.html`.
- **Docs refresh + v2.0.8 changelog**: new Race Configuration user guide (leg-based workflow, recipes, corridor pairing), rewritten leg platform dev guide, updated docs README and quick reference, CHANGELOG stamped as v2.0.8.

## Test plan
- [x] Dashboard: edit updates description in both `index.json` and `analysis.json`; table and Run Detail refresh
- [x] Dashboard: delete removes folder + index entry (verified with throwaway run); deleting the `latest.json` run is rejected with a clear error
- [x] Legs map: all 17 legs render with no selection; click on a route selects the leg; layer refreshes after leg edits
- [x] Run context line renders correct ID/Description/Date on all four report pages
- [x] Targeted unit tests pass (pre-existing `test_bins.py`/`test_flow.py` collection errors excluded)

Made with [Cursor](https://cursor.com)