### PR TITLE
Issue #798 Phase 0: Canonical paths & deprecation ledger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Issue #798 Phase 0 — Canonical paths & deprecation ledger
+- Added `docs/architecture/canonical-paths.md` (v2 analysis, density/flow report graphs, HTTP composition, frontend/Build)
+- Added `docs/architecture/deprecation-ledger.md` with dispositions for `new_*`, shims, host paths, Classic UI, etc.
+- Stub `docs/architecture/domain-glossary.md` (Runflow vs run-density; core nouns)
+- Indexed architecture docs from `docs/README.md`
+
 ## [v2.0.11] - 2026-07-22
 
 ### Summary

--- a/docs/README.md
+++ b/docs/README.md
@@ -35,7 +35,10 @@ This documentation is organized by audience and topic for easy navigation.
 | Document | Purpose |
 |----------|---------|
 | [Developer Guide](dev-guides/developer-guide.md) | **START HERE** - Complete v2 developer guide |
-| [Frontend UI Contract](dev-guides/frontend-ui.md) | Tables, sort, actions, Results chrome (Issue #791) |
+| [Frontend UI Contract](dev-guides/frontend-ui.md) | Tables, sort, actions, Results chrome, Tabler |
+| [Canonical paths](architecture/canonical-paths.md) | Supported API → pipeline → report call graphs (Issue #798) |
+| [Deprecation ledger](architecture/deprecation-ledger.md) | Live vs remove vs rename dispositions (Issue #798) |
+| [Domain glossary](architecture/domain-glossary.md) | Runflow vocabulary (Issue #798) |
 | [Docker Development](dev-guides/docker-dev.md) | Docker development workflow |
 | [Leg Library & Corridor Pairing](dev-guides/segment-library-2027.md) | Leg platform internals (org library, recipes, pairing, sync) |
 | [Quick Reference](reference/quick-reference.md) | Variable names, terminology, standards (v2.0.2+) |

--- a/docs/architecture/canonical-paths.md
+++ b/docs/architecture/canonical-paths.md
@@ -1,0 +1,150 @@
+# Canonical execution paths (Issue #798)
+
+**Product name:** Runflow  
+**Repository name:** `run-density` (historical; density was the original scope)  
+**Audience:** maintainers and coding agents  
+**Status:** living document — update when paths change
+
+This page answers: *what is the supported path today?* Names like `new_*` or `legacy` are **not** authoritative; this ledger and the [deprecation ledger](deprecation-ledger.md) are.
+
+---
+
+## 1. Analysis (v2) — canonical
+
+```text
+UI Build (Package → Run analysis)
+  or POST /runflow/v2/analyze
+        │
+        ▼
+app/routes/v2/analyze.py
+        │
+        ▼
+app/core/v2/analysis_submit.py  (submit_v2_analysis / run_analysis_background)
+        │
+        ▼
+app/core/v2/pipeline.py
+        │
+        ├─ analysis.json (SSOT for the run)
+        ├─ density:  app/core/v2/density.py  → analyze_density_segments_v2
+        ├─ flow:     app/core/v2/flow.py     → analyze_temporal_flow_segments_v2
+        ├─ bins:     app/core/v2/bins.py     → generate_bins_v2
+        ├─ reports:  app/core/v2/reports.py  → generate_reports_per_day
+        └─ artifacts / overlaps / UI helpers as invoked by the pipeline
+```
+
+**Run storage root:** `runflow/analysis/{run_id}/` (container: `/app/runflow/...`).  
+**Do not** treat flat legacy `app/main.py` report-generation endpoints as the primary authoring path; Build → package analysis → v2 is canonical.
+
+---
+
+## 2. Density report generation — live call graph
+
+Despite “DEPRECATED” banners on `new_*` modules, **production density Markdown still flows through them**:
+
+```text
+app/core/v2/reports.py
+  generate_density_report_v2(...)
+        │
+        ▼
+app/density_report.py
+  generate_new_density_report_issue246(...)
+        │
+        ▼
+app/new_density_report.py
+  generate_new_density_report(...)
+        │
+        ├─ app/new_flagging.py          (also used from app/save_bins.py)
+        └─ app/new_density_template_engine.py
+             NewDensityTemplateEngine
+```
+
+**Disposition (Phase 6):** rename/move to a canonical package (e.g. `app/core/reports/density/`). Do **not** delete `new_*` until callers are retargeted and ledger removal gates pass.
+
+Related: bin flagging during save uses `app/new_flagging.apply_new_flagging` from `app/save_bins.py`.
+
+---
+
+## 3. Flow report generation — live call graph
+
+```text
+app/core/v2/reports.py
+  generate_flow_report_v2(...)
+        │
+        ├─ app/flow_report.generate_temporal_flow_report
+        └─ app/flow_report.export_temporal_flow_csv
+
+Core interval/overlap math:
+  app/core/flow/flow.py   (large module; Phase 9 split candidates)
+  orchestrated via app/core/v2/flow.py
+```
+
+Issue #600: **Flow.csv** is the operator artifact; Flow.md generation is deprecated.
+
+---
+
+## 4. HTTP composition root
+
+| Concern | Canonical module | Notes |
+|---------|------------------|--------|
+| App entry (local) | `app/main.py` | Full UI + APIs |
+| App entry (cloud skinny) | `app/cloud_app.py` | Read-oriented subset |
+| v2 analyze | `app/routes/v2/analyze.py` | Prefix `/runflow/v2` |
+| Reports list/download UI API | `app/routes/api_reports.py` | Used by frontend |
+| Empty `/reports` shim | `app/routes/reports.py` | **Remove in Phase 1** — no routes |
+| Flow API | Prefer `app/api/flow.py` | `app/routes/api_flow.py` is wildcard re-export (**Phase 1**) |
+| Bidirectional API | Prefer `app/api/bidirectional.py` | `app/routes/api_bidirectional.py` is wildcard re-export (**Phase 1**) |
+| Build / packages | `app/routes/api_config_packages.py` | Large surface; org legs + packages |
+| Results UI pages | `app/routes/ui.py` | Jinja pages |
+
+---
+
+## 5. Frontend chrome
+
+| Path | Status |
+|------|--------|
+| Classic header/nav in `base.html` | **To be removed** — Tabler-only cutover (Phase 7) |
+| Tabler shell (`?ui=tabler` today) | **Adopt as sole UI** (Phase 7 makes default; drop Classic) |
+| Results pages | Shared templates; chrome from `base.html` + `run_context.html` |
+| Build hub | `race_configuration.html` + map/recipe JS modules |
+
+Until Phase 7, preview remains opt-in via `?ui=tabler` (Issue #796 / v2.0.11).
+
+---
+
+## 6. Configuration authoring
+
+```text
+Build UI (Legs / Courses / Packages)
+        │
+        ▼
+app/routes/api_config_packages.py
+        │
+        ▼
+app/core/config_package/*   (legs, saved courses, org library, recipes, analysis launch)
+        │
+        ▼
+Package on disk under runflow/config/...
+        │
+        ▼
+Run analysis → v2 pipeline (section 1)
+```
+
+Legacy course-mapping routes may still exist for compatibility; Race Configuration / Build is the supported authoring UX.
+
+---
+
+## 7. What is *not* canonical
+
+- Relying on module names containing `new_`, `legacy`, or `old` to decide delete vs keep.
+- Fabricated report metadata (`window_s = 30`, `bin_km = 0.2` TODOs in `new_density_report.py`) — fix in Phase 5.
+- Host-specific absolute paths (`/Users/.../runflow`) duplicated in code — Phase 4.
+- Multiple conflicting start-time ranges in docs/tests vs validators — Phase 2.
+
+---
+
+## 8. Related docs
+
+- [Deprecation ledger](deprecation-ledger.md) — dispositions and removal gates  
+- [Domain glossary](domain-glossary.md) — Phase 3 (naming)  
+- [Frontend UI contract](../dev-guides/frontend-ui.md)  
+- [Developer guide](../dev-guides/developer-guide.md)

--- a/docs/architecture/deprecation-ledger.md
+++ b/docs/architecture/deprecation-ledger.md
@@ -1,0 +1,60 @@
+# Deprecation ledger (Issue #798)
+
+Track modules that look transitional or dead. **Do not delete from name alone.**  
+Update this file in the same PR that changes disposition or removes a module.
+
+**Legend**
+
+| Disposition | Meaning |
+|-------------|---------|
+| **rename** | Live; name/location wrong — move/rename (do not delete first) |
+| **remove** | Proven unused after gates — delete in listed phase |
+| **shim** | Temporary re-export; dated removal |
+| **keep** | Supported as-is |
+| **investigate** | Callers or external use unclear |
+
+**Removal gates (all required for `remove`):**
+
+1. No internal callers after canonical imports  
+2. No registered route / background entry  
+3. No documented external compatibility promise (or shim expired)  
+4. Route/artifact contract tests pass  
+5. CHANGELOG + this ledger updated  
+
+---
+
+## Active ledger
+
+| Module / symbol | Status today | Callers (summary) | Disposition | Target phase | Owner notes | Removal version |
+|-----------------|--------------|-------------------|-------------|--------------|-------------|-----------------|
+| `app/new_density_report.py` | **LIVE** (banner says deprecated) | `density_report.generate_new_density_report_issue246` → v2 `reports.generate_density_report_v2` | **rename** → `app/core/reports/density/` (name TBD) | Phase 6 | Keep until rename + provenance (Phase 5) | After Phase 6 + one release if forwarding |
+| `app/new_density_template_engine.py` | **LIVE** | `new_density_report` | **rename** with density report package | Phase 6 | Drop `New` prefix | with above |
+| `app/new_flagging.py` | **LIVE** | `new_density_report`, `save_bins.apply_new_flagging` | **rename** | Phase 6 | Rulebook flagging is canonical behavior | with above |
+| `app/density_report.py` | **LIVE** façade + legacy helpers | v2 reports, bins, `main.py` legacy endpoints | **keep** then thin after Phase 6 | Phase 6 / 9 | Large module; soft LOC split later | — |
+| `app/flow_report.py` | **LIVE** | v2 `generate_flow_report_v2` | **keep** | — | Flow.md path deprecated; CSV kept | — |
+| `app/routes/reports.py` | Empty router, still registered | `main.py` `include_router` | **remove** | Phase 1 | Frontend uses `api_reports` | with Phase 1 merge |
+| `app/routes/api_flow.py` | Wildcard re-export | `main.py` | **remove** shim; import `app.api.flow` | Phase 1 | Add `noqa` only if temporary | Phase 1 |
+| `app/routes/api_bidirectional.py` | Wildcard re-export | `main.py` | **remove** shim; import `app.api.bidirectional` | Phase 1 | | Phase 1 |
+| `app/core/flow/flow.py` `_ShardWriter` | Unused (Parquet migration) | definitions only | **remove** | Phase 1 | Also `_write_index_csv`, `_write_topk_csv` | Phase 1 |
+| `app/utils/constants.py` `EVENT_DURATION_MINUTES` | Deprecated dict; capitalized dupes | v1 compatibility risk | **investigate** → remove or v1-only adapter | Phase 8 | Confirm v1 endpoint retirement | TBD |
+| `HOTSPOT_SEGMENTS` / map center constants | Sample-race / city defaults | bin generation / maps | **rename/move** to template data | Phase 8 | Not universal domain law | — |
+| Classic UI chrome (`base.html` else branch) | Dual chrome with Tabler | all pages without `ui=tabler` | **remove** | Phase 7 | Product: Tabler-only; Git for rollback | Phase 7 |
+| Course-mapping legacy DOM (`course-legacy-*`, hidden recipes) | Partially hidden | `course_mapping.js`, `segment_recipes.js` | **investigate** | Phase 9 | Smoke preferred Build workflow first | TBD |
+| Host path `/Users/jthompson/Documents/runflow` | Duplicated rewrite sites | constants, `analysis_submit`, `ui.py`, scripts, compose | **remove** literals | Phase 4 | Typed settings + PathMapper | Phase 4 |
+| Hardcoded `window_s=30` / `bin_km=0.2` in `new_density_report` | Fabricated metadata | density MD context | **remove** fallback or fail-fast | Phase 5 | Provenance from analysis.json | Phase 5 |
+| Start-time docs/tests claiming 0–1439 | Conflict with live 300–1200 | `models.Event` docstring, `test_hardcoded_values` | **fix** to one contract | Phase 2 | Operating hours 300–1200 is current product rule | Phase 2 |
+
+---
+
+## Completed
+
+_None yet — Phase 0 establishes this ledger._
+
+---
+
+## How to use (agents)
+
+1. Before deleting anything named `new_` / `legacy` / `old`, read this table.  
+2. Prefer **rename while live** for reporting stacks.  
+3. Record the PR that changes a row’s disposition.  
+4. See [canonical-paths.md](canonical-paths.md) for the supported call graphs.

--- a/docs/architecture/domain-glossary.md
+++ b/docs/architecture/domain-glossary.md
@@ -1,0 +1,40 @@
+# Domain glossary (Issue #798 Phase 3 stub)
+
+**Status:** stub published in Phase 0 so agents have a single vocabulary target.  
+**Phase 3** expands field maps (API / CSV / internal / frontend) and enforcement.
+
+## Product vs repository
+
+| Name | Use |
+|------|-----|
+| **Runflow** | Product / UX / runtime paths (`runflow/`, `/runflow/v2`) |
+| **run-density** | GitHub repository name (historical). Do not introduce new runtime identifiers with this name. |
+
+## Core nouns
+
+| Term | Meaning |
+|------|---------|
+| **Course** | Named frozen distance snapshot (e.g. 10K University) composed from legs |
+| **Leg** | Reusable route unit in the org (or package) library; may appear in multiple courses/recipes |
+| **Segment** | Analysis interval along a course after export/build (often `seg_id` in artifacts) |
+| **Zone** | Operational classification on a location after package build |
+| **Location** | Point of interest on a leg/course (`loc_id` crew-facing; stable `location_key` internal) |
+| **Configuration package** | Race package: assigned courses, runners, resources, analysis launch |
+| **Run** | One analysis execution under `runflow/analysis/{run_id}/` |
+
+## Units (prefer explicit suffixes in internal code)
+
+| Prefer | Avoid as ambiguous |
+|--------|--------------------|
+| `window_seconds` | bare `window_s` at core boundaries (adapters may alias) |
+| `event_duration_minutes` | bare `event_duration` when unit unclear |
+| `step_km` / `bin_km` | mix without documenting which is spatial resolution |
+| `start_time` minutes after midnight | document range once (Phase 2: **300–1200** operating hours) |
+
+## ID pairs (not always synonyms)
+
+- **leg_id** — library route identity  
+- **seg_id** / **segment_id** — analysis segment identity (may derive from legs after build)  
+- **loc_id** vs **location_id** — prefer `loc_id` in crew-facing CSV; document aliases at adapters  
+
+Full alias tables land in Phase 3.


### PR DESCRIPTION
## Summary
- Add architecture docs: canonical execution paths, deprecation ledger, domain glossary stub
- Index from `docs/README.md`; CHANGELOG Unreleased note
- Encodes sprint decisions: Tabler-only upcoming, rename-live `new_*`, Runflow naming

## Test plan
- [ ] Links from docs/README open correctly
- [ ] Ledger rows match known callers for `new_density_report` / empty reports router

Part of #798

Made with [Cursor](https://cursor.com)