### PR TITLE
Issue #791 Phase 1: Results hub chrome & analysis handoff

### DIFF
--- a/frontend/static/css/common.css
+++ b/frontend/static/css/common.css
@@ -249,3 +249,89 @@
 .leaflet-popup.location-popup .leaflet-popup-content {
     font-size: 0.875rem;
 }
+
+/* ============================================
+   Results chrome (Issue #791 Phase 1)
+   Shared sub-nav + run context on Results pages
+   ============================================ */
+.rf-results-chrome {
+    margin: -0.5rem 0 1.5rem;
+}
+
+.rf-results-subnav {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0;
+    border-bottom: 1px solid #e0e0e0;
+    margin-bottom: 0.75rem;
+}
+
+.rf-results-subnav a {
+    display: inline-block;
+    padding: 0.5rem 0.9rem;
+    color: #5f6f7a;
+    text-decoration: none;
+    font-weight: 500;
+    font-size: 0.9rem;
+    border-bottom: 3px solid transparent;
+    margin-bottom: -1px;
+}
+
+.rf-results-subnav a:hover {
+    color: #2c3e50;
+    background: #f4f7f9;
+}
+
+.rf-results-subnav a.active {
+    color: #2c3e50;
+    font-weight: 700;
+    border-bottom-color: #2980b9;
+}
+
+.rf-results-banner {
+    color: #555;
+    font-size: 0.9rem;
+    line-height: 1.5;
+    padding: 0.65rem 0.85rem;
+    background: #f8fafb;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+}
+
+.rf-results-banner-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 1.25rem;
+}
+
+.rf-results-actions {
+    margin-top: 0.45rem;
+}
+
+.rf-results-actions a {
+    margin-right: 0.9rem;
+    color: #2980b9;
+    font-weight: 600;
+    text-decoration: none;
+}
+
+.rf-results-actions a:hover {
+    text-decoration: underline;
+}
+
+.run-context-missing {
+    margin: 0;
+    padding: 0.85rem 1rem;
+    background: #eef5fb;
+    border: 1px solid #c5d9ea;
+    border-radius: 4px;
+    color: #2c3e50;
+    font-size: 0.95rem;
+    line-height: 1.45;
+}
+
+.run-context-missing a {
+    margin-left: 0.35rem;
+    font-weight: 600;
+    color: #2980b9;
+}

--- a/frontend/static/js/map/saved_courses.js
+++ b/frontend/static/js/map/saved_courses.js
@@ -46,7 +46,7 @@
         el.style.color = isError ? '#c0392b' : '#7f8c8d';
     }
 
-    function setAssignStatus(msg, isError) {
+    function setAssignStatus(msg, isError, asHtml) {
         var el = document.getElementById('assign-courses-status');
         if (!el) return;
         if (!msg) {
@@ -55,7 +55,11 @@
             return;
         }
         el.style.display = 'block';
-        el.textContent = msg;
+        if (asHtml) {
+            el.innerHTML = msg;
+        } else {
+            el.textContent = msg;
+        }
         el.style.color = isError ? '#c0392b' : '#7f8c8d';
     }
 
@@ -758,6 +762,7 @@
                     '</code>';
             }
             refreshPackageReadiness();
+            refreshPackageLatestRuns();
         });
     }
 
@@ -830,6 +835,96 @@
             .catch(function () {
                 syncRunAnalysisButton(null);
                 return null;
+            });
+    }
+
+    function packageIdFromDataDir(dataDir) {
+        if (!dataDir) return '';
+        var normalized = String(dataDir).replace(/\\/g, '/').replace(/\/+$/, '');
+        var marker = '/config/';
+        var idx = normalized.lastIndexOf(marker);
+        if (idx < 0) return '';
+        return (normalized.slice(idx + marker.length).split('/')[0] || '').trim();
+    }
+
+    function refreshPackageLatestRuns() {
+        var wrap = document.getElementById('package-latest-runs');
+        var list = document.getElementById('package-latest-runs-list');
+        var empty = document.getElementById('package-latest-runs-empty');
+        var pkgId = configId();
+        if (!wrap || !list || !empty || !pkgId) {
+            if (wrap) wrap.style.display = 'none';
+            return Promise.resolve();
+        }
+        wrap.style.display = 'block';
+        list.innerHTML = '';
+        empty.style.display = 'none';
+        empty.textContent = 'Loading recent runs…';
+        empty.style.display = 'block';
+
+        return fetch('/api/runs/list', { credentials: 'same-origin' })
+            .then(function (r) {
+                return r.ok ? r.json() : null;
+            })
+            .then(function (data) {
+                var runs = (data && data.runs) || [];
+                // Newest first; only probe a small recent window (client-side, zero new API)
+                var candidates = runs.slice(0, 20);
+                return Promise.all(
+                    candidates.map(function (run) {
+                        return fetch(
+                            '/api/analysis/' + encodeURIComponent(run.run_id) + '/config',
+                            { credentials: 'same-origin' }
+                        )
+                            .then(function (r) {
+                                return r.ok ? r.json() : null;
+                            })
+                            .then(function (cfg) {
+                                var matched = packageIdFromDataDir(cfg && cfg.data_dir) === pkgId;
+                                return matched
+                                    ? {
+                                          run_id: run.run_id,
+                                          description: run.description || '',
+                                          date: run.formatted_date || run.created_at || '',
+                                      }
+                                    : null;
+                            })
+                            .catch(function () {
+                                return null;
+                            });
+                    })
+                );
+            })
+            .then(function (matched) {
+                var hits = (matched || []).filter(Boolean).slice(0, 5);
+                list.innerHTML = '';
+                if (!hits.length) {
+                    empty.textContent = 'No analysis runs found for this package yet.';
+                    empty.style.display = 'block';
+                    return;
+                }
+                empty.style.display = 'none';
+                hits.forEach(function (hit) {
+                    var li = document.createElement('li');
+                    li.style.marginBottom = '0.25rem';
+                    var a = document.createElement('a');
+                    a.href = '/density?run_id=' + encodeURIComponent(hit.run_id);
+                    a.textContent = hit.description || hit.run_id;
+                    a.title = hit.run_id;
+                    li.appendChild(a);
+                    if (hit.date) {
+                        var span = document.createElement('span');
+                        span.style.color = '#7f8c8d';
+                        span.style.marginLeft = '0.4rem';
+                        span.textContent = '(' + hit.date + ')';
+                        li.appendChild(span);
+                    }
+                    list.appendChild(li);
+                });
+            })
+            .catch(function () {
+                empty.textContent = 'Could not load latest runs.';
+                empty.style.display = 'block';
             });
     }
 
@@ -1024,13 +1119,37 @@
                     );
                 }
                 var runId = payload.data.run_id;
+                var eventDay = (
+                    (runAnalysisSetup && runAnalysisSetup.event_day) ||
+                    ''
+                )
+                    .toLowerCase()
+                    .trim();
+                if (runId) {
+                    localStorage.setItem('selected_run_id', runId);
+                    if (eventDay) localStorage.setItem('selected_day', eventDay);
+                }
                 var msg =
                     'Analysis started. Run ID: ' +
                     runId +
-                    '. Results appear on the Dashboard in a few minutes.';
-                setAssignStatus(msg, false);
-                if (runId && window.confirm(msg + '\n\nOpen Dashboard now?')) {
-                    window.location.href = '/dashboard?run_id=' + encodeURIComponent(runId);
+                    '. Results will appear under Results in a few minutes.';
+                setAssignStatus(
+                    msg +
+                        ' <a href="/density?run_id=' +
+                        encodeURIComponent(runId) +
+                        (eventDay ? '&day=' + encodeURIComponent(eventDay) : '') +
+                        '">Open Density</a> · <a href="/dashboard?run_id=' +
+                        encodeURIComponent(runId) +
+                        '">Runs</a>',
+                    false,
+                    true
+                );
+                refreshPackageLatestRuns();
+                if (runId && window.confirm(msg + '\n\nOpen Density results now?')) {
+                    var dest =
+                        '/density?run_id=' + encodeURIComponent(runId);
+                    if (eventDay) dest += '&day=' + encodeURIComponent(eventDay);
+                    window.location.href = dest;
                 }
             })
             .catch(function (err) {

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Runflow{% endblock %} - Race Density & Flow Intelligence</title>
     
     <!-- Issue #652: Shared CSS for UI consistency -->
-    <link rel="stylesheet" href="/static/css/common.css">
+    <link rel="stylesheet" href="/static/css/common.css?v=791p1">
     
     <style>
         /* Reset and Base Styles */

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -307,7 +307,7 @@
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
 <script src="/static/js/map/course_mapping.js?v=795b"></script>
 <script src="/static/js/map/segment_recipes.js?v=799e"></script>
-<script src="/static/js/map/saved_courses.js?v=799a"></script>
+<script src="/static/js/map/saved_courses.js?v=791p1"></script>
 <script src="/static/js/runners_baseline.js?v=756k"></script>
 <script src="/static/js/race_configuration.js?v=791p0"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -209,6 +209,12 @@
             <p id="assign-courses-status" class="course-derived-empty" style="display: none;"></p>
             <div id="assign-courses-form" class="assign-courses-form"></div>
             <p id="assign-courses-data-dir" class="course-derived-empty" style="display: none; margin-top: 0.75rem;"></p>
+            <div id="package-latest-runs" class="package-latest-runs" style="display: none; margin-top: 1rem;">
+                <h5 class="course-derived-heading" style="margin: 0 0 0.4rem 0; font-size: 0.95rem;">Latest analysis runs</h5>
+                <p class="course-derived-empty" style="margin: 0 0 0.5rem 0;">Recent runs that used this package as <code>data_dir</code>.</p>
+                <ul id="package-latest-runs-list" class="package-latest-runs-list" style="margin: 0; padding-left: 1.15rem;"></ul>
+                <p id="package-latest-runs-empty" class="course-derived-empty" style="display: none; margin: 0;">No analysis runs found for this package yet.</p>
+            </div>
         </section>
         <section class="content-card course-derived-section" id="course-preview-section" style="display: none;">
             <div class="card-header">

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -1,11 +1,10 @@
 {#
-  Run Context Partial
+  Results chrome (Issue #791 Phase 1)
 
-  Shows the selected run's ID, description, and date under the page heading
-  on Results pages (Segments, Density, Flow, Locations, Reports).
+  Shared sub-nav + run context banner on Results pages
+  (Segments, Density, Flow, Locations, Reports). Not used on Runs.
 
-  When no run is selected, shows a CTA to choose a run on the Runs page
-  (Issue #791 Phase 0).
+  When no run is selected, shows a CTA to choose a run on the Runs page.
 
   Resolves the run client-side (URL ?run_id= → window.runflowDay → localStorage)
   and looks up description/date from /api/runs/list.
@@ -13,33 +12,37 @@
   Usage in templates (place right after the .page-header div):
     {% include "partials/run_context.html" %}
 #}
-<div id="run-context-missing" class="run-context-missing" style="display: none;" role="status">
-    <strong>No analysis run selected.</strong>
-    Choose a run to view Segments, Density, Flow, Locations, and Reports.
-    <a id="run-context-choose-link" href="/dashboard">Choose a run</a>
+<div id="rf-results-chrome" class="rf-results-chrome">
+    <nav class="rf-results-subnav" aria-label="Results views">
+        <a href="/segments" data-results-path="/segments">Segments</a>
+        <a href="/density" data-results-path="/density">Density</a>
+        <a href="/flow" data-results-path="/flow">Flow</a>
+        <a href="/locations" data-results-path="/locations">Locations</a>
+        <a href="/reports" data-results-path="/reports">Reports</a>
+    </nav>
+
+    <div id="run-context-missing" class="run-context-missing" style="display: none;" role="status">
+        <strong>No analysis run selected.</strong>
+        Choose a run to view Segments, Density, Flow, Locations, and Reports.
+        <a id="run-context-choose-link" href="/dashboard">Choose a run</a>
+    </div>
+
+    <div id="run-context" class="rf-results-banner" style="display: none;" role="status">
+        <div class="rf-results-banner-meta">
+            <span><strong>ID:</strong> <span id="run-context-id"></span></span>
+            <span><strong>Description:</strong> <span id="run-context-desc"></span></span>
+            <span><strong>Date:</strong> <span id="run-context-date"></span></span>
+            <span id="run-context-day-wrap" style="display: none;">
+                <strong>Day:</strong> <span id="run-context-day"></span>
+            </span>
+        </div>
+        <div class="rf-results-actions">
+            <a id="run-context-open-reports" href="/reports">Open reports</a>
+            <a id="run-context-open-package" href="/config" style="display: none;">Open package</a>
+            <a id="run-context-change-run" href="/dashboard">Change run</a>
+        </div>
+    </div>
 </div>
-<div id="run-context" style="display: none; margin: -1rem 0 1.5rem; color: #555; font-size: 0.9rem; line-height: 1.5;">
-    <div><strong>ID:</strong> <span id="run-context-id"></span></div>
-    <div><strong>Description:</strong> <span id="run-context-desc"></span></div>
-    <div><strong>Date:</strong> <span id="run-context-date"></span></div>
-</div>
-<style>
-    .run-context-missing {
-        margin: -0.5rem 0 1.5rem;
-        padding: 0.85rem 1rem;
-        background: #eef5fb;
-        border: 1px solid #c5d9ea;
-        border-radius: 4px;
-        color: #2c3e50;
-        font-size: 0.95rem;
-        line-height: 1.45;
-    }
-    .run-context-missing a {
-        margin-left: 0.35rem;
-        font-weight: 600;
-        color: #2980b9;
-    }
-</style>
 <script>
 (function () {
     var resolved = false;
@@ -52,17 +55,117 @@
         return (localStorage.getItem('selected_run_id') || '').trim();
     }
 
+    function resolveDay() {
+        var params = new URLSearchParams(window.location.search);
+        var fromUrl = (params.get('day') || '').trim().toLowerCase();
+        if (fromUrl) return fromUrl;
+        if (window.runflowDay && window.runflowDay.selected) return String(window.runflowDay.selected).toLowerCase();
+        return (localStorage.getItem('selected_day') || '').trim().toLowerCase();
+    }
+
+    function resultsHref(path, runId, day) {
+        var url = path;
+        var qs = [];
+        if (runId) qs.push('run_id=' + encodeURIComponent(runId));
+        if (day) qs.push('day=' + encodeURIComponent(day));
+        if (qs.length) url += '?' + qs.join('&');
+        return url;
+    }
+
+    function updateResultsSubnav(runId, day) {
+        var path = window.location.pathname || '';
+        document.querySelectorAll('.rf-results-subnav a[data-results-path]').forEach(function (a) {
+            var p = a.getAttribute('data-results-path');
+            a.href = resultsHref(p, runId, day);
+            if (path === p || path.indexOf(p + '/') === 0) {
+                a.classList.add('active');
+                a.setAttribute('aria-current', 'page');
+            } else {
+                a.classList.remove('active');
+                a.removeAttribute('aria-current');
+            }
+        });
+    }
+
+    function configIdFromDataDir(dataDir) {
+        if (!dataDir) return '';
+        var normalized = String(dataDir).replace(/\\/g, '/').replace(/\/+$/, '');
+        var marker = '/config/';
+        var idx = normalized.lastIndexOf(marker);
+        if (idx < 0) return '';
+        var rest = normalized.slice(idx + marker.length);
+        var id = rest.split('/')[0];
+        return id || '';
+    }
+
     function showMissingRunCta() {
         var missing = document.getElementById('run-context-missing');
         var ctx = document.getElementById('run-context');
         if (ctx) ctx.style.display = 'none';
         if (!missing) return;
         var link = document.getElementById('run-context-choose-link');
+        var day = resolveDay();
         if (link) {
-            var day = (localStorage.getItem('selected_day') || '').trim();
             link.href = day ? ('/dashboard?day=' + encodeURIComponent(day)) : '/dashboard';
         }
+        updateResultsSubnav(null, day);
         missing.style.display = 'block';
+    }
+
+    function fillBanner(runId, run) {
+        var day = resolveDay();
+        var multiDay = window.runflowDay && Array.isArray(window.runflowDay.available) &&
+            window.runflowDay.available.length > 1;
+
+        document.getElementById('run-context-id').textContent = runId;
+        document.getElementById('run-context-desc').textContent = (run && run.description) || '—';
+        document.getElementById('run-context-date').textContent =
+            (run && (run.formatted_date || run.created_at)) || '—';
+
+        var dayWrap = document.getElementById('run-context-day-wrap');
+        var dayEl = document.getElementById('run-context-day');
+        if (dayWrap && dayEl) {
+            if (multiDay && day) {
+                dayEl.textContent = day.toUpperCase();
+                dayWrap.style.display = '';
+            } else {
+                dayWrap.style.display = 'none';
+            }
+        }
+
+        var reports = document.getElementById('run-context-open-reports');
+        if (reports) reports.href = resultsHref('/reports', runId, day);
+        var change = document.getElementById('run-context-change-run');
+        if (change) {
+            change.href = day
+                ? ('/dashboard?day=' + encodeURIComponent(day) + '&run_id=' + encodeURIComponent(runId))
+                : ('/dashboard?run_id=' + encodeURIComponent(runId));
+        }
+
+        updateResultsSubnav(runId, day);
+        document.getElementById('run-context').style.display = 'block';
+        var missing = document.getElementById('run-context-missing');
+        if (missing) missing.style.display = 'none';
+    }
+
+    function resolveOpenPackage(runId) {
+        var pkgLink = document.getElementById('run-context-open-package');
+        if (!pkgLink) return;
+        fetch('/api/analysis/' + encodeURIComponent(runId) + '/config', { credentials: 'same-origin' })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (cfg) {
+                var configId = configIdFromDataDir(cfg && cfg.data_dir);
+                if (!configId) {
+                    pkgLink.style.display = 'none';
+                    return;
+                }
+                pkgLink.href = '/config?config_id=' + encodeURIComponent(configId);
+                pkgLink.style.display = '';
+                pkgLink.title = 'Open package ' + configId;
+            })
+            .catch(function () {
+                pkgLink.style.display = 'none';
+            });
     }
 
     function showRunContext(runId) {
@@ -70,26 +173,19 @@
             .then(function (r) { return r.ok ? r.json() : null; })
             .then(function (data) {
                 var run = data && (data.runs || []).find(function (x) { return x.run_id === runId; });
-                document.getElementById('run-context-id').textContent = runId;
-                document.getElementById('run-context-desc').textContent = (run && run.description) || '—';
-                document.getElementById('run-context-date').textContent = (run && (run.formatted_date || run.created_at)) || '—';
-                document.getElementById('run-context').style.display = 'block';
-                var missing = document.getElementById('run-context-missing');
-                if (missing) missing.style.display = 'none';
+                fillBanner(runId, run || null);
+                resolveOpenPackage(runId);
             })
             .catch(function () {
-                document.getElementById('run-context-id').textContent = runId;
-                document.getElementById('run-context-desc').textContent = '—';
-                document.getElementById('run-context-date').textContent = '—';
-                document.getElementById('run-context').style.display = 'block';
-                var missing = document.getElementById('run-context-missing');
-                if (missing) missing.style.display = 'none';
+                fillBanner(runId, null);
+                resolveOpenPackage(runId);
             });
     }
 
     function refreshRunContext() {
         if (resolved) return;
         var runId = resolveRunContextRunId();
+        updateResultsSubnav(runId || null, resolveDay());
         if (!runId) {
             showMissingRunCta();
             return;
@@ -99,7 +195,7 @@
     }
 
     document.addEventListener('DOMContentLoaded', function () {
-        // Prefer day/run init signal from base.html (Issue #791); fallback if it never fires
+        updateResultsSubnav(resolveRunContextRunId() || null, resolveDay());
         window.addEventListener('runflow:context-ready', function () {
             refreshRunContext();
         });


### PR DESCRIPTION
## Summary
- Shared Results chrome on Segments / Density / Flow / Locations / Reports: sub-nav + run banner (ID, description, date, day when multi-day) with Open reports / Open package / Change run.
- Package **Run analysis** success now sets `selected_run_id`, offers **Open Density results**, and keeps Runs as a secondary link.
- Optional package **Latest analysis runs** list (client-side match via `analysis.json` `data_dir`).

Part of https://github.com/thomjeff/run-density/issues/791 (Phase 1).

## Test plan
- [ ] Results pages show sub-nav with active tab; switching preserves `run_id`/`day`
- [ ] Runs (`/dashboard`) has no Results sub-nav
- [ ] Banner shows run metadata; Open package links to `/config?config_id=…` when `data_dir` is a package
- [ ] Empty run still shows Choose a run CTA
- [ ] After Package → Start analysis, confirm opens Density with `run_id` (and day when known)
- [ ] Package Courses panel shows Latest analysis runs when matches exist


Made with [Cursor](https://cursor.com)