### PR TITLE
Issue #791 Phase 2: Build IA polish

### DIFF
--- a/frontend/static/css/common.css
+++ b/frontend/static/css/common.css
@@ -335,3 +335,50 @@
     font-weight: 600;
     color: #2980b9;
 }
+
+/* Package readiness checklist (Issue #791 Phase 2) */
+.package-readiness-checklist {
+    margin: 0.65rem 0 0.85rem;
+    padding: 0.65rem 0.85rem;
+    background: #f8fafb;
+    border: 1px solid #e0e0e0;
+    border-radius: 4px;
+}
+
+.package-readiness-list {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.35rem 1rem;
+    font-size: 0.875rem;
+}
+
+.package-readiness-ok {
+    color: #1e7e34;
+    font-weight: 600;
+}
+
+.package-readiness-missing {
+    color: #c0392b;
+    font-weight: 600;
+}
+
+.package-readiness-soft {
+    color: #b9770e;
+    font-weight: 500;
+}
+
+.legacy-event-recipes-details {
+    display: inline-block;
+}
+
+.legacy-event-recipes-details summary {
+    display: inline;
+}
+
+.legacy-event-recipes-details[open] #btn-edit-event-recipes {
+    display: inline-block;
+    margin-left: 0.5rem;
+}

--- a/frontend/static/js/map/saved_courses.js
+++ b/frontend/static/js/map/saved_courses.js
@@ -446,7 +446,7 @@
                         if (
                             !ta.doubleConfirmDelete({
                                 subject: 'course ' + sc.id + ' (“' + (sc.name || sc.id) + '”)',
-                                detail: 'Frozen exports under runflow/org/courses/' + sc.id + '/ will be removed.',
+                                detail: 'This frozen course snapshot and its exports will be removed (' + sc.id + ').',
                             })
                         ) {
                             return;
@@ -756,10 +756,9 @@
             var dirEl = document.getElementById('assign-courses-data-dir');
             if (dirEl) {
                 dirEl.style.display = 'block';
-                dirEl.innerHTML =
-                    'After <strong>Build race exports</strong>, use <strong>Run analysis</strong> or analyze with <code>data_dir</code>: <code>runflow/config/' +
-                    configId() +
-                    '</code>';
+                dirEl.title = 'Package folder: runflow/config/' + configId();
+                dirEl.textContent =
+                    'After Build race exports, use Run analysis to launch a Results run from this package.';
             }
             refreshPackageReadiness();
             refreshPackageLatestRuns();
@@ -802,19 +801,70 @@
         var ready = !!(readiness && readiness.analyze_ready);
         btn.disabled = !ready || !configId();
         if (ready) {
-            btn.title =
-                'Run v2 analysis using runflow/config/' +
-                configId() +
-                ' (you will enter start times for each event)';
+            btn.title = 'Enter start times for each event and start analysis for this package';
         } else {
             var missing = (readiness && readiness.missing) || [];
             var extras = [];
-            if (readiness && !readiness.has_runners) extras.push('*_runners.csv');
-            if (readiness && !readiness.has_gpx) extras.push('*.gpx');
+            if (readiness && !readiness.has_runners) extras.push('runner files');
+            if (readiness && !readiness.has_gpx) extras.push('course GPX');
             btn.title =
                 'Analysis not ready — missing: ' +
                 (missing.concat(extras).join(', ') || 'required files');
         }
+        renderPackageReadinessChecklist(readiness);
+    }
+
+    function renderPackageReadinessChecklist(readiness) {
+        var wrap = document.getElementById('package-readiness-checklist');
+        var list = document.getElementById('package-readiness-list');
+        if (!wrap || !list) return;
+        if (!configId()) {
+            wrap.style.display = 'none';
+            list.innerHTML = '';
+            return;
+        }
+        wrap.style.display = 'block';
+        var missing = (readiness && readiness.missing) || [];
+        var items = [
+            {
+                label: 'Course segments',
+                ok: readiness ? missing.indexOf('segments.csv') < 0 : false,
+                tip: 'segments.csv from Build race exports',
+            },
+            {
+                label: 'Flow',
+                ok: readiness ? missing.indexOf('flow.csv') < 0 : false,
+                tip: 'flow.csv from Build race exports',
+            },
+            {
+                label: 'Locations',
+                ok: readiness ? missing.indexOf('locations.csv') < 0 : false,
+                tip: 'locations.csv (recommended; not required to start analysis)',
+                soft: true,
+            },
+            {
+                label: 'Runner files',
+                ok: !!(readiness && readiness.has_runners),
+                tip: '*_runners.csv in this package',
+            },
+            {
+                label: 'Course GPX',
+                ok: !!(readiness && readiness.has_gpx),
+                tip: '*.gpx in this package',
+            },
+        ];
+        list.innerHTML = '';
+        items.forEach(function (item) {
+            var li = document.createElement('li');
+            li.className = item.ok
+                ? 'package-readiness-ok'
+                : item.soft
+                  ? 'package-readiness-soft'
+                  : 'package-readiness-missing';
+            li.title = item.tip;
+            li.textContent = (item.ok ? '✓ ' : '○ ') + item.label;
+            list.appendChild(li);
+        });
     }
 
     function refreshPackageReadiness() {
@@ -1183,10 +1233,7 @@
             .then(function (payload) {
                 if (!payload.ok) throw new Error(payload.data.detail || 'Build failed');
                 var warnings = payload.data.stitch_warnings || [];
-                var msg =
-                    'Race exports ready at ' +
-                    (payload.data.analysis_data_dir || 'package root') +
-                    '.';
+                var msg = 'Race exports built. You can run analysis when readiness is complete.';
                 if (warnings.length) msg += ' Warnings: ' + warnings.join(' · ');
                 setAssignStatus(msg, warnings.length > 0);
                 syncRunAnalysisButton(payload.data.readiness || null);

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -4939,8 +4939,11 @@
     function syncCoursePanelUi(options) {
         options = options || {};
         var editBtn = document.getElementById('btn-edit-event-recipes');
+        var legacyWrap = document.getElementById('legacy-event-recipes-details');
         var hasCourse = hasCombinedCourse();
-        if (editBtn) {
+        if (legacyWrap) {
+            legacyWrap.style.display = hasCourse ? '' : 'none';
+        } else if (editBtn) {
             editBtn.style.display = hasCourse ? '' : 'none';
         }
         syncCoursePreviewUi();

--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -33,7 +33,7 @@
     function getHubView() {
         const raw = getQuery().get('view');
         if (raw === 'legs' || raw === 'courses' || raw === 'packages') return raw;
-        return 'packages';
+        return 'legs';
     }
 
     function getTab() {
@@ -448,6 +448,12 @@
             tr.addEventListener('click', function () {
                 window.location.href = buildConfigUrl(pkg.config_id, 'course');
             });
+            if (pkg.legacy) {
+                const nameCell = tr.firstElementChild;
+                if (nameCell) {
+                    nameCell.title = 'Older package folder without modern config.json';
+                }
+            }
             tbody.appendChild(tr);
         });
     }
@@ -528,9 +534,9 @@
             !ta.doubleConfirmDelete({
                 subject: subject,
                 detail:
-                    'All legs, course data, runners, and files under runflow/config/' +
+                    'All legs, course data, runners, and files for this package will be removed (' +
                     pkg.config_id +
-                    '/ will be removed.',
+                    ').',
             })
         ) {
             return;

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Runflow{% endblock %} - Race Density & Flow Intelligence</title>
     
     <!-- Issue #652: Shared CSS for UI consistency -->
-    <link rel="stylesheet" href="/static/css/common.css?v=791p1">
+    <link rel="stylesheet" href="/static/css/common.css?v=791p2">
     
     <style>
         /* Reset and Base Styles */

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -18,42 +18,16 @@
 
     <div id="race-config-entry" class="page-shell page-shell--entry">
         <div class="content-card race-config-hub-shell">
-            <div class="race-config-hub-tabs" role="tablist" aria-label="Race configuration library">
-                <button type="button" class="race-config-hub-tab active" data-hub-view="packages" role="tab" aria-selected="true">Packages</button>
-                <button type="button" class="race-config-hub-tab" data-hub-view="legs" role="tab" aria-selected="false">Legs</button>
+            <div class="race-config-hub-tabs" role="tablist" aria-label="Build library">
+                <button type="button" class="race-config-hub-tab active" data-hub-view="legs" role="tab" aria-selected="true">Legs</button>
                 <button type="button" class="race-config-hub-tab" data-hub-view="courses" role="tab" aria-selected="false">Courses</button>
+                <button type="button" class="race-config-hub-tab" data-hub-view="packages" role="tab" aria-selected="false">Packages</button>
             </div>
 
             <div class="race-config-hub-body">
-                <div id="race-config-hub-packages" class="race-config-hub-panel">
-                    <div class="card-header">
-                        <h3 class="card-title">Packages</h3>
-                        <div class="card-actions">
-                            <button type="button" id="race-config-new-btn" class="course-btn primary">New package</button>
-                        </div>
-                    </div>
-                    <p class="card-help">Each package assigns one course per distance (Full / Half / 10K) and holds runner files for multi-distance analysis.</p>
-                    <div class="scrollable-table-container">
-                        <table id="race-config-list-table" class="table-sticky-header">
-                            <thead>
-                                <tr>
-                                    <th class="table-sortable" data-sort="label">Name <span class="table-sortable-indicator">↕</span></th>
-                                    <th class="table-sortable" data-sort="description">Description <span class="table-sortable-indicator">↕</span></th>
-                                    <th class="table-sortable" data-sort="updated">Saved On <span class="table-sortable-indicator">↕</span></th>
-                                    <th class="course-map-action-cell" style="width: 5.5rem;">Actions</th>
-                                </tr>
-                            </thead>
-                            <tbody id="race-config-list-tbody">
-                                <tr><td colspan="4" class="placeholder">Loading packages…</td></tr>
-                            </tbody>
-                        </table>
-                    </div>
-                    <p class="card-help" style="margin-bottom: 0;">Click a row to assign courses and runners.</p>
-                </div>
-
-                <div id="race-config-hub-legs" class="race-config-hub-panel" style="display: none;">
-                    <p class="card-help race-config-hub-lead">
-                        Legs are shared routes and locations (<code>runflow/org/legs/</code>).
+                <div id="race-config-hub-legs" class="race-config-hub-panel">
+                    <p class="card-help race-config-hub-lead" title="Stored in the organization leg library">
+                        Legs are shared routes and locations used by every package.
                         Edit them here, then freeze distance recipes on the <strong>Courses</strong> tab.
                     </p>
                     <div id="race-config-hub-legs-slot" class="race-config-hub-legs-slot"></div>
@@ -66,9 +40,9 @@
                             <button type="button" id="btn-save-named-course" class="course-btn primary" title="Compose a course from org legs and freeze exports">New course</button>
                         </div>
                     </div>
-                    <p class="card-help">
+                    <p class="card-help" title="Frozen snapshots live in the organization course library">
                         A course is a named frozen snapshot for one distance (e.g. 10K University).
-                        Stored under <code>runflow/org/courses/</code> and assigned to packages by distance.
+                        Assign courses to packages by distance.
                     </p>
                     <p id="saved-courses-status" class="course-derived-empty" style="display: none;"></p>
                     <div id="saved-courses-table-wrap" style="display: none;">
@@ -119,6 +93,32 @@
                         </div>
                     </div>
                 </div>
+
+                <div id="race-config-hub-packages" class="race-config-hub-panel" style="display: none;">
+                    <div class="card-header">
+                        <h3 class="card-title">Packages</h3>
+                        <div class="card-actions">
+                            <button type="button" id="race-config-new-btn" class="course-btn primary">New package</button>
+                        </div>
+                    </div>
+                    <p class="card-help">Each package assigns one course per distance (Full / Half / 10K) and holds runner files for multi-distance analysis.</p>
+                    <div class="scrollable-table-container">
+                        <table id="race-config-list-table" class="table-sticky-header">
+                            <thead>
+                                <tr>
+                                    <th class="table-sortable" data-sort="label">Name <span class="table-sortable-indicator">↕</span></th>
+                                    <th class="table-sortable" data-sort="description">Description <span class="table-sortable-indicator">↕</span></th>
+                                    <th class="table-sortable" data-sort="updated">Saved On <span class="table-sortable-indicator">↕</span></th>
+                                    <th class="course-map-action-cell" style="width: 5.5rem;">Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="race-config-list-tbody">
+                                <tr><td colspan="4" class="placeholder">Loading packages…</td></tr>
+                            </tbody>
+                        </table>
+                    </div>
+                    <p class="card-help" style="margin-bottom: 0;">Click a row to assign courses and runners.</p>
+                </div>
             </div>
         </div>
     </div>
@@ -131,10 +131,9 @@
                 <button type="button" id="saved-course-modal-close" aria-label="Close">&times;</button>
             </div>
             <div class="course-location-modal-body">
-                <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;">
-                    Compose a recipe from org legs and freeze read-only exports under
-                    <code>runflow/org/courses/{id}/</code> (segments, flow, locations, GPX).
-                    Later leg edits do not change this snapshot until you save again.
+                <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;" title="Exports are frozen under the organization course library">
+                    Compose a recipe from org legs and freeze a read-only course snapshot
+                    (segments, flow, locations, GPX). Later leg edits do not change this snapshot until you save again.
                 </p>
                 <p id="saved-course-edit-note" class="course-derived-empty" style="display: none; margin: 0 0 0.75rem 0;">
                     Updating the recipe rebuilds segments, flow, locations, and GPX for this course id.
@@ -306,8 +305,8 @@
 <script src="/static/js/table_actions.js?v=799e"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
 <script src="/static/js/map/course_mapping.js?v=795b"></script>
-<script src="/static/js/map/segment_recipes.js?v=799e"></script>
-<script src="/static/js/map/saved_courses.js?v=791p1"></script>
+<script src="/static/js/map/segment_recipes.js?v=791p2"></script>
+<script src="/static/js/map/saved_courses.js?v=791p2"></script>
 <script src="/static/js/runners_baseline.js?v=756k"></script>
-<script src="/static/js/race_configuration.js?v=791p0"></script>
+<script src="/static/js/race_configuration.js?v=791p2"></script>
 {% endblock %}

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -113,14 +113,14 @@
                 <div class="card-actions course-planner-toolbar config-legs-table-toolbar">
                 <input type="file" id="segment-library-gpx-input" accept=".gpx,.json" multiple style="display: none;" />
                 <button type="button" id="btn-import-gpx" class="course-btn" title="Import third-party GPX (+ optional leg export JSON) into the organization leg library">Import legs…</button>
-                <button type="button" id="btn-org-leg-library" class="course-btn" title="View legs stored outside this package (runflow/org/legs)">Leg library…</button>
+                <button type="button" id="btn-org-leg-library" class="course-btn" title="Browse the shared organization leg library">Leg library…</button>
                 <button type="button" id="btn-export-all-legs" class="course-btn" disabled title="Download all legs (GPX + metadata + locations per leg)">Export legs…</button>
                 <button type="button" id="btn-draw-leg-map" class="course-btn" title="Draw a new leg on the map by clicking along roads and trails">Draw leg on map</button>
                 <button type="button" id="btn-manage-resources-legs" class="course-btn" title="Add or remove schedulable resources (FPF, YSSR, Officials, …)">Manage resources…</button>
                 </div>
             </div>
-            <p class="card-help course-derived-empty" id="course-legs-help">
-                Legs are <strong>global</strong> (<code>runflow/org/legs/</code>). <strong>Import legs…</strong> or <strong>Draw leg</strong> to add routes.
+            <p class="card-help course-derived-empty" id="course-legs-help" title="Shared organization leg library">
+                Legs are <strong>shared across all packages</strong>. <strong>Import legs…</strong> or <strong>Draw leg</strong> to add routes.
                 Place locations on each leg, then open <strong>Courses → New course</strong> to freeze a named distance snapshot.
             </p>
             <p id="course-legs-status" class="course-derived-empty" style="display: none;"></p>
@@ -203,15 +203,19 @@
                 </div>
             </div>
             <p class="card-help course-derived-empty">
-                Pick one <strong>global course</strong> per distance. Create courses under Race Configuration → <strong>Courses</strong>.
-                Then <strong>Build race exports</strong> to write combined <code>segments.csv</code>, <code>flow.csv</code>, locations, and GPX at the package root for analysis.
+                Pick one <strong>global course</strong> per distance. Create courses under Build → <strong>Courses</strong>.
+                Then <strong>Build race exports</strong> to combine them for multi-distance analysis.
             </p>
+            <div id="package-readiness-checklist" class="package-readiness-checklist" style="display: none;" aria-live="polite">
+                <h5 class="course-derived-heading" style="margin: 0 0 0.35rem 0; font-size: 0.9rem;">Analysis readiness</h5>
+                <ul id="package-readiness-list" class="package-readiness-list"></ul>
+            </div>
             <p id="assign-courses-status" class="course-derived-empty" style="display: none;"></p>
             <div id="assign-courses-form" class="assign-courses-form"></div>
             <p id="assign-courses-data-dir" class="course-derived-empty" style="display: none; margin-top: 0.75rem;"></p>
             <div id="package-latest-runs" class="package-latest-runs" style="display: none; margin-top: 1rem;">
                 <h5 class="course-derived-heading" style="margin: 0 0 0.4rem 0; font-size: 0.95rem;">Latest analysis runs</h5>
-                <p class="course-derived-empty" style="margin: 0 0 0.5rem 0;">Recent runs that used this package as <code>data_dir</code>.</p>
+                <p class="course-derived-empty" style="margin: 0 0 0.5rem 0;">Recent runs launched from this package.</p>
                 <ul id="package-latest-runs-list" class="package-latest-runs-list" style="margin: 0; padding-left: 1.15rem;"></ul>
                 <p id="package-latest-runs-empty" class="course-derived-empty" style="display: none; margin: 0;">No analysis runs found for this package yet.</p>
             </div>
@@ -235,7 +239,10 @@
             <div class="card-header">
                 <h4 class="card-title">Segments (combined course)</h4>
                 <div class="card-actions">
-                    <button type="button" id="btn-edit-event-recipes" class="course-map-action-text-btn" style="display: none;" title="Legacy recipe editor (prefer Assign courses + Build race exports)">Edit event recipes</button>
+                    <details id="legacy-event-recipes-details" class="legacy-event-recipes-details" style="display: none;">
+                        <summary class="course-map-action-text-btn" style="cursor: pointer; list-style: none;">Advanced</summary>
+                        <button type="button" id="btn-edit-event-recipes" class="course-map-action-text-btn" title="Legacy per-event recipe editor — prefer Assign courses + Build race exports">Edit event recipes</button>
+                    </details>
                 </div>
             </div>
             <p id="segments-empty" class="card-help course-derived-empty">Assign global courses above, then <strong>Build race exports</strong>. Pan/zoom the preview map to filter segments and locations tables.</p>
@@ -423,7 +430,7 @@
         <div class="course-location-modal-body">
             <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;">
                 Enter a <strong>start time</strong> (HH:MM, 05:00–20:00) and <strong>duration</strong> (minutes) for each event.
-                Analysis uses files in this package folder as <code>data_dir</code>.
+                Analysis uses the exports built for this package.
             </p>
             <p id="run-analysis-event-day" class="course-derived-empty" style="margin: 0 0 0.75rem 0;"></p>
             <div class="scrollable-table-container course-derived-table-scroll course-derived-table-scroll--modal">
@@ -478,8 +485,8 @@
             <button type="button" id="org-leg-library-close" aria-label="Close">&times;</button>
         </div>
         <div class="course-location-modal-body">
-            <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;">
-                Legs are stored at <code>runflow/org/legs/</code> and shared across all config packages.
+            <p class="course-derived-empty" style="margin: 0 0 0.75rem 0;" title="Organization leg library">
+                Legs are shared across all packages.
                 Use <strong>Import legs…</strong> on the Legs tab to add GPX files here.
             </p>
             <p id="org-leg-library-status" class="course-derived-empty" style="display: none;"></p>


### PR DESCRIPTION
## Summary
- Build hub tab order is now **Legs → Courses → Packages** (default view Legs).
- Package Courses panel shows an **Analysis readiness** checklist from existing readiness fields before Run analysis.
- Legacy **Edit event recipes** is under an **Advanced** disclosure when a combined course exists.
- Soften default help copy (paths moved to tooltips / delete confirms).

Part of https://github.com/thomjeff/run-density/issues/791 (Phase 2).

## Test plan
- [ ] `/config` opens on Legs; tabs ordered Legs → Courses → Packages
- [ ] Packages list still works; opening a package shows Assign courses + readiness checklist
- [ ] Ready package shows green checklist items; incomplete packages show missing items and disabled Run analysis
- [ ] Advanced → Edit event recipes only when combined course exists
- [ ] Visible help no longer leads with `runflow/...` / `data_dir` jargon


Made with [Cursor](https://cursor.com)