### PR TITLE
Issue #791 Phase 0: Build/Results nav IA

### DIFF
--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -283,7 +283,7 @@
 
     function setPageTitle(text) {
         const el = document.getElementById('race-config-page-title');
-        if (el) el.textContent = text || 'Race Configuration';
+        if (el) el.textContent = text || 'Build';
     }
 
     function showEntryOnly() {
@@ -293,7 +293,7 @@
         if (entry) entry.style.display = 'block';
         if (workspace) workspace.style.display = 'none';
         if (pageHeader) pageHeader.style.display = '';
-        setPageTitle('Race Configuration');
+        setPageTitle('Build');
         const lead = document.getElementById('race-config-page-lead');
         if (lead) lead.style.display = '';
         ensureHubModalsOnBody();

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -51,15 +51,38 @@
             display: flex;
             flex-wrap: wrap;
             gap: 0;
+            align-items: stretch;
         }
         
         nav li {
             margin: 0;
         }
+
+        nav li.nav-group-label {
+            display: flex;
+            align-items: center;
+            padding: 0.875rem 0.65rem 0.875rem 1.1rem;
+            color: #95a5a6;
+            font-size: 0.68rem;
+            font-weight: 700;
+            letter-spacing: 0.07em;
+            text-transform: uppercase;
+            pointer-events: none;
+            user-select: none;
+            white-space: nowrap;
+        }
+
+        nav li.nav-build-sep {
+            width: 1px;
+            align-self: stretch;
+            background: #2c3e50;
+            margin: 0.55rem 0.35rem;
+            pointer-events: none;
+        }
         
         nav a {
             display: block;
-            padding: 0.875rem 1.5rem;
+            padding: 0.875rem 1.25rem;
             color: #ecf0f1;
             text-decoration: none;
             font-weight: 500;
@@ -298,24 +321,27 @@
     <nav>
         <ul>
             {% if cloud_mode %}
-            <li><a href="/dashboard" {% if request.url and request.url.path == "/dashboard" %}class="active"{% endif %}>Dashboard</a></li>
+            <li class="nav-group-label" aria-hidden="true">Results</li>
+            <li><a href="/dashboard" {% if request.url and request.url.path == "/dashboard" %}class="active"{% endif %}>Runs</a></li>
             <li><a href="/locations" {% if request.url and request.url.path == "/locations" %}class="active"{% endif %}>Locations</a></li>
             {# Loc Sheets (/locsheets) hidden from nav; one-pagers linked from Locations UI — route kept for now #}
             <li><a href="/logout" style="color: #e74c3c;">Logout</a></li>
             {% else %}
-            <li><a href="/dashboard" {% if request.url and request.url.path == "/dashboard" %}class="active"{% endif %}>Dashboard</a></li>
+            <li class="nav-group-label" aria-hidden="true">Results</li>
+            <li><a href="/dashboard" {% if request.url and request.url.path == "/dashboard" %}class="active"{% endif %}>Runs</a></li>
             <li><a href="/segments" {% if request.url and request.url.path == "/segments" %}class="active"{% endif %}>Segments</a></li>
             <li><a href="/density" {% if request.url and request.url.path == "/density" %}class="active"{% endif %}>Density</a></li>
             <li><a href="/flow" {% if request.url and request.url.path == "/flow" %}class="active"{% endif %}>Flow</a></li>
             <li><a href="/locations" {% if request.url and request.url.path == "/locations" %}class="active"{% endif %}>Locations</a></li>
             {# Loc Sheets (/locsheets) hidden from nav; one-pagers linked from Locations UI — route kept for now #}
             <li><a href="/reports" {% if request.url and request.url.path == "/reports" %}class="active"{% endif %}>Reports</a></li>
-            <li><a href="/analysis" {% if request.url and request.url.path == "/analysis" %}class="active"{% endif %}>Analysis</a></li>
-            <li><a href="/config" {% if request.url and request.url.path == "/config" %}class="active"{% endif %}>Race Configuration</a></li>
+            {# Analysis (/analysis) hidden from nav; primary path is Package → Run analysis — route kept (Issue #791) #}
+            <li class="nav-build-sep" aria-hidden="true"></li>
+            <li><a href="/config" {% if request.url and (request.url.path == "/config" or request.url.path.startswith("/race-configuration")) %}class="active"{% endif %} title="Legs, Courses, and Packages">Build</a></li>
             {# Course Mapping (/course-mapping) hidden from nav; superseded by Race Configuration — route kept for now #}
-            <li><a href="/health-check" {% if request.url and request.url.path == "/health-check" %}class="active"{% endif %}>Health</a></li>
+            {# Health (/health-check) hidden from nav; ops utility — route kept (Issue #791) #}
             {% endif %}
-            <li id="day-selector-wrap" style="margin-left:auto; padding: 0.5rem 1rem; display: flex; align-items: center; gap: 0.5rem;">
+            <li id="day-selector-wrap" style="margin-left:auto; padding: 0.5rem 1rem; display: none; align-items: center; gap: 0.5rem;" aria-hidden="true">
                 <label for="day-selector" style="color:#ecf0f1; font-weight:600;">Day</label>
                 <select id="day-selector" style="padding: 0.35rem 0.5rem; border-radius: 4px; border: 1px solid #2c3e50; background: #fff; color: #2c3e50; min-width: 90px;">
                     <option value="">—</option>
@@ -403,18 +429,44 @@
             return u.pathname + (u.search ? u.search : "");
         }
 
-        const CONFIG_ROUTE_PREFIXES = ["/config"];
+        const CONFIG_ROUTE_PREFIXES = ["/config", "/race-configuration"];
+        const RESULTS_ROUTE_PATHS = [
+            "/dashboard",
+            "/segments",
+            "/density",
+            "/flow",
+            "/locations",
+            "/reports",
+        ];
 
         function isConfigRoutePath(pathname) {
             return CONFIG_ROUTE_PREFIXES.some(p => pathname === p || pathname.startsWith(p + "/"));
         }
 
+        function isResultsRoutePath(pathname) {
+            return RESULTS_ROUTE_PATHS.some(p => pathname === p || pathname.startsWith(p + "/"));
+        }
+
         function isAnalysisRoutePath(pathname) {
             if (isConfigRoutePath(pathname)) return false;
-            if (pathname === "/course-mapping" || pathname === "/health-check" || pathname === "/logout") {
+            if (pathname === "/course-mapping" || pathname === "/health-check" || pathname === "/logout" || pathname === "/analysis") {
                 return false;
             }
-            return true;
+            return isResultsRoutePath(pathname);
+        }
+
+        function setDaySelectorVisible(visible) {
+            const wrap = document.getElementById("day-selector-wrap");
+            if (!wrap) return;
+            wrap.style.display = visible ? "flex" : "none";
+            wrap.setAttribute("aria-hidden", visible ? "false" : "true");
+        }
+
+        function announceRunflowContextReady(runId, day) {
+            // Issue #791: Results pages (run_context) wait for day/run init before empty CTA
+            window.dispatchEvent(new CustomEvent("runflow:context-ready", {
+                detail: { run_id: runId || null, day: day || null },
+            }));
         }
 
         function updateNavLinks(day, runId) {
@@ -460,8 +512,7 @@
         }
 
         function initConfigPageNav() {
-            const wrap = document.getElementById("day-selector-wrap");
-            if (wrap) wrap.style.display = "none";
+            setDaySelectorVisible(false);
 
             const params = new URLSearchParams(window.location.search);
             let changed = false;
@@ -490,11 +541,24 @@
 
             if (isConfigRoutePath(window.location.pathname)) {
                 initConfigPageNav();
+                announceRunflowContextReady(
+                    (localStorage.getItem("selected_run_id") || "").trim() || null,
+                    (localStorage.getItem("selected_day") || "").toLowerCase().trim() || null
+                );
                 return;
             }
 
-            const wrap = document.getElementById("day-selector-wrap");
-            if (wrap) wrap.style.display = "flex";
+            // Day chrome belongs on Results routes only (Issue #791 Phase 0)
+            if (!isResultsRoutePath(window.location.pathname)) {
+                setDaySelectorVisible(false);
+                const day = (localStorage.getItem("selected_day") || "").toLowerCase().trim() || null;
+                const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
+                updateNavLinks(day, storedRun);
+                announceRunflowContextReady(storedRun, day);
+                return;
+            }
+
+            setDaySelectorVisible(false); // show only after we know multi-day
 
             const params = new URLSearchParams(window.location.search);
             const urlDayRaw = params.get("day");
@@ -555,21 +619,19 @@
                 }
             }
 
-            const DEFAULT_ORDER = ["fri","sat","sun","mon"];
-
             // Issue #565: If run_id is set, only use available_days from API (don't add invalid days)
-            // If no run_id, fallback to defaults
+            // If no run_id, keep empty — do not invent fri/sat/sun/mon
             if (!availableDays.length) {
-                if (runId) {
-                    // Run_id exists but no available_days - this shouldn't happen, but handle gracefully
-                    availableDays = selectedDay ? [selectedDay] : [];
+                if (runId && selectedDay) {
+                    availableDays = [selectedDay];
+                } else if (!runId && selectedDay) {
+                    availableDays = [selectedDay];
                 } else {
-                    // No run_id - use defaults
-                    availableDays = selectedDay ? [selectedDay] : DEFAULT_ORDER;
+                    availableDays = [];
                 }
             } else if (selectedDay && !availableDays.includes(selectedDay)) {
                 // URL has a day that's not available for this run_id - remove it and use first available
-                selectedDay = availableDays[0];
+                selectedDay = availableDays[0] || null;
                 // Update URL to remove invalid day or set to first available
                 const params = new URLSearchParams(window.location.search);
                 if (selectedDay) {
@@ -609,6 +671,9 @@
                 }
             }
 
+            // Show Day control only when the selected run has more than one day
+            setDaySelectorVisible(availableDays.length > 1);
+
             if (CLOUD_MODE) {
                 // Force canonical run_id and day in URL for cloud mode
                 const params = new URLSearchParams(window.location.search);
@@ -625,9 +690,10 @@
             if (runId) localStorage.setItem("selected_run_id", runId);
             updateNavLinks(selectedDay, runId);
             window.runflowDay = { selected: selectedDay, available: availableDays, run_id: runId };
+            announceRunflowContextReady(runId, selectedDay);
 
             select.addEventListener("change", (e) => {
-                if (isConfigRoutePath(window.location.pathname)) {
+                if (isConfigRoutePath(window.location.pathname) || !isResultsRoutePath(window.location.pathname)) {
                     return;
                 }
                 const day = (e.target.value || "").toLowerCase().trim();

--- a/frontend/templates/pages/dashboard.html
+++ b/frontend/templates/pages/dashboard.html
@@ -1,10 +1,10 @@
 {% extends "base.html" %}
 
-{% block title %}Dashboard{% endblock %}
+{% block title %}Runs{% endblock %}
 
 {% block content %}
 <div class="page-header">
-    <h2>Dashboard</h2>
+    <h2>Runs</h2>
     <div style="display: flex; align-items: center; gap: 1rem;">
     </div>
 </div>

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Race Configuration{% endblock %}
+{% block title %}Build{% endblock %}
 
 {% block extra_head %}
 {% include 'partials/course_mapping_styles.html' %}
@@ -10,7 +10,7 @@
 {% block content %}
 <div class="race-config-page">
     <div class="page-header">
-        <h2 id="race-config-page-title">Race Configuration</h2>
+        <h2 id="race-config-page-title">Build</h2>
         <p id="race-config-page-lead" class="race-config-page-lead">
             Build global <strong>Legs</strong> and named <strong>Courses</strong>, then assemble them into race <strong>Packages</strong>.
         </p>
@@ -309,5 +309,5 @@
 <script src="/static/js/map/segment_recipes.js?v=799e"></script>
 <script src="/static/js/map/saved_courses.js?v=799a"></script>
 <script src="/static/js/runners_baseline.js?v=756k"></script>
-<script src="/static/js/race_configuration.js?v=795a"></script>
+<script src="/static/js/race_configuration.js?v=791p0"></script>
 {% endblock %}

--- a/frontend/templates/pages/reports.html
+++ b/frontend/templates/pages/reports.html
@@ -8,6 +8,7 @@
     {% if meta %}
     {% endif %}
 </div>
+{% include "partials/run_context.html" %}
 
 <!-- Reports Section -->
 <div class="card">

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -2,7 +2,10 @@
   Run Context Partial
 
   Shows the selected run's ID, description, and date under the page heading
-  on report pages (Segments, Density, Flow, Locations).
+  on Results pages (Segments, Density, Flow, Locations, Reports).
+
+  When no run is selected, shows a CTA to choose a run on the Runs page
+  (Issue #791 Phase 0).
 
   Resolves the run client-side (URL ?run_id= → window.runflowDay → localStorage)
   and looks up description/date from /api/runs/list.
@@ -10,13 +13,37 @@
   Usage in templates (place right after the .page-header div):
     {% include "partials/run_context.html" %}
 #}
+<div id="run-context-missing" class="run-context-missing" style="display: none;" role="status">
+    <strong>No analysis run selected.</strong>
+    Choose a run to view Segments, Density, Flow, Locations, and Reports.
+    <a id="run-context-choose-link" href="/dashboard">Choose a run</a>
+</div>
 <div id="run-context" style="display: none; margin: -1rem 0 1.5rem; color: #555; font-size: 0.9rem; line-height: 1.5;">
     <div><strong>ID:</strong> <span id="run-context-id"></span></div>
     <div><strong>Description:</strong> <span id="run-context-desc"></span></div>
     <div><strong>Date:</strong> <span id="run-context-date"></span></div>
 </div>
+<style>
+    .run-context-missing {
+        margin: -0.5rem 0 1.5rem;
+        padding: 0.85rem 1rem;
+        background: #eef5fb;
+        border: 1px solid #c5d9ea;
+        border-radius: 4px;
+        color: #2c3e50;
+        font-size: 0.95rem;
+        line-height: 1.45;
+    }
+    .run-context-missing a {
+        margin-left: 0.35rem;
+        font-weight: 600;
+        color: #2980b9;
+    }
+</style>
 <script>
 (function () {
+    var resolved = false;
+
     function resolveRunContextRunId() {
         var params = new URLSearchParams(window.location.search);
         var fromUrl = (params.get('run_id') || '').trim();
@@ -24,9 +51,21 @@
         if (window.runflowDay && window.runflowDay.run_id) return window.runflowDay.run_id;
         return (localStorage.getItem('selected_run_id') || '').trim();
     }
-    document.addEventListener('DOMContentLoaded', function () {
-        var runId = resolveRunContextRunId();
-        if (!runId) return;
+
+    function showMissingRunCta() {
+        var missing = document.getElementById('run-context-missing');
+        var ctx = document.getElementById('run-context');
+        if (ctx) ctx.style.display = 'none';
+        if (!missing) return;
+        var link = document.getElementById('run-context-choose-link');
+        if (link) {
+            var day = (localStorage.getItem('selected_day') || '').trim();
+            link.href = day ? ('/dashboard?day=' + encodeURIComponent(day)) : '/dashboard';
+        }
+        missing.style.display = 'block';
+    }
+
+    function showRunContext(runId) {
         fetch('/api/runs/list', { credentials: 'same-origin' })
             .then(function (r) { return r.ok ? r.json() : null; })
             .then(function (data) {
@@ -35,8 +74,38 @@
                 document.getElementById('run-context-desc').textContent = (run && run.description) || '—';
                 document.getElementById('run-context-date').textContent = (run && (run.formatted_date || run.created_at)) || '—';
                 document.getElementById('run-context').style.display = 'block';
+                var missing = document.getElementById('run-context-missing');
+                if (missing) missing.style.display = 'none';
             })
-            .catch(function () { /* context line is best-effort */ });
+            .catch(function () {
+                document.getElementById('run-context-id').textContent = runId;
+                document.getElementById('run-context-desc').textContent = '—';
+                document.getElementById('run-context-date').textContent = '—';
+                document.getElementById('run-context').style.display = 'block';
+                var missing = document.getElementById('run-context-missing');
+                if (missing) missing.style.display = 'none';
+            });
+    }
+
+    function refreshRunContext() {
+        if (resolved) return;
+        var runId = resolveRunContextRunId();
+        if (!runId) {
+            showMissingRunCta();
+            return;
+        }
+        resolved = true;
+        showRunContext(runId);
+    }
+
+    document.addEventListener('DOMContentLoaded', function () {
+        // Prefer day/run init signal from base.html (Issue #791); fallback if it never fires
+        window.addEventListener('runflow:context-ready', function () {
+            refreshRunContext();
+        });
+        setTimeout(function () {
+            refreshRunContext();
+        }, 1500);
     });
 })();
 </script>


### PR DESCRIPTION
## Summary
- Restructure primary nav into a **Results** group (Runs, Segments, Density, Flow, Locations, Reports) plus **Build** (`/config`); hide Analysis and Health from nav while keeping their routes.
- Rename Dashboard → **Runs** and Race Configuration → **Build**; show the Day selector only on Results routes and only when the selected run has more than one day.
- Add an empty-run CTA on Results pages (including Reports), coordinated with day/run init via `runflow:context-ready` so it does not flash before auto-pick finishes.

Closes part of https://github.com/thomjeff/run-density/issues/791 (Phase 0 only).

## Test plan
- [ ] Nav shows RESULTS + Runs…Reports + Build; Analysis and Health absent
- [ ] `/config` title and h2 are **Build**; `/dashboard` is **Runs**
- [ ] Direct URLs `/analysis` and `/health-check` still load
- [ ] Day selector hidden on Build / Analysis / Health; hidden on single-day Results; visible only for multi-day runs
- [ ] With a run selected, Segments/Density/Flow/Locations/Reports show run context (ID/description/date)
- [ ] With no run available, Results pages show “Choose a run” CTA linking to `/dashboard`


Made with [Cursor](https://cursor.com)