### PR TITLE
Issue #791 Phase 3: design-system consolidation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [Unreleased]
+
+### Issue #791 Phase 3 — Frontend design-system consolidation
+- Unified table/sort/action button styles in `common.css`; migrated Flow, Locations, and Density off forked sort CSS
+- Documented the frontend UI contract (`docs/dev-guides/frontend-ui.md`); Tabler admin template deferred pending a dedicated spike
+- Corrected Developer Guide styling note (hand-rolled `common.css`, not Tailwind)
+
 ## [v2.0.8] - 2026-06-10
 
 ### Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,6 +35,7 @@ This documentation is organized by audience and topic for easy navigation.
 | Document | Purpose |
 |----------|---------|
 | [Developer Guide](dev-guides/developer-guide.md) | **START HERE** - Complete v2 developer guide |
+| [Frontend UI Contract](dev-guides/frontend-ui.md) | Tables, sort, actions, Results chrome (Issue #791) |
 | [Docker Development](dev-guides/docker-dev.md) | Docker development workflow |
 | [Leg Library & Corridor Pairing](dev-guides/segment-library-2027.md) | Leg platform internals (org library, recipes, pairing, sync) |
 | [Quick Reference](reference/quick-reference.md) | Variable names, terminology, standards (v2.0.2+) |

--- a/docs/dev-guides/developer-guide.md
+++ b/docs/dev-guides/developer-guide.md
@@ -60,7 +60,7 @@ The application uses server-side rendering with Jinja2 templates and vanilla Jav
 - **Templates:** Jinja2 templates in `frontend/templates/pages/`
 - **JavaScript:** Vanilla JavaScript in `frontend/static/js/`
 - **Mapping:** Leaflet (via CDN: `https://unpkg.com/leaflet@1.9.4/`)
-- **Styling:** Tailwind CSS
+- **Styling:** Hand-rolled CSS — shared contract in `frontend/static/css/common.css` (see [Frontend UI Contract](frontend-ui.md))
 - **No Build Tooling:** No webpack, vite, or npm dependencies
 
 ### Implementation Guidelines
@@ -71,6 +71,7 @@ The application uses server-side rendering with Jinja2 templates and vanilla Jav
 - Use Leaflet for mapping (not react-leaflet)
 - Fetch data via FastAPI endpoints (`/api/*`)
 - Extract shared JS to reusable modules (e.g., `base_map.js`)
+- Use the shared table/sort/action classes from `common.css` (see [Frontend UI Contract](frontend-ui.md))
 
 **❌ DON'T:**
 - Add React, Vue, Svelte, or any SPA framework
@@ -78,6 +79,7 @@ The application uses server-side rendering with Jinja2 templates and vanilla Jav
 - Reference TypeScript (.tsx) files
 - Use build tools (webpack, vite, rollup)
 - Suggest `pnpm dev` or `npm start` commands
+- Invent new inline table/sort CSS on Results pages
 
 ### Code Organization
 

--- a/docs/dev-guides/frontend-ui.md
+++ b/docs/dev-guides/frontend-ui.md
@@ -1,0 +1,59 @@
+# Frontend UI contract (Issue #791 Phase 3)
+
+Short guide so new tables and Results chrome do not fork styling again.
+
+## Stack
+
+- Jinja2 templates in `frontend/templates/`
+- Vanilla JS in `frontend/static/js/`
+- Shared styles in `frontend/static/css/common.css` (linked from `base.html`)
+- Leaflet for maps
+- **No** Tailwind, React, or npm build step
+
+## Tables (one primitive)
+
+```html
+<div class="scrollable-table-container">
+  <table class="table-sticky-header">
+    <thead>
+      <tr>
+        <th class="table-sortable" data-sort="name">
+          Name <span class="table-sortable-indicator">↕</span>
+        </th>
+        <th class="course-map-action-cell">Actions</th>
+      </tr>
+    </thead>
+    <tbody>…</tbody>
+  </table>
+</div>
+```
+
+| Piece | Class | Notes |
+|-------|--------|--------|
+| Scroll + sticky area | `.scrollable-table-container` | Required for sticky headers |
+| Table | `table.table-sticky-header` | Sticky `thead` |
+| Sortable header | `.table-sortable` | Cursor + hover |
+| Sort glyph | `.table-sortable-indicator` | Update text to `▲` / `▼` / `↕` in JS |
+| Actions cell | `.course-map-action-cell` or `.rf-table-actions` | Centered icon buttons |
+
+**Do not** add page-local `#my-table th { padding… }` or a third sort contract (`::after`, `.sortable` / `.sort-indicator` forks). Override only when Build map tables need denser layout (`course_mapping_styles.html`).
+
+## Action buttons
+
+Use `frontend/static/js/table_actions.js` (`TableActions.createIconButton`). Buttons get `.course-map-action-btn` (and optional `--copy` / `--reverse`). Styles live in `common.css`.
+
+## Results chrome
+
+On Segments / Density / Flow / Locations / Reports (not Runs):
+
+```jinja
+{% include "partials/run_context.html" %}
+```
+
+Provides Results sub-nav + run banner / empty CTA. Styles: `.rf-results-*` in `common.css`.
+
+## Tabler / admin template (deferred)
+
+**Selected for a future spike:** [Tabler](https://github.com/tabler/tabler) (MIT, Bootstrap 5). AdminLTE 4 remains the fallback.
+
+**Not adopted in Phase 3.** Loading Bootstrap/Tabler beside today’s hand-rolled `base.html` + `common.css` risks cascade collisions. Revisit only after this SSOT is stable, ideally as an isolated chrome spike (one Build page + one Results page) behind an explicit decision.

--- a/frontend/static/css/common.css
+++ b/frontend/static/css/common.css
@@ -104,6 +104,57 @@
 }
 
 /* ============================================
+   Table action buttons (Issue #791 Phase 3)
+   Shared by Runs, Build, Course Mapping via TableActions
+   ============================================ */
+.course-map-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    padding: 0;
+    margin: 0 2px;
+    border: 1px solid #bdc3c7;
+    border-radius: 4px;
+    background: #fff;
+    cursor: pointer;
+    font-size: 0;
+    vertical-align: middle;
+}
+
+.course-map-action-btn:hover {
+    background: #ecf0f1;
+    border-color: #95a5a6;
+}
+
+.course-map-action-btn svg {
+    width: 16px;
+    height: 16px;
+    pointer-events: none;
+}
+
+.course-map-action-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+}
+
+.course-map-action-btn--copy svg {
+    color: #5b6eae;
+}
+
+.course-map-action-btn--reverse svg {
+    color: #2a7a6f;
+}
+
+.course-map-action-cell,
+.rf-table-actions {
+    text-align: center;
+    white-space: nowrap;
+    vertical-align: middle;
+}
+
+/* ============================================
    Reference Table Card
    ============================================ */
 .reference-table-card {

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -6,7 +6,7 @@
     <title>{% block title %}Runflow{% endblock %} - Race Density & Flow Intelligence</title>
     
     <!-- Issue #652: Shared CSS for UI consistency -->
-    <link rel="stylesheet" href="/static/css/common.css?v=791p2">
+    <link rel="stylesheet" href="/static/css/common.css?v=791p3">
     
     <style>
         /* Reset and Base Styles */

--- a/frontend/templates/pages/dashboard.html
+++ b/frontend/templates/pages/dashboard.html
@@ -156,38 +156,7 @@
         box-shadow: 0 0 0 2px rgba(52, 152, 219, 0.2);
     }
 
-    /* Actions column icon buttons (same look as Race Configuration table) */
-    .course-map-action-btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 28px;
-        height: 28px;
-        padding: 0;
-        margin: 0 2px;
-        border: 1px solid #bdc3c7;
-        border-radius: 4px;
-        background: #fff;
-        cursor: pointer;
-        font-size: 0;
-    }
-    .course-map-action-btn:hover {
-        background: #ecf0f1;
-        border-color: #95a5a6;
-    }
-    .course-map-action-btn svg {
-        width: 16px;
-        height: 16px;
-        pointer-events: none;
-    }
-    .course-map-action-btn:disabled {
-        opacity: 0.4;
-        cursor: not-allowed;
-    }
-    #run-history-table td.course-map-action-cell {
-        text-align: center;
-        white-space: nowrap;
-    }
+    /* Action buttons: common.css .course-map-action-btn / .course-map-action-cell */
 </style>
 {% endblock %}
 

--- a/frontend/templates/pages/density.html
+++ b/frontend/templates/pages/density.html
@@ -166,11 +166,11 @@
                     <table id="bin-details-table" class="table-sticky-header">
                         <thead>
                             <tr>
-                                <th class="sortable" data-sort="start_km">KM (START/END)</th>
-                                <th class="sortable text-center" data-sort="t_start">TIME (START/END)</th>
-                                <th class="sortable text-right" data-sort="density">Density (p/m²)</th>
-                                <th class="sortable text-right" data-sort="rate">Rate (vph)</th>
-                                <th class="sortable text-center" data-sort="los_class">LOS</th>
+                                <th class="table-sortable" data-sort="start_km">KM (START/END) <span class="table-sortable-indicator">↕</span></th>
+                                <th class="table-sortable text-center" data-sort="t_start">TIME (START/END) <span class="table-sortable-indicator">↕</span></th>
+                                <th class="table-sortable text-right" data-sort="density">Density (p/m²) <span class="table-sortable-indicator">↕</span></th>
+                                <th class="table-sortable text-right" data-sort="rate">Rate (vph) <span class="table-sortable-indicator">↕</span></th>
+                                <th class="table-sortable text-center" data-sort="los_class">LOS <span class="table-sortable-indicator">↕</span></th>
                             </tr>
                         </thead>
                         <tbody id="bin-details-table-body">
@@ -234,39 +234,8 @@
 
 {% block extra_head %}
 <style>
-    /* Issue #374: Bin details table styling */
-    #bin-details-table th.sortable {
-        cursor: pointer;
-        user-select: none;
-        position: relative;
-        padding: 0.75rem;
-        background: #f8f9fa;
-        border-bottom: 2px solid #dee2e6;
-        font-weight: 600;
-    }
-    
-    #bin-details-table th.sortable:hover {
-        background: #e9ecef;
-    }
-    
-    #bin-details-table th.sortable::after {
-        content: ' ↕';
-        opacity: 0.5;
-        font-size: 0.8em;
-    }
-    
-    #bin-details-table th.sort-asc::after {
-        content: ' ↑';
-        opacity: 1;
-        color: #007bff;
-    }
-    
-    #bin-details-table th.sort-desc::after {
-        content: ' ↓';
-        opacity: 1;
-        color: #007bff;
-    }
-    
+    /* Bin-details sort SSOT: common.css .table-sortable + .table-sortable-indicator */
+
     #bin-details-table td {
         padding: 0.75rem;
         border-bottom: 1px solid #dee2e6;
@@ -604,7 +573,7 @@
         // Issue #652: Removed pagination button handlers - pagination no longer used
         
         // Setup column sorting
-        const sortableHeaders = document.querySelectorAll('#bin-details-table th.sortable');
+        const sortableHeaders = document.querySelectorAll('#bin-details-table th.table-sortable');
         sortableHeaders.forEach(header => {
             header.addEventListener('click', () => {
                 const column = header.dataset.sort;
@@ -725,11 +694,14 @@
             currentBinSort.direction = 'asc';
         }
         
-        // Update header classes
-        document.querySelectorAll('#bin-details-table th.sortable').forEach(th => {
-            th.classList.remove('sort-asc', 'sort-desc');
+        // Update sort indicators (Issue #791 Phase 3 — shared contract)
+        document.querySelectorAll('#bin-details-table th.table-sortable').forEach(th => {
+            const indicator = th.querySelector('.table-sortable-indicator');
+            if (!indicator) return;
             if (th.dataset.sort === column) {
-                th.classList.add(`sort-${currentBinSort.direction}`);
+                indicator.textContent = currentBinSort.direction === 'asc' ? '▲' : '▼';
+            } else {
+                indicator.textContent = '↕';
             }
         });
         

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -73,9 +73,9 @@
                     <th>NAME</th>
                     <th>EVENT</th>
                     <th>WORST ZONE</th>
-                    <th class="sortable" data-sort="overtaking">OVERTAKING <span class="sort-indicator"></span></th>
+                    <th class="table-sortable" data-sort="overtaking">OVERTAKING <span class="table-sortable-indicator"></span></th>
                     <th>PCT</th>
-                    <th class="sortable" data-sort="copresence">CO-PRESENCE <span class="sort-indicator"></span></th>
+                    <th class="table-sortable" data-sort="copresence">CO-PRESENCE <span class="table-sortable-indicator"></span></th>
                 </tr>
             </thead>
             <tbody id="flow-tbody">
@@ -307,14 +307,14 @@
         let html = '<div style="margin-bottom: 1rem;"><h4 style="margin: 0 0 0.75rem 0;">Zone-Level Details</h4></div>';
         html += '<div style="overflow-x: auto;"><table id="zone-table-' + segment.seg_id + '-' + segment.event_a + '-' + segment.event_b + '" class="zone-table">';
         html += '<thead><tr>';
-        html += '<th class="sortable" data-sort="zone_index">Zone <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="cp_km">Distance <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="overtaking_a">Overtaking <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="overtaken_a">Overtaken <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="copresence_a">Co-presence <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="unique_encounters">Unique Encounters <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="participants_involved">Participants <span class="sort-indicator"></span></th>';
-        html += '<th class="sortable" data-sort="multi_category_runners">Multi-category <span class="sort-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="zone_index">Zone <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="cp_km">Distance <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="overtaking_a">Overtaking <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="overtaken_a">Overtaken <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="copresence_a">Co-presence <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="unique_encounters">Unique Encounters <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="participants_involved">Participants <span class="table-sortable-indicator"></span></th>';
+        html += '<th class="table-sortable" data-sort="multi_category_runners">Multi-category <span class="table-sortable-indicator"></span></th>';
         html += '</tr></thead><tbody>';
         
         sortedZones.forEach(zone => {
@@ -392,7 +392,7 @@
     }
     
     function initializeSorting() {
-        const sortableHeaders = document.querySelectorAll('#flow-table th.sortable');
+        const sortableHeaders = document.querySelectorAll('#flow-table th.table-sortable');
         sortableHeaders.forEach(header => {
             header.style.cursor = 'pointer';
             header.addEventListener('click', function() {
@@ -416,9 +416,9 @@
     }
     
     function updateSortIndicators() {
-        const sortableHeaders = document.querySelectorAll('#flow-table th.sortable');
+        const sortableHeaders = document.querySelectorAll('#flow-table th.table-sortable');
         sortableHeaders.forEach(header => {
-            const indicator = header.querySelector('.sort-indicator');
+            const indicator = header.querySelector('.table-sortable-indicator');
             const column = header.getAttribute('data-sort');
             
             if (indicator) {
@@ -676,45 +676,9 @@
 
 {% block extra_styles %}
 <style>
-    #flow-table th.sortable {
-        cursor: pointer;
-        user-select: none;
-        position: relative;
-    }
-    
-    #flow-table th.sortable:hover {
-        background: #e9ecef;
-    }
-    
-    #flow-table th.sortable .sort-indicator {
-        color: #007bff;
-        font-size: 0.75rem;
-        margin-left: 0.25rem;
-    }
-    
-    #flow-table {
-        width: 100%;
-        border-collapse: collapse;
-    }
-    
-    /* Match base template styling for consistency with Segments table */
-    #flow-table th,
-    #flow-table td {
-        padding: 0.875rem 1rem;  /* Match base template: px-4 py-3 equivalent */
-        text-align: left;
-        border-bottom: 1px solid #e0e0e0;  /* Match base template border color */
-    }
-    
-    #flow-table th {
-        background: #f8f9fa;
-        font-weight: 600;
-        color: #2c3e50;
-    }
-    
-    #flow-table tbody tr:hover {
-        background: #f8f9fa;
-    }
-    
+    /* Table/sort SSOT: common.css (.scrollable-table-container, .table-sortable)
+       Keep Flow-specific accordion / zone / pair cell styles below. */
+
     /* Styling for merged A/B columns */
     td.numeric-pair {
         text-align: right;
@@ -773,15 +737,6 @@
         padding: 0.5rem 0.75rem;
         text-align: left;
         border-bottom: 2px solid #dee2e6;
-    }
-    
-    .zone-table th.sortable {
-        cursor: pointer;
-        user-select: none;
-    }
-    
-    .zone-table th.sortable:hover {
-        background: #dee2e6;
     }
     
     .zone-table td {

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -156,13 +156,13 @@
         <table id="locations-table" class="table-sticky-header">
             <thead>
                 <tr>
-                    <th class="sortable" data-sort="loc_id">ID <span class="sort-indicator"></span></th>
+                    <th class="table-sortable" data-sort="loc_id">ID <span class="table-sortable-indicator"></span></th>
                     <th>Location</th>
-                    <th class="sortable" data-sort="loc_type">Type <span class="sort-indicator"></span></th>
-                    <th class="sortable" data-sort="zone">Zone <span class="sort-indicator"></span></th>
-                    <th class="sortable" data-sort="flag">Flag <span class="sort-indicator"></span></th>
+                    <th class="table-sortable" data-sort="loc_type">Type <span class="table-sortable-indicator"></span></th>
+                    <th class="table-sortable" data-sort="zone">Zone <span class="table-sortable-indicator"></span></th>
+                    <th class="table-sortable" data-sort="flag">Flag <span class="table-sortable-indicator"></span></th>
                     <th>Operational Window</th>
-                    <th class="sortable" data-sort="first_runner">First/Last Runner <span class="sort-indicator"></span></th>
+                    <th class="table-sortable" data-sort="first_runner">First/Last Runner <span class="table-sortable-indicator"></span></th>
                     <th>Peak Window</th>
                 </tr>
             </thead>
@@ -1018,7 +1018,7 @@
      * Initialize sorting functionality (Issue #483)
      */
     function initializeSorting() {
-        const sortableHeaders = document.querySelectorAll('#locations-table th.sortable');
+        const sortableHeaders = document.querySelectorAll('#locations-table th.table-sortable');
         sortableHeaders.forEach(header => {
             header.style.cursor = 'pointer';
             header.addEventListener('click', function() {
@@ -1046,9 +1046,9 @@
      * Update sort indicators in table headers
      */
     function updateSortIndicators() {
-        const sortableHeaders = document.querySelectorAll('#locations-table th.sortable');
+        const sortableHeaders = document.querySelectorAll('#locations-table th.table-sortable');
         sortableHeaders.forEach(header => {
-            const indicator = header.querySelector('.sort-indicator');
+            const indicator = header.querySelector('.table-sortable-indicator');
             const column = header.getAttribute('data-sort');
             
             if (indicator) {
@@ -1237,47 +1237,4 @@
 </style>
 {% endblock %}
 
-{% block extra_styles %}
-<style>
-    #locations-table {
-        width: 100%;
-        border-collapse: separate;
-        border-spacing: 0;
-    }
-    
-    /* Match base template styling for consistency with Flow table */
-    #locations-table th,
-    #locations-table td {
-        padding: 0.875rem 1rem;  /* Match base template: px-4 py-3 equivalent */
-        text-align: left;
-        border-bottom: 1px solid #e0e0e0;  /* Match base template border color */
-    }
-    
-    #locations-table th {
-        background: #f8f9fa;
-        font-weight: 600;
-        color: #2c3e50;
-    }
-    
-    #locations-table tbody tr:hover {
-        background: #f8f9fa;
-    }
-    
-    /* Sortable column styling (Issue #483) */
-    #locations-table th.sortable {
-        cursor: pointer;
-        user-select: none;
-    }
-    
-    #locations-table th.sortable:hover {
-        background: #e9ecef;
-    }
-    
-    #locations-table th.sortable .sort-indicator {
-        color: #007bff;
-        font-size: 0.75rem;
-        margin-left: 0.25rem;
-    }
-</style>
-{% endblock %}
 

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -472,36 +472,8 @@
         border-radius: 4px;
         box-sizing: border-box;
     }
-    .course-map-action-btn {
-        display: inline-flex;
-        align-items: center;
-        justify-content: center;
-        width: 28px;
-        height: 28px;
-        padding: 0;
-        margin: 0 2px;
-        border: 1px solid #bdc3c7;
-        border-radius: 4px;
-        background: #fff;
-        cursor: pointer;
-        font-size: 0;
-        vertical-align: middle;
-    }
-    .course-map-action-btn:hover {
-        background: #ecf0f1;
-        border-color: #95a5a6;
-    }
-    .course-map-action-btn svg {
-        width: 16px;
-        height: 16px;
-        pointer-events: none;
-    }
-    .course-map-action-btn--copy svg {
-        color: #5b6eae;
-    }
-    .course-map-action-btn--reverse svg {
-        color: #2a7a6f;
-    }
+    /* Base action button styles live in common.css (Issue #791 Phase 3).
+       Keep Build-specific action-cell widths below. */
     #segments-table td.course-map-action-cell,
     #race-config-list-table th.course-map-action-cell,
     #race-config-list-table td.course-map-action-cell,


### PR DESCRIPTION
## Summary
- Hoist shared table action-button styles into `common.css`; remove forks from Dashboard and Build styles.
- Migrate Flow / Locations / Density to `.table-sortable` + `.table-sortable-indicator`; delete duplicate page-local table/sort CSS.
- Add `docs/dev-guides/frontend-ui.md` (table/sort/actions/Results chrome contract); correct Developer Guide (no Tailwind).
- **Tabler deferred** — selected for a future spike; not loaded in this PR to avoid Bootstrap cascade collisions.

Part of https://github.com/thomjeff/run-density/issues/791 (Phase 3).

## Test plan
- [ ] Runs: sticky table, sort indicators, action icon buttons still styled/clickable
- [ ] Locations: column sort updates ▲/▼; table padding unchanged via common.css
- [ ] Flow / Density: Results chrome present; no old `.sortable` / `.sort-indicator` forks
- [ ] Build: Legs/Courses/Packages and package action icons unchanged
- [ ] Docs: `docs/dev-guides/frontend-ui.md` linked from `docs/README.md`


Made with [Cursor](https://cursor.com)