### PR TITLE
Issue #796: Opt-in Tabler chrome + Overview Results UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,33 @@
 
 ## [Unreleased]
 
-### Issue #791 Phase 3 — Frontend design-system consolidation
-- Unified table/sort/action button styles in `common.css`; migrated Flow, Locations, and Density off forked sort CSS
-- Documented the frontend UI contract (`docs/dev-guides/frontend-ui.md`); Tabler admin template deferred pending a dedicated spike
-- Corrected Developer Guide styling note (hand-rolled `common.css`, not Tailwind)
+## [v2.0.11] - 2026-07-22
+
+### Summary
+- **Issue #796 — Tabler chrome spike (opt-in):** light horizontal admin shell powered by open-source [Tabler](https://tabler.io/) (`@tabler/core` MIT), loaded from CDN only when `?ui=tabler`
+- New **Overview** Results destination; Runs catalog vs run workspace hierarchy; Build hub card-header tabs
+- Flow / Reports page title and lead copy polish
+- Documented Tabler as a third-party frontend dependency (Developer Guide + Frontend UI contract)
+
+### New Features
+
+#### Opt-in Tabler UI (Issue #796)
+- Append `?ui=tabler` to preview; **Classic UI** control exits the spike (default UI unchanged)
+- Horizontal top bar: Runs ▾ · Overview · Segments · Density · Flow · Locations · Reports · Build · Day · Classic UI · Logout
+- Runs dropdown (label + short id) opens `/overview`; catalog at `/dashboard?ui=tabler` is history-only
+- Active-run context strip with Package link; Build Legs/Courses/Packages use Tabler card-header-tabs
+- Runflow overrides: `frontend/static/css/tabler_spike.css`
+
+### UI Changes
+- Flow page title: **Flow Analysis** (removed “Temporal”)
+- Reports page title: **Reports**; lead copy moved under the page header (removed duplicate card heading)
+
+### Documentation
+- `docs/dev-guides/frontend-ui.md` — Tabler enablement, CDN assets, MIT attribution, UX model
+- `docs/dev-guides/developer-guide.md` — Tabler listed under Frontend Architecture stack components
+
+### Third-party notice
+- **Tabler** ([tabler/tabler](https://github.com/tabler/tabler), MIT License) via `cdn.jsdelivr.net/npm/@tabler/core@1.4.0`
 
 ## [v2.0.8] - 2026-06-10
 

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -134,6 +134,38 @@ async def logout(request: Request):
     return clear_session_response("/", request)
 
 
+@router.get("/overview", response_class=HTMLResponse)
+async def overview(request: Request):
+    """
+    Results Overview — analysis inputs + run KPIs before deep views (Issue #796).
+    """
+    auth_redirect = require_auth(request)
+    if auth_redirect:
+        return auth_redirect
+    meta = get_stub_meta()
+    try:
+        reporting_config = load_reporting()
+        los_colors = reporting_config.get("reporting", {}).get("los_colors", {})
+    except Exception:
+        los_colors = {
+            "A": "#4CAF50",
+            "B": "#8BC34A",
+            "C": "#FFC107",
+            "D": "#FF9800",
+            "E": "#FF5722",
+            "F": "#F44336",
+        }
+    return templates.TemplateResponse(
+        request=request,
+        name="pages/overview.html",
+        context={
+            "request": request,
+            "meta": meta,
+            "los_colors": los_colors,
+        },
+    )
+
+
 @router.get("/dashboard", response_class=HTMLResponse)
 async def dashboard(request: Request):
     """

--- a/docs/dev-guides/developer-guide.md
+++ b/docs/dev-guides/developer-guide.md
@@ -60,8 +60,9 @@ The application uses server-side rendering with Jinja2 templates and vanilla Jav
 - **Templates:** Jinja2 templates in `frontend/templates/pages/`
 - **JavaScript:** Vanilla JavaScript in `frontend/static/js/`
 - **Mapping:** Leaflet (via CDN: `https://unpkg.com/leaflet@1.9.4/`)
-- **Styling:** Hand-rolled CSS — shared contract in `frontend/static/css/common.css` (see [Frontend UI Contract](frontend-ui.md))
-- **No Build Tooling:** No webpack, vite, or npm dependencies
+- **Admin chrome (opt-in):** [Tabler](https://tabler.io/) `@tabler/core@1.4.0` (MIT, open source) via jsDelivr CDN when `?ui=tabler` — see [Frontend UI Contract → Tabler](frontend-ui.md#tabler-ui-issue-796--third-party-admin-chrome)
+- **Styling:** Hand-rolled CSS — shared contract in `frontend/static/css/common.css` (see [Frontend UI Contract](frontend-ui.md)); Tabler remaps in `frontend/static/css/tabler_spike.css`
+- **No Build Tooling:** No webpack, vite, or npm dependencies (CDN only for Leaflet + optional Tabler)
 
 ### Implementation Guidelines
 

--- a/docs/dev-guides/frontend-ui.md
+++ b/docs/dev-guides/frontend-ui.md
@@ -52,8 +52,43 @@ On Segments / Density / Flow / Locations / Reports (not Runs):
 
 Provides Results sub-nav + run banner / empty CTA. Styles: `.rf-results-*` in `common.css`.
 
-## Tabler / admin template (deferred)
+## Tabler UI (Issue #796) — third-party admin chrome
 
-**Selected for a future spike:** [Tabler](https://github.com/tabler/tabler) (MIT, Bootstrap 5). AdminLTE 4 remains the fallback.
+**[Tabler](https://tabler.io/)** (`@tabler/core`) is an open-source admin dashboard UI kit (MIT License). Runflow loads it **opt-in only** from the jsDelivr CDN — there is still no npm/webpack step.
 
-**Not adopted in Phase 3.** Loading Bootstrap/Tabler beside today’s hand-rolled `base.html` + `common.css` risks cascade collisions. Revisit only after this SSOT is stable, ideally as an isolated chrome spike (one Build page + one Results page) behind an explicit decision.
+### How to enable
+
+Append `?ui=tabler` (or `&ui=tabler`) to any authenticated page URL. Use **Classic UI** in the top bar (or drop `ui=tabler`) to leave the preview. Default chrome is unchanged when the query param is absent.
+
+### What we load
+
+| Asset | Source |
+|-------|--------|
+| CSS | `https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css` |
+| JS | `https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/js/tabler.min.js` |
+| Runflow overrides | `frontend/static/css/tabler_spike.css` (linked only when `ui=tabler`) |
+
+Wired from `frontend/templates/base.html` when Jinja sets `tabler_ui` from the query string.
+
+### UX model (horizontal light shell)
+
+- Top bar: **Runflow** | **Runs ▾** | Overview · Segments · Density · Flow · Locations · Reports | **Build** | Day (multi-day) | Classic UI | Logout
+- **Runs ▾:** up to 10 recent runs (label primary, short id secondary) + **View all runs…** → `/dashboard?ui=tabler`
+- Picking a run opens **`/overview?run_id=&day=&ui=tabler`** (Analysis Inputs + Analysis Outputs)
+- Context strip: Active run · label · short id · day · **Package**
+- Runs catalog under Tabler is history-only
+- Build hub uses Tabler **card-header-tabs** for Legs / Courses / Packages
+- Nav preserves `ui=tabler` via `updateNavLinks` / Results `resultsHref` / Build handoffs
+
+### Attribution & license
+
+- Project: [tabler/tabler](https://github.com/tabler/tabler) / [tabler.io](https://tabler.io/)
+- License: **MIT** — free to use in Runflow; keep copyright notice when redistributing Tabler sources
+- We consume the published CDN build; we do not vendor a fork in-repo
+- See also [Developer Guide → Frontend Architecture](developer-guide.md#frontend-architecture)
+
+### Guidelines
+
+- Do **not** load Tabler CSS/JS on Classic UI pages
+- Prefer Tabler primitives (`navbar`, `card`, `nav-tabs` / `card-header-tabs`, `dropdown`, `btn`) under `html.rf-tabler`, remapped in `tabler_spike.css`
+- Keep Classic markup paths working; dual chrome is gated by `{% if tabler_ui %}`

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -1,0 +1,376 @@
+/**
+ * Tabler chrome spike — light horizontal shell (Issue #796).
+ * Opt-in via ?ui=tabler. Default (classic) UI unchanged.
+ */
+
+html.rf-tabler,
+html.rf-tabler body {
+    /* Hardcoded so Tabler’s near-white --tblr-body-bg doesn’t wash out cards */
+    background: #f1f5f9 !important;
+    color: var(--tblr-body-color, #182433);
+}
+
+html.rf-tabler .page {
+    min-height: 100vh;
+}
+
+html.rf-tabler .rf-tabler-brand {
+    font-size: 1.15rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+html.rf-tabler .navbar {
+    background: #fff;
+    border-bottom: 1px solid var(--tblr-border-color, #e6e7e9);
+}
+
+html.rf-tabler .navbar .nav-link.active {
+    font-weight: 700;
+    color: var(--tblr-primary, #206bc4);
+}
+
+html.rf-tabler .page-wrapper {
+    background: #f1f5f9;
+}
+
+html.rf-tabler .page-body {
+    padding-top: 1.25rem;
+    padding-bottom: 2rem;
+}
+
+html.rf-tabler .rf-tabler-content {
+    max-width: 1600px;
+}
+
+/* Context strip under top bar */
+html.rf-tabler .rf-tabler-context-strip {
+    background: #fff;
+    border-bottom: 1px solid var(--tblr-border-color, #e6e7e9);
+    padding: 0.55rem 0;
+}
+
+html.rf-tabler .rf-tabler-context-inner {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    font-size: 0.875rem;
+}
+
+html.rf-tabler .rf-tabler-context-pill {
+    font-size: 0.65rem;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+    color: var(--tblr-primary, #206bc4);
+    background: rgba(32, 107, 196, 0.1);
+    padding: 0.2rem 0.45rem;
+    border-radius: 4px;
+}
+
+html.rf-tabler .rf-tabler-context-label {
+    font-weight: 650;
+    color: var(--tblr-body-color, #182433);
+}
+
+html.rf-tabler .rf-tabler-context-id,
+html.rf-tabler .rf-tabler-context-day {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 0.78rem;
+    color: var(--tblr-secondary, #667382);
+}
+
+html.rf-tabler .rf-tabler-context-pkg {
+    margin-left: auto;
+    font-weight: 600;
+    font-size: 0.8125rem;
+    color: var(--tblr-primary, #206bc4);
+    text-decoration: none;
+}
+
+html.rf-tabler .rf-tabler-context-pkg:hover {
+    text-decoration: underline;
+}
+
+/* Runs dropdown */
+html.rf-tabler #rf-runs-dropdown-menu {
+    min-width: 20rem;
+    max-width: 28rem;
+}
+
+html.rf-tabler #rf-runs-dropdown-menu .dropdown-item {
+    text-align: left;
+}
+
+html.rf-tabler .rf-runs-pick {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.1rem;
+    white-space: normal;
+    text-align: left;
+}
+
+html.rf-tabler .rf-runs-pick-label,
+html.rf-tabler .rf-runs-pick-meta {
+    display: block;
+    width: 100%;
+    text-align: left;
+}
+
+html.rf-tabler .rf-runs-pick-label {
+    font-weight: 600;
+    color: var(--tblr-body-color, #182433);
+}
+
+html.rf-tabler .rf-runs-pick-meta {
+    font-size: 0.75rem;
+    color: var(--tblr-secondary, #667382);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+}
+
+html.rf-tabler .rf-runs-pick.active {
+    background: rgba(32, 107, 196, 0.1);
+}
+
+/* Page headers */
+html.rf-tabler .page-header {
+    display: block !important;
+    margin: 0 0 1.25rem !important;
+    padding: 0 0 0.85rem !important;
+    border-bottom: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    background: transparent !important;
+}
+
+html.rf-tabler .page-header h2 {
+    margin: 0 !important;
+    font-size: 1.5rem !important;
+    font-weight: 700 !important;
+    letter-spacing: -0.02em;
+    color: var(--tblr-body-color, #182433) !important;
+}
+
+html.rf-tabler .race-config-page .page-header h2 {
+    margin: 0 !important;
+    font-size: 1.5rem !important;
+    font-weight: 700 !important;
+    color: var(--tblr-body-color, #182433) !important;
+}
+
+html.rf-tabler .race-config-page-lead {
+    margin-top: 0.35rem !important;
+    color: var(--tblr-secondary, #667382) !important;
+}
+
+/* Cards */
+html.rf-tabler .card,
+html.rf-tabler .content-card,
+html.rf-tabler .race-config-page .content-card {
+    background: #fff !important;
+    border: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    border-radius: var(--tblr-border-radius, 6px) !important;
+    box-shadow: var(--tblr-box-shadow-card, 0 1px 2px rgba(0, 0, 0, 0.04)) !important;
+    padding: 1.25rem !important;
+    margin-bottom: 1.25rem;
+}
+
+html.rf-tabler .card-header,
+html.rf-tabler .race-config-page .card-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.75rem;
+    margin: -0.25rem 0 0.85rem;
+    padding: 0 !important;
+    border: 0 !important;
+    background: transparent !important;
+}
+
+html.rf-tabler .card-title,
+html.rf-tabler .race-config-page .card-title {
+    margin: 0 !important;
+    font-size: 1rem !important;
+    font-weight: 650 !important;
+}
+
+html.rf-tabler .card h3 {
+    margin: 0 0 1rem;
+    font-size: 1.05rem;
+    font-weight: 650;
+}
+
+/* Buttons */
+html.rf-tabler .course-btn,
+html.rf-tabler .race-config-page .card-actions button {
+    display: inline-flex !important;
+    align-items: center !important;
+    justify-content: center !important;
+    padding: 0.35rem 0.75rem !important;
+    border: 1px solid var(--tblr-border-color, #c6cbd2) !important;
+    border-radius: var(--tblr-border-radius, 4px) !important;
+    background: #fff !important;
+    color: var(--tblr-body-color, #182433) !important;
+    font-size: 0.8125rem !important;
+    font-weight: 500 !important;
+}
+
+html.rf-tabler .course-btn.primary,
+html.rf-tabler .course-btn.active,
+html.rf-tabler .race-config-page .card-actions .course-btn.primary,
+html.rf-tabler .race-config-page .card-actions #btn-save-named-course {
+    background: var(--tblr-primary, #206bc4) !important;
+    border-color: var(--tblr-primary, #206bc4) !important;
+    color: #fff !important;
+    font-weight: 600 !important;
+}
+
+html.rf-tabler .course-btn:hover:not(:disabled) {
+    background: #f1f5f9 !important;
+}
+
+html.rf-tabler .course-btn.primary:hover:not(:disabled),
+html.rf-tabler .course-btn.active:hover:not(:disabled) {
+    background: #1a5a9e !important;
+}
+
+html.rf-tabler .filter-input {
+    display: block;
+    width: 100%;
+    max-width: 28rem;
+    padding: 0.45rem 0.75rem;
+    font-size: 0.875rem;
+    border: 1px solid var(--tblr-border-color, #c6cbd2);
+    border-radius: 4px;
+    background: #fff;
+}
+
+/* Tables */
+html.rf-tabler .scrollable-table-container {
+    background: #fff;
+    border: 1px solid var(--tblr-border-color, #e6e7e9);
+    border-radius: 4px;
+    overflow: auto;
+}
+
+html.rf-tabler .table-sticky-header thead th {
+    background: #f8fafc !important;
+    color: var(--tblr-secondary, #667382) !important;
+    font-size: 0.7rem !important;
+    font-weight: 700 !important;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    padding: 0.65rem 0.75rem !important;
+}
+
+html.rf-tabler .table-sticky-header tbody td {
+    padding: 0.55rem 0.75rem !important;
+    border-bottom: 1px solid #eef1f4 !important;
+}
+
+/* Results chrome: top nav + context strip replace sub-nav / banner / actions */
+html.rf-tabler .rf-results-subnav,
+html.rf-tabler .rf-results-actions,
+html.rf-tabler .rf-results-banner {
+    display: none !important;
+}
+
+html.rf-tabler .rf-results-chrome {
+    margin: 0 0 1rem !important;
+}
+
+html.rf-tabler .run-context-missing {
+    background: #fff !important;
+    border: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    border-radius: 6px !important;
+    padding: 0.85rem 1rem !important;
+}
+
+/* Catalog-only Runs page — do NOT hide Overview panels (same element ids) */
+html.rf-tabler .rf-classic-dashboard-panels {
+    display: none !important;
+}
+
+/* Build hub — Tabler card-header-tabs (anchored in card shell) */
+html.rf-tabler .race-config-page .race-config-hub-shell {
+    background: #fff !important;
+    border: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    border-radius: var(--tblr-border-radius, 6px) !important;
+    box-shadow: var(--tblr-box-shadow-card, 0 1px 2px rgba(0, 0, 0, 0.04)) !important;
+    padding: 0 !important;
+    overflow: hidden;
+}
+
+/* White header inside the card so tabs sit in the frame (not page-bg gray) */
+html.rf-tabler .race-config-page .race-config-hub-header {
+    background: #fff !important;
+    border-bottom: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+html.rf-tabler .race-config-page .race-config-hub-tabs {
+    display: flex !important;
+    flex-wrap: wrap !important;
+    align-items: stretch !important;
+    gap: 0 !important;
+    margin: 0 !important;
+    padding: 0 0.5rem !important;
+    border: 0 !important;
+    background: transparent !important;
+    list-style: none !important;
+}
+
+html.rf-tabler .race-config-page .race-config-hub-tabs > .nav-item {
+    margin: 0 !important;
+}
+
+html.rf-tabler .race-config-page .race-config-hub-tab.nav-link,
+html.rf-tabler .race-config-page .race-config-hub-tab {
+    display: block !important;
+    position: relative !important;
+    z-index: 1 !important;
+    margin: 0 0 -1px !important;
+    padding: 0.9rem 1.15rem !important;
+    border: 0 !important;
+    border-bottom: 2px solid transparent !important;
+    border-radius: 0 !important;
+    background: transparent !important;
+    color: var(--tblr-secondary, #667382) !important;
+    font-size: 0.9375rem !important;
+    font-weight: 500 !important;
+    line-height: 1.25 !important;
+    text-decoration: none !important;
+    box-shadow: none !important;
+}
+
+html.rf-tabler .race-config-page .race-config-hub-tab:hover {
+    color: var(--tblr-body-color, #182433) !important;
+    background: transparent !important;
+    border-bottom-color: rgba(32, 107, 196, 0.35) !important;
+}
+
+html.rf-tabler .race-config-page .race-config-hub-tab.active {
+    color: var(--tblr-primary, #206bc4) !important;
+    font-weight: 650 !important;
+    background: #fff !important;
+    border-bottom-color: var(--tblr-primary, #206bc4) !important;
+}
+
+html.rf-tabler .race-config-page .race-config-hub-body {
+    padding: 1.25rem !important;
+    background: #fff !important;
+}
+
+/* Nested map/table cards inside hub stay flush with body */
+html.rf-tabler .race-config-page .race-config-hub-legs-slot > .content-card,
+html.rf-tabler .race-config-page .race-config-hub-legs-slot > .card {
+    border: 1px solid var(--tblr-border-color, #e6e7e9) !important;
+    box-shadow: none !important;
+}
+
+html.rf-tabler .footer {
+    border-top: 1px solid var(--tblr-border-color, #e6e7e9);
+    padding: 1rem 0;
+}

--- a/frontend/static/js/map/saved_courses.js
+++ b/frontend/static/js/map/saved_courses.js
@@ -958,7 +958,13 @@
                     var li = document.createElement('li');
                     li.style.marginBottom = '0.25rem';
                     var a = document.createElement('a');
-                    a.href = '/density?run_id=' + encodeURIComponent(hit.run_id);
+                    var uiQ = document.documentElement.classList.contains('rf-tabler')
+                        ? '?ui=tabler&'
+                        : '?';
+                    var resultsPath = document.documentElement.classList.contains('rf-tabler')
+                        ? '/overview'
+                        : '/density';
+                    a.href = resultsPath + uiQ + 'run_id=' + encodeURIComponent(hit.run_id);
                     a.textContent = hit.description || hit.run_id;
                     a.title = hit.run_id;
                     li.appendChild(a);
@@ -1179,26 +1185,41 @@
                     localStorage.setItem('selected_run_id', runId);
                     if (eventDay) localStorage.setItem('selected_day', eventDay);
                 }
+                var uiQ = document.documentElement.classList.contains('rf-tabler')
+                    ? '&ui=tabler'
+                    : '';
+                var resultsPath = document.documentElement.classList.contains('rf-tabler')
+                    ? '/overview'
+                    : '/density';
                 var msg =
                     'Analysis started. Run ID: ' +
                     runId +
                     '. Results will appear under Results in a few minutes.';
                 setAssignStatus(
                     msg +
-                        ' <a href="/density?run_id=' +
+                        ' <a href="' +
+                        resultsPath +
+                        '?run_id=' +
                         encodeURIComponent(runId) +
                         (eventDay ? '&day=' + encodeURIComponent(eventDay) : '') +
-                        '">Open Density</a> · <a href="/dashboard?run_id=' +
+                        uiQ +
+                        '">Open ' +
+                        (resultsPath === '/overview' ? 'Overview' : 'Density') +
+                        '</a> · <a href="/dashboard?run_id=' +
                         encodeURIComponent(runId) +
+                        uiQ +
                         '">Runs</a>',
                     false,
                     true
                 );
                 refreshPackageLatestRuns();
-                if (runId && window.confirm(msg + '\n\nOpen Density results now?')) {
+                if (runId && window.confirm(msg + '\n\nOpen results now?')) {
                     var dest =
-                        '/density?run_id=' + encodeURIComponent(runId);
+                        resultsPath +
+                        '?run_id=' +
+                        encodeURIComponent(runId);
                     if (eventDay) dest += '&day=' + encodeURIComponent(eventDay);
+                    if (uiQ) dest += uiQ;
                     window.location.href = dest;
                 }
             })

--- a/frontend/static/js/run_overview.js
+++ b/frontend/static/js/run_overview.js
@@ -1,0 +1,151 @@
+/**
+ * Shared Analysis Inputs + Analysis Outputs renderers (Issue #796 Overview).
+ * Used by /overview (Tabler). Classic dashboard keeps its own renderers.
+ */
+(function (global) {
+    'use strict';
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function renderAnalysisInputsView(data) {
+        var section = document.getElementById('analysis-inputs-section');
+        var content = document.getElementById('analysis-inputs-content');
+        if (!section || !content) return;
+
+        section.style.display = 'block';
+
+        var days = data.days || [];
+        var inputs = data.analysis_inputs || {};
+
+        var html = ''
+            + '<div class="rf-overview-meta">'
+            + '<strong>Run ID:</strong> ' + escapeHtml(data.run_id || '—') + '<br>'
+            + '<strong>Description:</strong> ' + escapeHtml(data.description || 'N/A')
+            + '</div>'
+            + '<h4 class="rf-overview-subhead">Events</h4>'
+            + '<div class="scrollable-table-container"><table class="table-sticky-header"><thead><tr>'
+            + '<th>Day</th><th>Event</th><th>Participants</th><th>Start Time</th>'
+            + '<th>First Finisher</th><th>Last Finisher</th><th>Duration</th>'
+            + '</tr></thead><tbody>';
+
+        var eventRows = 0;
+        days.forEach(function (day) {
+            var row = inputs[day] || {};
+            var evs = row.events || [];
+            if (!evs.length) {
+                html += '<tr><td>' + escapeHtml(day) + '</td>'
+                    + '<td colspan="6">—</td></tr>';
+                eventRows += 1;
+                return;
+            }
+            evs.forEach(function (ev, idx) {
+                html += '<tr>';
+                if (idx === 0) {
+                    html += '<td rowspan="' + evs.length + '">' + escapeHtml(day) + '</td>';
+                }
+                html += '<td>' + escapeHtml(ev.event || '—') + '</td>'
+                    + '<td>' + (ev.participants != null ? escapeHtml(ev.participants) : '—') + '</td>'
+                    + '<td>' + escapeHtml(ev.start_time || '—') + '</td>'
+                    + '<td>' + escapeHtml(ev.first_finisher || '—') + '</td>'
+                    + '<td>' + escapeHtml(ev.last_finisher || '—') + '</td>'
+                    + '<td>' + escapeHtml(ev.duration || '—') + '</td>'
+                    + '</tr>';
+                eventRows += 1;
+            });
+        });
+        if (!eventRows) {
+            html += '<tr><td colspan="7" class="placeholder">—</td></tr>';
+        }
+        html += '</tbody></table></div>';
+        content.innerHTML = html;
+    }
+
+    function renderRunDetailView(data) {
+        var section = document.getElementById('run-detail-section');
+        var content = document.getElementById('run-detail-content');
+        if (!section || !content) return;
+
+        section.style.display = 'block';
+
+        var days = data.days || [];
+        var metrics = data.metrics || {};
+
+        var metricRows = [
+            { key: 'participants', label: 'Total Participants' },
+            { key: 'events', label: 'Events', format: function (val) {
+                return Array.isArray(val) ? val.join(', ') : val;
+            } },
+            { key: 'day_first_finisher', label: 'First Finisher', format: function (val) { return val || '—'; } },
+            { key: 'day_last_finisher', label: 'Last Finisher', format: function (val) { return val || '—'; } },
+            { key: 'day_duration', label: 'Day Duration', format: function (val) { return val || '—'; } },
+            { key: 'segments_with_flags', label: 'Segments with Flags' },
+            { key: 'peak_density', label: 'Peak Density (P/m²)' },
+            { key: 'peak_rate', label: 'Peak Rate (P/s)' },
+            { key: 'overtaking_segments', label: 'Overtaking Segments' },
+            { key: 'co_presence_segments', label: 'Co-Presence Segments' },
+            { key: 'flagged_bins', label: 'Flagged Bins', format: function (val) {
+                return (val !== undefined && val !== null && !Number.isNaN(Number(val))
+                    ? Number(val).toLocaleString() : '—');
+            } },
+            { key: 'operational_status', label: 'Operational Status' },
+            { key: 'event_groups', label: 'Runner Experience Scores (RES)', format: function (val) {
+                if (!val || typeof val !== 'object' || Object.keys(val).length === 0) return '—';
+                return Object.entries(val).map(function (pair) {
+                    var res = (pair[1] && pair[1].res) || 0;
+                    return pair[0] + ': ' + Number(res).toFixed(2);
+                }).join(', ') || '—';
+            } }
+        ];
+
+        var html = ''
+            + '<div class="scrollable-table-container"><table class="table-sticky-header"><thead><tr>'
+            + '<th>Metric</th>'
+            + days.map(function (d) { return '<th>' + escapeHtml(d) + '</th>'; }).join('')
+            + '</tr></thead><tbody>';
+
+        metricRows.forEach(function (row) {
+            html += '<tr><td>' + escapeHtml(row.label) + '</td>';
+            days.forEach(function (day) {
+                var dayMetrics = metrics[day] || {};
+                var value = dayMetrics[row.key];
+                if (row.format) value = row.format(value, dayMetrics);
+                else if (typeof value === 'number') value = value.toLocaleString();
+
+                if (row.key === 'peak_density' && dayMetrics.peak_density_los) {
+                    var los = dayMetrics.peak_density_los;
+                    html += '<td>' + escapeHtml(value || '—')
+                        + ' <span class="badge-los badge-' + escapeHtml(los) + '">'
+                        + escapeHtml(los) + '</span></td>';
+                } else {
+                    html += '<td>' + escapeHtml(value || '—') + '</td>';
+                }
+            });
+            html += '</tr>';
+        });
+
+        html += '</tbody></table></div>';
+        content.innerHTML = html;
+    }
+
+    function loadRunSummary(runId, fetchJson) {
+        return fetchJson('/api/runs/' + encodeURIComponent(runId) + '/summary')
+            .then(function (data) {
+                try { renderAnalysisInputsView(data); } catch (e) { console.error(e); }
+                try { renderRunDetailView(data); } catch (e) { console.error(e); }
+                return data;
+            });
+    }
+
+    global.RunOverview = {
+        renderAnalysisInputsView: renderAnalysisInputsView,
+        renderRunDetailView: renderRunDetailView,
+        loadRunSummary: loadRunSummary,
+        escapeHtml: escapeHtml
+    };
+})(window);

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -1,13 +1,22 @@
 <!DOCTYPE html>
-<html lang="en">
+{# Issue #796: opt-in Tabler chrome spike via ?ui=tabler (default UI unchanged) #}
+{% set tabler_ui = request is defined and request.query_params.get('ui') == 'tabler' %}
+<html lang="en" class="{% if tabler_ui %}rf-tabler{% endif %}">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>{% block title %}Runflow{% endblock %} - Race Density & Flow Intelligence</title>
     
+{% if tabler_ui %}
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css" />
+    <link rel="stylesheet" href="/static/css/common.css?v=791p3">
+    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=796k">
+{% else %}
     <!-- Issue #652: Shared CSS for UI consistency -->
     <link rel="stylesheet" href="/static/css/common.css?v=791p3">
+{% endif %}
     
+{% if not tabler_ui %}
     <style>
         /* Reset and Base Styles */
         * { margin: 0; padding: 0; box-sizing: border-box; }
@@ -308,11 +317,98 @@
         
     </style>
     
+{% endif %}
+    
     {% block extra_styles %}{% endblock %}
     
     {% block extra_head %}{% endblock %}
 </head>
-<body>
+<body{% if tabler_ui %} class="layout-fluid"{% endif %}>
+{% if tabler_ui %}
+    <div class="page">
+        {# Light horizontal Tabler chrome (Issue #796) — full-width content #}
+        <header class="navbar navbar-expand-md d-print-none">
+            <div class="container-xl">
+                <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#rf-tabler-menu" aria-controls="rf-tabler-menu" aria-expanded="false" aria-label="Toggle navigation">
+                    <span class="navbar-toggler-icon"></span>
+                </button>
+                <h1 class="navbar-brand navbar-brand-autodark d-none-navbar-horizontal pe-0 pe-md-3 mb-0">
+                    <a href="/overview?ui=tabler" class="text-decoration-none text-reset">
+                        <span class="rf-tabler-brand">Runflow</span>
+                    </a>
+                </h1>
+                <div class="navbar-nav flex-row order-md-last align-items-center gap-1">
+                    <div id="day-selector-wrap" class="nav-item rf-tabler-day" style="display:none;" aria-hidden="true">
+                        <label for="day-selector" class="form-label mb-0 me-1 visually-hidden">Day</label>
+                        <select id="day-selector" class="form-select form-select-sm" style="min-width:88px;">
+                            <option value="">—</option>
+                        </select>
+                    </div>
+                    <a id="rf-tabler-exit" class="nav-link px-2" href="?" title="Leave Tabler preview">Classic UI</a>
+                    <a class="nav-link px-2 text-danger" href="/logout">Logout</a>
+                </div>
+                <div class="collapse navbar-collapse" id="rf-tabler-menu">
+                    <ul class="navbar-nav">
+                        {% if cloud_mode %}
+                        <li class="nav-item">
+                            <a class="nav-link{% if request.url and request.url.path == '/dashboard' %} active{% endif %}" href="/dashboard?ui=tabler">Runs</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link{% if request.url and request.url.path == '/locations' %} active{% endif %}" href="/locations?ui=tabler">Locations</a>
+                        </li>
+                        {% else %}
+                        <li class="nav-item dropdown" id="rf-runs-dropdown">
+                            <a class="nav-link dropdown-toggle{% if request.url and request.url.path == '/dashboard' %} active{% endif %}" href="#" id="rf-runs-dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+                                <span id="rf-runs-trigger-label">Runs</span>
+                            </a>
+                            <div class="dropdown-menu" id="rf-runs-dropdown-menu">
+                                <div class="dropdown-header">Recent runs</div>
+                                <div id="rf-runs-dropdown-list">
+                                    <span class="dropdown-item disabled">Loading…</span>
+                                </div>
+                                <div class="dropdown-divider"></div>
+                                <a class="dropdown-item" id="rf-runs-view-all" href="/dashboard?ui=tabler">View all runs…</a>
+                            </div>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/overview' %} active{% endif %}" href="/overview?ui=tabler" data-rf-run-view="1">Overview</a>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/segments' %} active{% endif %}" href="/segments?ui=tabler" data-rf-run-view="1">Segments</a>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/density' %} active{% endif %}" href="/density?ui=tabler" data-rf-run-view="1">Density</a>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/flow' %} active{% endif %}" href="/flow?ui=tabler" data-rf-run-view="1">Flow</a>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/locations' %} active{% endif %}" href="/locations?ui=tabler" data-rf-run-view="1">Locations</a>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/reports' %} active{% endif %}" href="/reports?ui=tabler" data-rf-run-view="1">Reports</a>
+                        </li>
+                        <li class="nav-item">
+                            <a class="nav-link{% if request.url and (request.url.path == '/config' or request.url.path.startswith('/race-configuration')) %} active{% endif %}" href="/config?ui=tabler" title="Legs, Courses, and Packages">Build</a>
+                        </li>
+                        {% endif %}
+                    </ul>
+                </div>
+            </div>
+        </header>
+        <div id="rf-tabler-context-strip" class="rf-tabler-context-strip" hidden>
+            <div class="container-xl rf-tabler-context-inner">
+                <span class="rf-tabler-context-pill">Active run</span>
+                <span id="rf-tabler-context-label" class="rf-tabler-context-label">—</span>
+                <span id="rf-tabler-context-id" class="rf-tabler-context-id"></span>
+                <span id="rf-tabler-context-day" class="rf-tabler-context-day" hidden></span>
+                <a id="rf-tabler-open-package" class="rf-tabler-context-pkg" href="/config?ui=tabler" hidden>Package</a>
+            </div>
+        </div>
+        <div class="page-wrapper">
+            <div class="page-body">
+                <div class="container-xl rf-tabler-content">
+{% else %}
     <header>
         <h1>Runflow</h1>
         <div class="tagline">Race Density & Flow Intelligence</div>
@@ -354,12 +450,26 @@
     </nav>
     
     <main>
+{% endif %}
         {% block content %}{% endblock %}
+{% if tabler_ui %}
+                </div>
+            </div>
+            <footer class="footer footer-transparent d-print-none">
+                <div class="container-xl">
+                    <p class="text-secondary m-0">&copy; 2025 Runflow - Race Density &amp; Flow Intelligence System</p>
+                </div>
+            </footer>
+        </div>
+    </div>
+    <script src="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/js/tabler.min.js"></script>
+{% else %}
     </main>
     
     <footer>
         <p>&copy; 2025 Runflow - Race Density & Flow Intelligence System</p>
     </footer>
+{% endif %}
     
     {% block extra_scripts %}{% endblock %}
     
@@ -432,6 +542,7 @@
         const CONFIG_ROUTE_PREFIXES = ["/config", "/race-configuration"];
         const RESULTS_ROUTE_PATHS = [
             "/dashboard",
+            "/overview",
             "/segments",
             "/density",
             "/flow",
@@ -469,12 +580,193 @@
             }));
         }
 
+        function shortRunId(runId) {
+            const id = String(runId || "");
+            return id.length > 10 ? id.slice(0, 8) + "…" : id;
+        }
+
+        function syncTablerRunNav(runId, day) {
+            if (!document.documentElement.classList.contains("rf-tabler")) return;
+            const hasRun = !!(runId && String(runId).trim());
+            document.querySelectorAll(".rf-tabler-run-view-link").forEach(function (li) {
+                li.hidden = !hasRun;
+            });
+
+            const strip = document.getElementById("rf-tabler-context-strip");
+            const labelEl = document.getElementById("rf-tabler-context-label");
+            const idEl = document.getElementById("rf-tabler-context-id");
+            const dayEl = document.getElementById("rf-tabler-context-day");
+            const trigger = document.getElementById("rf-runs-trigger-label");
+
+            if (!hasRun) {
+                if (strip) strip.hidden = true;
+                if (trigger) trigger.textContent = "Runs";
+                syncTablerPackageLink(null);
+                refreshRunsDropdown(null);
+                return;
+            }
+
+            const id = String(runId).trim();
+            let label = id;
+            try {
+                const cached = sessionStorage.getItem("rf_run_label_" + id);
+                if (cached) label = cached;
+            } catch (e) { /* ignore */ }
+
+            if (strip) strip.hidden = false;
+            if (labelEl) labelEl.textContent = label;
+            if (idEl) {
+                idEl.textContent = shortRunId(id);
+                idEl.title = id;
+            }
+            if (dayEl) {
+                const multi = window.runflowDay && Array.isArray(window.runflowDay.available)
+                    && window.runflowDay.available.length > 1;
+                if (multi && day) {
+                    dayEl.textContent = "· " + String(day).toUpperCase();
+                    dayEl.hidden = false;
+                } else {
+                    dayEl.hidden = true;
+                }
+            }
+            if (trigger) {
+                const trunc = label.length > 28 ? label.slice(0, 26) + "…" : label;
+                trigger.textContent = trunc + " · " + shortRunId(id);
+            }
+            syncTablerPackageLink(id);
+            refreshRunsDropdown(id);
+        }
+
+        function configIdFromDataDir(dataDir) {
+            if (!dataDir) return "";
+            const normalized = String(dataDir).replace(/\\/g, "/").replace(/\/+$/, "");
+            const marker = "/config/";
+            const idx = normalized.lastIndexOf(marker);
+            if (idx < 0) return "";
+            const rest = normalized.slice(idx + marker.length);
+            return (rest.split("/")[0] || "");
+        }
+
+        function syncTablerPackageLink(runId) {
+            const link = document.getElementById("rf-tabler-open-package");
+            if (!link) return;
+            if (!runId) {
+                link.hidden = true;
+                return;
+            }
+            fetch("/api/analysis/" + encodeURIComponent(runId) + "/config", { credentials: "same-origin" })
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (cfg) {
+                    const configId = configIdFromDataDir(cfg && cfg.data_dir);
+                    if (!configId) {
+                        link.hidden = true;
+                        return;
+                    }
+                    localStorage.setItem("selected_config_id", configId);
+                    link.href = "/config?config_id=" + encodeURIComponent(configId) + "&ui=tabler";
+                    link.title = "Open package " + configId;
+                    link.hidden = false;
+                })
+                .catch(function () {
+                    link.hidden = true;
+                });
+        }
+
+        function refreshRunsDropdown(activeRunId) {
+            const list = document.getElementById("rf-runs-dropdown-list");
+            if (!list) return;
+            if (list.dataset.fetched === "1") {
+                list.querySelectorAll(".rf-runs-pick").forEach(function (a) {
+                    a.classList.toggle("active", a.dataset.runId === activeRunId);
+                });
+                return;
+            }
+            if (list.dataset.loading === "1") return;
+            list.dataset.loading = "1";
+            fetch("/api/runs/list", { credentials: "same-origin" })
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (data) {
+                    list.dataset.loading = "0";
+                    list.dataset.fetched = "1";
+                    const runs = (data && data.runs) || [];
+                    const top = runs.slice(0, 10);
+                    if (!top.length) {
+                        list.innerHTML = '<span class="dropdown-item disabled">No runs yet</span>';
+                        return;
+                    }
+                    list.innerHTML = "";
+                    top.forEach(function (run) {
+                        const id = run.run_id;
+                        const label = (run.description || "").trim() || id;
+                        try { sessionStorage.setItem("rf_run_label_" + id, label); } catch (e) { /* ignore */ }
+                        const a = document.createElement("a");
+                        a.className = "dropdown-item rf-runs-pick" + (id === activeRunId ? " active" : "");
+                        a.href = "#";
+                        a.dataset.runId = id;
+                        a.innerHTML = '<span class="rf-runs-pick-label"></span>'
+                            + '<span class="rf-runs-pick-meta"></span>';
+                        a.querySelector(".rf-runs-pick-label").textContent = label;
+                        a.querySelector(".rf-runs-pick-meta").textContent =
+                            shortRunId(id) + (run.formatted_date ? " · " + run.formatted_date : "");
+                        a.addEventListener("click", function (ev) {
+                            ev.preventDefault();
+                            pickTablerRun(id, label);
+                        });
+                        list.appendChild(a);
+                    });
+                    if (activeRunId) {
+                        const labelEl = document.getElementById("rf-tabler-context-label");
+                        const trigger = document.getElementById("rf-runs-trigger-label");
+                        try {
+                            const cached = sessionStorage.getItem("rf_run_label_" + activeRunId);
+                            if (cached && labelEl) labelEl.textContent = cached;
+                            if (cached && trigger) {
+                                const trunc = cached.length > 28 ? cached.slice(0, 26) + "…" : cached;
+                                trigger.textContent = trunc + " · " + shortRunId(activeRunId);
+                            }
+                        } catch (e) { /* ignore */ }
+                    }
+                })
+                .catch(function () {
+                    list.dataset.loading = "0";
+                    list.innerHTML = '<span class="dropdown-item disabled">Could not load runs</span>';
+                });
+        }
+
+        function pickTablerRun(runId, label) {
+            if (label) {
+                try { sessionStorage.setItem("rf_run_label_" + runId, label); } catch (e) { /* ignore */ }
+            }
+            localStorage.setItem("selected_run_id", runId);
+            fetch("/api/runs/" + encodeURIComponent(runId) + "/summary", { credentials: "same-origin" })
+                .then(function (r) { return r.ok ? r.json() : null; })
+                .then(function (data) {
+                    const days = (data && data.days) || [];
+                    let day = (localStorage.getItem("selected_day") || "").trim().toLowerCase();
+                    if (day && days.length && days.indexOf(day) < 0) day = days[0];
+                    else if (!day && days.length) day = days[0];
+                    if (day) localStorage.setItem("selected_day", day);
+                    const params = new URLSearchParams();
+                    params.set("run_id", runId);
+                    if (day) params.set("day", day);
+                    params.set("ui", "tabler");
+                    window.location.href = "/overview?" + params.toString();
+                })
+                .catch(function () {
+                    window.location.href = "/overview?run_id=" + encodeURIComponent(runId) + "&ui=tabler";
+                });
+        }
+
         function updateNavLinks(day, runId) {
-            const onConfigPage = isConfigRoutePath(window.location.pathname);
-            document.querySelectorAll("nav a").forEach(a => {
+            const tablerUi = document.documentElement.classList.contains("rf-tabler");
+            document.querySelectorAll("nav a, .navbar-nav a, .navbar-brand a").forEach(a => {
                 const href = a.getAttribute("href");
-                if (!href || href === "/logout" || href === "/health-check") return;
+                if (!href || href === "/logout" || href === "/health-check" || href === "#") return;
+                if (a.id === "rf-tabler-exit") return;
+                if (a.id === "rf-tabler-open-package" || a.getAttribute("data-rf-package-link") === "1") return;
+                if (a.classList.contains("dropdown-toggle") || a.classList.contains("dropdown-item")) return;
                 const linkPath = href.split("?")[0];
+                if (!linkPath) return;
                 let newHref = href.split("?")[0];
                 if (isConfigRoutePath(linkPath)) {
                     if (linkPath === "/config") {
@@ -487,20 +779,45 @@
                     }
                     newHref = setQueryParam(newHref, "run_id", null);
                     newHref = setQueryParam(newHref, "day", null);
-                } else if (isAnalysisRoutePath(linkPath) && !onConfigPage) {
+                } else if (isAnalysisRoutePath(linkPath)) {
                     if (day) newHref = setQueryParam(newHref, "day", day);
                     if (runId) newHref = setQueryParam(newHref, "run_id", runId);
+                    // Catalog page should not require a run in the URL
+                    if (linkPath === "/dashboard") {
+                        newHref = setQueryParam(newHref, "run_id", null);
+                        newHref = setQueryParam(newHref, "day", null);
+                    }
                     newHref = setQueryParam(newHref, "config_id", null);
+                }
+                if (tablerUi) {
+                    newHref = setQueryParam(newHref, "ui", "tabler");
+                } else {
+                    newHref = setQueryParam(newHref, "ui", null);
                 }
                 a.setAttribute("href", newHref);
             });
+            const exit = document.getElementById("rf-tabler-exit");
+            if (exit) {
+                const exitParams = new URLSearchParams(window.location.search);
+                exitParams.delete("ui");
+                const qs = exitParams.toString();
+                exit.setAttribute("href", window.location.pathname + (qs ? "?" + qs : ""));
+            }
+            const viewAll = document.getElementById("rf-runs-view-all");
+            if (viewAll && tablerUi) {
+                viewAll.setAttribute("href", "/dashboard?ui=tabler");
+            }
+            syncTablerRunNav(runId, day);
         }
 
         window.updateConfigNavLinks = function(configId) {
             if (configId) {
                 localStorage.setItem("selected_config_id", configId);
             }
-            updateNavLinks(null, null);
+            // Keep Results nest visible while on Build/Package (Issue #796)
+            const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
+            const storedDay = (localStorage.getItem("selected_day") || "").trim() || null;
+            updateNavLinks(storedDay, storedRun);
         };
 
         // Make updateNavLinks globally accessible for dashboard.html
@@ -532,7 +849,18 @@
             if (changed && newUrl !== window.location.pathname + window.location.search) {
                 window.history.replaceState({}, "", newUrl);
             }
-            updateNavLinks(null, null);
+            // Preserve Tabler spike flag if present
+            if (document.documentElement.classList.contains("rf-tabler")) {
+                const p2 = new URLSearchParams(window.location.search);
+                if (p2.get("ui") !== "tabler") {
+                    p2.set("ui", "tabler");
+                    window.history.replaceState({}, "", window.location.pathname + "?" + p2.toString());
+                }
+            }
+            // Keep last Results run in top-bar views while authoring
+            const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
+            const storedDay = (localStorage.getItem("selected_day") || "").trim() || null;
+            updateNavLinks(storedDay, storedRun);
         }
 
         async function initDaySelector() {

--- a/frontend/templates/pages/dashboard.html
+++ b/frontend/templates/pages/dashboard.html
@@ -5,9 +5,20 @@
 {% block content %}
 <div class="page-header">
     <h2>Runs</h2>
+    <p class="rf-tabler-runs-lead" style="display:none; margin:0.35rem 0 0; color:#667382; font-size:0.9rem;">
+        Pick a run to open its Overview. Use the top bar for Segments, Density, Flow, Locations, and Reports.
+    </p>
     <div style="display: flex; align-items: center; gap: 1rem;">
     </div>
 </div>
+<script>
+(function () {
+    if (document.documentElement.classList.contains('rf-tabler')) {
+        var lead = document.querySelector('.rf-tabler-runs-lead');
+        if (lead) lead.style.display = 'block';
+    }
+})();
+</script>
 
 <!-- Run History Table Section (Issue #565) -->
 <div class="card" style="margin-bottom: 2rem;">
@@ -66,6 +77,8 @@
     </div>
 </div>
 
+<!-- Classic dashboard panels (hidden under Tabler — Overview owns this UX) -->
+<div class="rf-classic-dashboard-panels">
 <!-- Analysis Inputs (Issue #739): day windows + per-event timings from metadata.json / API -->
 <div id="analysis-inputs-section" class="card" style="display: none; margin-bottom: 2rem;">
     <h3 style="margin-bottom: 1rem; color: #2c3e50;">Analysis Inputs</h3>
@@ -89,6 +102,7 @@
             <div id="data-missing-message" style="font-size: 0.875rem; color: #856404;">Data not found for one or more inputs (meta.json, metrics, or flags). Showing placeholders.</div>
         </div>
     </div>
+</div>
 </div>
 
 
@@ -243,9 +257,9 @@
                 filteredRuns = [...runsList];
                 renderRunHistoryTable();
                 
-                // Auto-select most recent run if none selected
+                // Auto-select most recent run if none selected (stay on catalog; do not enter workspace)
                 if (!selectedRunId && runsList.length > 0) {
-                    selectRun(runsList[0].run_id);
+                    selectRun(runsList[0].run_id, false);
                 }
             })
             .catch(error => {
@@ -301,7 +315,7 @@
             const rowStyle = isSelected ? 'background: #e3f2fd; font-weight: 600;' : '';
             
             return `
-                <tr data-run-id="${run.run_id}" style="${rowStyle} cursor: pointer;" onclick="selectRun('${run.run_id}')">
+                <tr data-run-id="${run.run_id}" style="${rowStyle} cursor: pointer;" onclick="selectRun('${run.run_id}', true)" title="Open Overview for this run">
                     <td style="padding: 0.75rem; border-bottom: 1px solid #dee2e6;" title="${run.run_id}">${runIdShort}</td>
                     <td style="padding: 0.75rem; border-bottom: 1px solid #dee2e6;" title="${run.description || ''}">${description}</td>
                     <td style="padding: 0.75rem; border-bottom: 1px solid #dee2e6;">${run.formatted_date || run.created_at}</td>
@@ -431,7 +445,7 @@
                     selectedRunId = null;
                     localStorage.removeItem('selected_run_id');
                     if (runsList.length > 0) {
-                        selectRun(runsList[0].run_id);
+                        selectRun(runsList[0].run_id, false);
                     }
                 }
             })
@@ -559,7 +573,7 @@
         });
     }
     
-    function selectRun(runId) {
+    function selectRun(runId, enterWorkspace) {
         selectedRunId = runId;
         localStorage.setItem('selected_run_id', runId);
         
@@ -577,6 +591,19 @@
                 dayToUse = availableDays[0];
             }
             
+            // Tabler spike (#796): explicit catalog click enters Overview
+            if (enterWorkspace && document.documentElement.classList.contains('rf-tabler')) {
+                const params = new URLSearchParams();
+                params.set('run_id', runId);
+                if (dayToUse) params.set('day', dayToUse);
+                params.set('ui', 'tabler');
+                if (data.description) {
+                    try { sessionStorage.setItem('rf_run_label_' + runId, data.description); } catch (e) {}
+                }
+                window.location.href = '/overview?' + params.toString();
+                return;
+            }
+
             // Update URL
             const url = new URL(window.location);
             url.searchParams.set('run_id', runId);
@@ -584,6 +611,9 @@
                 url.searchParams.set('day', dayToUse);
             } else {
                 url.searchParams.delete('day');
+            }
+            if (document.documentElement.classList.contains('rf-tabler')) {
+                url.searchParams.set('ui', 'tabler');
             }
             window.history.pushState({}, '', url);
             

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -4,7 +4,7 @@
 
 {% block content %}
 <div class="page-header">
-    <h2>Temporal Flow Analysis</h2>
+    <h2>Flow Analysis</h2>
     {% if meta %}
     {% endif %}
 </div>

--- a/frontend/templates/pages/overview.html
+++ b/frontend/templates/pages/overview.html
@@ -1,0 +1,148 @@
+{% extends "base.html" %}
+
+{% block title %}Overview{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h2>Overview</h2>
+    <p id="rf-overview-lead" class="rf-overview-lead">
+        Summary of the selected analysis run — inputs and key metrics before Segments, Density, and Flow.
+    </p>
+</div>
+
+{% include "partials/run_context.html" %}
+
+<div id="rf-overview-empty" class="card" style="display: none;">
+    <p><strong>No analysis run selected.</strong></p>
+    <p>Choose a run from the <strong>Runs</strong> menu, or open the full catalog.</p>
+    <p>
+        <a id="rf-overview-choose" class="btn btn-primary" href="/dashboard">View all runs</a>
+    </p>
+</div>
+
+<div id="rf-overview-body" style="display: none;">
+    <div id="analysis-inputs-section" class="card" style="display: none; margin-bottom: 1.25rem;">
+        <h3 style="margin-bottom: 1rem;">Analysis Inputs</h3>
+        <div id="analysis-inputs-content"></div>
+    </div>
+
+    <div id="run-detail-section" class="card" style="display: none; margin-bottom: 1.25rem;">
+        <h3 style="margin-bottom: 1rem;">Analysis Outputs</h3>
+        <div id="run-detail-content"></div>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_styles %}
+<style>
+.badge-los {
+    display: inline-block;
+    padding: 0.15rem 0.45rem;
+    border-radius: 4px;
+    font-size: 0.75rem;
+    font-weight: 700;
+    color: #fff;
+}
+.badge-A { background: {{ los_colors.get('A', '#4CAF50') }}; }
+.badge-B { background: {{ los_colors.get('B', '#8BC34A') }}; }
+.badge-C { background: {{ los_colors.get('C', '#FFC107') }}; color: #333; }
+.badge-D { background: {{ los_colors.get('D', '#FF9800') }}; }
+.badge-E { background: {{ los_colors.get('E', '#FF5722') }}; }
+.badge-F { background: {{ los_colors.get('F', '#F44336') }}; }
+.rf-overview-lead { margin: 0.35rem 0 0; color: #667382; font-size: 0.9rem; max-width: 40rem; }
+.rf-overview-meta { margin-bottom: 1rem; }
+.rf-overview-subhead { margin: 1rem 0 0.5rem; font-size: 1rem; color: #34495e; }
+</style>
+{% endblock %}
+
+{% block extra_scripts %}
+<script src="/static/js/run_overview.js?v=796h"></script>
+<script>
+(function () {
+    var tabler = document.documentElement.classList.contains('rf-tabler');
+
+    function fetchJson(url) {
+        return fetch(url, { credentials: 'same-origin' }).then(function (r) {
+            if (r.status === 401) {
+                window.location.href = '/';
+                return Promise.reject(new Error('unauthorized'));
+            }
+            if (!r.ok) return Promise.reject(new Error('HTTP ' + r.status));
+            return r.json();
+        });
+    }
+
+    function withUi(path) {
+        return tabler ? path + '?ui=tabler' : path;
+    }
+
+    function resolveRunId() {
+        var params = new URLSearchParams(window.location.search);
+        return (params.get('run_id') || localStorage.getItem('selected_run_id') || '').trim();
+    }
+
+    function resolveDay() {
+        var params = new URLSearchParams(window.location.search);
+        var fromUrl = (params.get('day') || '').trim().toLowerCase();
+        if (fromUrl) return fromUrl;
+        if (window.runflowDay && window.runflowDay.selected) return String(window.runflowDay.selected).toLowerCase();
+        return (localStorage.getItem('selected_day') || '').trim().toLowerCase();
+    }
+
+    function wireEmptyLink() {
+        var choose = document.getElementById('rf-overview-choose');
+        if (choose) choose.href = withUi('/dashboard');
+    }
+
+    function showEmpty() {
+        document.getElementById('rf-overview-empty').style.display = 'block';
+        document.getElementById('rf-overview-body').style.display = 'none';
+        wireEmptyLink();
+    }
+
+    function showBody() {
+        document.getElementById('rf-overview-empty').style.display = 'none';
+        document.getElementById('rf-overview-body').style.display = 'block';
+    }
+
+    function boot(runId) {
+        document.getElementById('rf-overview-body').dataset.booted = '1';
+        if (!runId) {
+            showEmpty();
+            return;
+        }
+        localStorage.setItem('selected_run_id', runId);
+        showBody();
+        window.RunOverview.loadRunSummary(runId, fetchJson)
+            .then(function (data) {
+                var days = data.days || [];
+                var day = resolveDay();
+                if (day && days.length && days.indexOf(day) < 0) day = days[0];
+                else if (!day && days.length) day = days[0];
+                if (day) localStorage.setItem('selected_day', day);
+                if (window.updateNavLinks) window.updateNavLinks(day, runId);
+            })
+            .catch(function () {
+                showBody();
+            });
+    }
+
+    function onReady() {
+        boot(resolveRunId());
+    }
+
+    // Prefer URL/localStorage immediately; refresh when base day/run init finishes.
+    document.addEventListener('DOMContentLoaded', onReady);
+    window.addEventListener('runflow:context-ready', function (ev) {
+        var id = (ev.detail && ev.detail.run_id) || resolveRunId();
+        if (id && document.getElementById('rf-overview-body').dataset.booted !== '1') {
+            boot(id);
+            return;
+        }
+        if (id && id !== resolveRunId()) {
+            boot(id);
+        }
+    });
+})();
+</script>
+{% endblock %}

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -18,10 +18,18 @@
 
     <div id="race-config-entry" class="page-shell page-shell--entry">
         <div class="content-card race-config-hub-shell">
-            <div class="race-config-hub-tabs" role="tablist" aria-label="Build library">
-                <button type="button" class="race-config-hub-tab active" data-hub-view="legs" role="tab" aria-selected="true">Legs</button>
-                <button type="button" class="race-config-hub-tab" data-hub-view="courses" role="tab" aria-selected="false">Courses</button>
-                <button type="button" class="race-config-hub-tab" data-hub-view="packages" role="tab" aria-selected="false">Packages</button>
+            <div class="race-config-hub-header">
+                <ul class="race-config-hub-tabs nav nav-tabs card-header-tabs" role="tablist" aria-label="Build library">
+                    <li class="nav-item" role="presentation">
+                        <button type="button" class="nav-link race-config-hub-tab active" data-hub-view="legs" role="tab" aria-selected="true">Legs</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button type="button" class="nav-link race-config-hub-tab" data-hub-view="courses" role="tab" aria-selected="false">Courses</button>
+                    </li>
+                    <li class="nav-item" role="presentation">
+                        <button type="button" class="nav-link race-config-hub-tab" data-hub-view="packages" role="tab" aria-selected="false">Packages</button>
+                    </li>
+                </ul>
             </div>
 
             <div class="race-config-hub-body">

--- a/frontend/templates/pages/reports.html
+++ b/frontend/templates/pages/reports.html
@@ -4,7 +4,10 @@
 
 {% block content %}
 <div class="page-header">
-    <h2>Generated Reports</h2>
+    <h2>Reports</h2>
+    <p style="margin: 0.35rem 0 0; color: #666; font-size: 0.9rem; max-width: 40rem;">
+        Generated Density, Flow, Locations, and finish-time wave reports (grouped by day).
+    </p>
     {% if meta %}
     {% endif %}
 </div>
@@ -12,10 +15,6 @@
 
 <!-- Reports Section -->
 <div class="card">
-    <h3 style="margin-bottom: 1rem;">Reports</h3>
-    <p style="margin-bottom: 1rem; color: #666; font-size: 0.9rem;">
-        Generated Density, Flow, Locations, and finish-time wave reports (grouped by day).
-    </p>
     <div id="reports-list">
         <p class="placeholder">Loading reports...</p>
     </div>

--- a/frontend/templates/partials/race_config_page_styles.html
+++ b/frontend/templates/partials/race_config_page_styles.html
@@ -27,21 +27,34 @@
         line-height: 1.45;
     }
 
-    /* Hub tabs: same underline pattern as package tabs (avoid global <nav> chrome) */
+    /* Hub tabs: Tabler-style card-header tabs (also used under classic) */
     .race-config-page .race-config-hub-shell {
         padding: 0;
         overflow: hidden;
     }
-    .race-config-page .race-config-hub-tabs {
-        display: flex;
-        align-items: flex-end;
-        gap: 0;
+    .race-config-page .race-config-hub-header {
         margin: 0;
-        padding: 0 0.75rem;
+        padding: 0;
         background: #f7f9fb;
         border-bottom: 1px solid #d9e0e6;
     }
+    .race-config-page .race-config-hub-tabs {
+        display: flex;
+        align-items: flex-end;
+        flex-wrap: wrap;
+        gap: 0;
+        list-style: none;
+        margin: 0;
+        padding: 0 0.75rem;
+        border: 0;
+        background: transparent;
+    }
+    .race-config-page .race-config-hub-tabs > .nav-item {
+        list-style: none;
+        margin: 0;
+    }
     .race-config-page .race-config-hub-tab {
+        display: block;
         padding: 12px 18px;
         background: transparent;
         border: 0;
@@ -53,6 +66,8 @@
         font-size: 0.95rem;
         cursor: pointer;
         border-radius: 0;
+        text-decoration: none;
+        line-height: 1.25;
     }
     .race-config-page .race-config-hub-tab.active {
         color: #243746;

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -63,11 +63,26 @@
         return (localStorage.getItem('selected_day') || '').trim().toLowerCase();
     }
 
+    function isTablerUi() {
+        return new URLSearchParams(window.location.search).get('ui') === 'tabler'
+            || document.documentElement.classList.contains('rf-tabler');
+    }
+
+    function withTablerUi(url) {
+        if (!isTablerUi()) return url;
+        var parts = String(url).split('?');
+        var path = parts[0];
+        var params = new URLSearchParams(parts[1] || '');
+        params.set('ui', 'tabler');
+        return path + '?' + params.toString();
+    }
+
     function resultsHref(path, runId, day) {
         var url = path;
         var qs = [];
         if (runId) qs.push('run_id=' + encodeURIComponent(runId));
         if (day) qs.push('day=' + encodeURIComponent(day));
+        if (isTablerUi()) qs.push('ui=tabler');
         if (qs.length) url += '?' + qs.join('&');
         return url;
     }
@@ -106,7 +121,7 @@
         var link = document.getElementById('run-context-choose-link');
         var day = resolveDay();
         if (link) {
-            link.href = day ? ('/dashboard?day=' + encodeURIComponent(day)) : '/dashboard';
+            link.href = withTablerUi(day ? ('/dashboard?day=' + encodeURIComponent(day)) : '/dashboard');
         }
         updateResultsSubnav(null, day);
         missing.style.display = 'block';
@@ -137,9 +152,9 @@
         if (reports) reports.href = resultsHref('/reports', runId, day);
         var change = document.getElementById('run-context-change-run');
         if (change) {
-            change.href = day
+            change.href = withTablerUi(day
                 ? ('/dashboard?day=' + encodeURIComponent(day) + '&run_id=' + encodeURIComponent(runId))
-                : ('/dashboard?run_id=' + encodeURIComponent(runId));
+                : ('/dashboard?run_id=' + encodeURIComponent(runId)));
         }
 
         updateResultsSubnav(runId, day);
@@ -159,7 +174,7 @@
                     pkgLink.style.display = 'none';
                     return;
                 }
-                pkgLink.href = '/config?config_id=' + encodeURIComponent(configId);
+                pkgLink.href = withTablerUi('/config?config_id=' + encodeURIComponent(configId));
                 pkgLink.style.display = '';
                 pkgLink.title = 'Open package ' + configId;
             })


### PR DESCRIPTION
## Summary
- Opt-in Tabler (`@tabler/core` MIT, CDN) horizontal admin shell via `?ui=tabler`; Classic UI unchanged
- New `/overview` Results workspace; Runs catalog vs run views; Build card-header-tabs; Flow/Reports copy polish
- Document Tabler as a third-party dependency in the Developer Guide and Frontend UI contract; CHANGELOG for v2.0.11

## Test plan
- [ ] Classic UI (`/dashboard` without `ui=tabler`) unchanged
- [ ] `/dashboard?ui=tabler` → Runs ▾ → Overview with Analysis Inputs / Outputs
- [ ] Context strip Package link; Build Legs/Courses/Packages tabs anchored in card
- [ ] Flow title is “Flow Analysis”; Reports title + lead under page header
- [ ] Classic UI exit drops `ui=tabler`

Closes #796

Made with [Cursor](https://cursor.com)