### PR TITLE
Issue #798 Phase 2: canonical start-time contract

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #798 Phase 2 — Canonical start-time contract
+- Added `app/core/v2/start_time.py` (300–1200 operating hours, 05:00–20:00)
+- Wired validators / Pydantic models / package analysis / `Event` to the shared helper
+- Fixed tests that incorrectly accepted 0–1439; regression: `tests/unit/test_issue798_phase2_start_time.py`
+
 ### Issue #798 Phase 1 — Dead routers & unused flow audit helpers
 - Compose flow/bidirectional routers from `app.api.*` (deleted wildcard shims)
 - Removed empty `app/routes/reports.py` registration

--- a/app/api/models/v2.py
+++ b/app/api/models/v2.py
@@ -10,12 +10,19 @@ Phase 2: API Route (Issue #496)
 from typing import List, Optional, Dict, Any
 from pydantic import BaseModel, Field, field_validator
 
+from app.core.v2.start_time import (
+    START_TIME_MAX_MINUTES,
+    START_TIME_MIN_MINUTES,
+    START_TIME_RANGE_DESCRIPTION,
+)
+
 
 class V2EventRequest(BaseModel):
     """
     Event request model matching api_v2.md event structure.
     
     Issue #553: Extended to include event_duration_minutes and updated start_time range.
+    Issue #798 Phase 2: start_time bounds from app.core.v2.start_time.
     
     Attributes:
         name: Event name (lowercase, e.g., "full", "half", "10k")
@@ -27,7 +34,12 @@ class V2EventRequest(BaseModel):
     """
     name: str = Field(..., description="Event name (lowercase)")
     day: str = Field(..., description="Day code (fri, sat, sun, mon)")
-    start_time: int = Field(..., ge=300, le=1200, description="Start time in minutes after midnight (300-1200)")
+    start_time: int = Field(
+        ...,
+        ge=START_TIME_MIN_MINUTES,
+        le=START_TIME_MAX_MINUTES,
+        description=START_TIME_RANGE_DESCRIPTION,
+    )
     event_duration_minutes: int = Field(..., ge=1, le=500, description="Event duration in minutes (1-500)")
     runners_file: str = Field(..., description="Name of runners CSV file")
     gpx_file: str = Field(..., description="Name of GPX file")

--- a/app/core/config_package/package_analysis.py
+++ b/app/core/config_package/package_analysis.py
@@ -12,6 +12,12 @@ from app.core.config_package.storage import (
     resolve_config_package_path,
     validate_config_id,
 )
+from app.core.v2.start_time import (
+    START_TIME_MAX_MINUTES,
+    START_TIME_MIN_MINUTES,
+    StartTimeValidationError,
+    validate_start_minute,
+)
 
 # UI-only suggestions when opening the run-analysis dialog (not applied server-side).
 SUGGESTED_EVENT_SCHEDULE: Dict[str, Dict[str, int]] = {
@@ -132,8 +138,13 @@ def build_package_analyze_payload(
             raise ValueError(f"Event '{name}' requires start_time and event_duration_minutes")
         start_time = int(start_time)
         duration = int(duration)
-        if start_time < 300 or start_time > 1200:
-            raise ValueError(f"Event '{name}' start_time must be between 300 and 1200 minutes")
+        try:
+            start_time = validate_start_minute(start_time, event_name=name)
+        except StartTimeValidationError as e:
+            raise ValueError(
+                f"Event '{name}' start_time must be between "
+                f"{START_TIME_MIN_MINUTES} and {START_TIME_MAX_MINUTES} minutes"
+            ) from e
         if duration < 1 or duration > 500:
             raise ValueError(
                 f"Event '{name}' event_duration_minutes must be between 1 and 500"

--- a/app/core/v2/analysis_config.py
+++ b/app/core/v2/analysis_config.py
@@ -9,12 +9,20 @@ Phase 2: analysis.json Creation (Single Source of Truth)
 """
 
 import json
-import os
-from pathlib import Path
-from typing import Dict, List, Any, Optional
-from datetime import datetime, timezone
-import pandas as pd
 import logging
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pandas as pd
+
+from app.core.v2.start_time import (
+    START_TIME_MAX_MINUTES,
+    START_TIME_MIN_MINUTES,
+    StartTimeValidationError,
+    validate_start_minute,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -481,11 +489,13 @@ def get_start_time(
                     raise ValueError(
                         f"Event '{event_name}' found in analysis.json but missing 'start_time' field"
                     )
-                if not isinstance(start_time, int) or not (300 <= start_time <= 1200):
+                try:
+                    return validate_start_minute(start_time, event_name=event_name)
+                except StartTimeValidationError as e:
                     raise ValueError(
-                        f"Event '{event_name}' has invalid start_time: {start_time} (must be integer 300-1200)"
-                    )
-                return start_time
+                        f"Event '{event_name}' has invalid start_time: {start_time} "
+                        f"(must be integer {START_TIME_MIN_MINUTES}-{START_TIME_MAX_MINUTES})"
+                    ) from e
         
         # Event not found - fail fast per Issue #553 requirements
         available_events = [e.get("name", "unknown") for e in events]
@@ -495,12 +505,13 @@ def get_start_time(
         )
     
     # Validate start_time
-    if not isinstance(start_time, int) or not (300 <= start_time <= 1200):
+    try:
+        return validate_start_minute(start_time, event_name=event_name)
+    except StartTimeValidationError as e:
         raise ValueError(
-            f"Event '{event_name}' has invalid start_time: {start_time} (must be integer 300-1200)"
-        )
-    
-    return start_time
+            f"Event '{event_name}' has invalid start_time: {start_time} "
+            f"(must be integer {START_TIME_MIN_MINUTES}-{START_TIME_MAX_MINUTES})"
+        ) from e
 
 
 def get_all_start_times(

--- a/app/core/v2/models.py
+++ b/app/core/v2/models.py
@@ -11,6 +11,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import List, Optional
 
+from app.core.v2.start_time import validate_start_minute
+
 
 class Day(str, Enum):
     """
@@ -93,7 +95,7 @@ class Event:
     Attributes:
         name: Event name (normalized to lowercase, e.g., "full", "half", "10k")
         day: Day enumeration (fri, sat, sun, mon)
-        start_time: Start time in minutes after midnight (0-1439)
+        start_time: Start time in minutes after midnight (300-1200, 05:00–20:00)
         gpx_file: Path to GPX file defining this event's course
         runners_file: Path to CSV file containing runners for this event
         seg_ids: List of segment IDs used by this event (references, not copies)
@@ -101,15 +103,16 @@ class Event:
     """
     name: str
     day: Day
-    start_time: int  # minutes after midnight (0-1439)
+    start_time: int  # minutes after midnight (300-1200 operating hours; see app.core.v2.start_time)
     gpx_file: str
     runners_file: str
     seg_ids: List[str] = field(default_factory=list)
     runners: List[Runner] = field(default_factory=list)
     
     def __post_init__(self):
-        """Normalize event name to lowercase."""
+        """Normalize event name to lowercase; enforce canonical start_time range."""
         self.name = self.name.lower()
+        self.start_time = validate_start_minute(self.start_time, event_name=self.name)
     
     def __hash__(self) -> int:
         """Make Event hashable for use in sets/dicts."""

--- a/app/core/v2/start_time.py
+++ b/app/core/v2/start_time.py
@@ -1,0 +1,61 @@
+"""
+Canonical event start-time contract (Issue #798 Phase 2).
+
+Product rule: race operating hours — minutes after midnight, inclusive.
+  300  = 05:00
+  1200 = 20:00
+
+Use these constants and helpers at every API / config / analysis boundary.
+Do not reintroduce a parallel 0–1439 "any minute of day" range without updating
+docs/architecture/domain-glossary.md and this module together.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# Inclusive operating-hours window (minutes after midnight)
+START_TIME_MIN_MINUTES = 300
+START_TIME_MAX_MINUTES = 1200
+
+START_TIME_RANGE_DESCRIPTION = (
+    f"Start time in minutes after midnight "
+    f"({START_TIME_MIN_MINUTES}-{START_TIME_MAX_MINUTES}, 05:00–20:00)"
+)
+
+
+class StartTimeValidationError(ValueError):
+    """Invalid start_time under the canonical operating-hours contract."""
+
+    def __init__(self, message: str, *, code: int = 400):
+        super().__init__(message)
+        self.message = message
+        self.code = code
+
+
+def validate_start_minute(start_time: Any, *, event_name: str = "unknown") -> int:
+    """
+    Validate and return start_time as int in [START_TIME_MIN_MINUTES, START_TIME_MAX_MINUTES].
+
+    Raises:
+        StartTimeValidationError: missing, non-int, or out of range
+    """
+    if start_time is None:
+        raise StartTimeValidationError(
+            f"Missing required field 'start_time' for event '{event_name}'",
+            code=400,
+        )
+    if isinstance(start_time, bool) or not isinstance(start_time, int):
+        raise StartTimeValidationError(
+            f"start_time must be an integer for event '{event_name}', "
+            f"got {type(start_time).__name__}",
+            code=400,
+        )
+    if start_time < START_TIME_MIN_MINUTES or start_time > START_TIME_MAX_MINUTES:
+        raise StartTimeValidationError(
+            f"start_time {start_time} for event '{event_name}' must be between "
+            f"{START_TIME_MIN_MINUTES} and {START_TIME_MAX_MINUTES} "
+            f"(5:00 AM to 8:00 PM)",
+            code=400,
+        )
+    return start_time

--- a/app/core/v2/validation.py
+++ b/app/core/v2/validation.py
@@ -13,6 +13,7 @@ from typing import Dict, List, Optional, Tuple, Any
 import pandas as pd
 
 from app.core.v2.models import Day, Event
+from app.core.v2.start_time import StartTimeValidationError, validate_start_minute
 
 
 class ValidationError(Exception):
@@ -54,37 +55,16 @@ def validate_day_codes(events: List[Dict[str, Any]]) -> None:
 
 def validate_start_times(events: List[Dict[str, Any]]) -> None:
     """
-    Validate start_time is integer between 300 and 1200 (inclusive).
-    
-    Issue #553: Updated range to 300-1200 (5:00 AM to 8:00 PM).
-    
-    Args:
-        events: List of event dictionaries from API payload
-        
-    Raises:
-        ValidationError (400): If any start_time is out of range or not an integer
+    Validate start_time is integer in the canonical operating-hours range.
+
+    Issue #553 / #798 Phase 2: single contract via app.core.v2.start_time.
     """
     for event in events:
-        start_time = event.get("start_time")
         event_name = event.get("name", "unknown")
-        
-        if start_time is None:
-            raise ValidationError(
-                f"Missing required field 'start_time' for event '{event_name}'",
-                code=400
-            )
-        
-        if not isinstance(start_time, int):
-            raise ValidationError(
-                f"start_time must be an integer for event '{event_name}', got {type(start_time).__name__}",
-                code=400
-            )
-        
-        if start_time < 300 or start_time > 1200:
-            raise ValidationError(
-                f"start_time {start_time} for event '{event_name}' must be between 300 and 1200 (5:00 AM to 8:00 PM)",
-                code=400
-            )
+        try:
+            validate_start_minute(event.get("start_time"), event_name=event_name)
+        except StartTimeValidationError as e:
+            raise ValidationError(e.message, code=e.code) from e
 
 
 def validate_event_names(events: List[Dict[str, Any]]) -> None:

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -13,6 +13,7 @@ from fastapi import APIRouter, BackgroundTasks, File, Form, HTTPException, Query
 from fastapi.responses import JSONResponse, Response
 from pydantic import BaseModel, Field
 
+from app.core.v2.start_time import START_TIME_MAX_MINUTES, START_TIME_MIN_MINUTES
 from app.core.config_package import (
     create_config_package,
     delete_config_package,
@@ -198,7 +199,7 @@ class AssignPackageCoursesRequest(BaseModel):
 
 class RunPackageAnalysisEventSchedule(BaseModel):
     name: str = Field(..., min_length=1)
-    start_time: int = Field(..., ge=300, le=1200)
+    start_time: int = Field(..., ge=START_TIME_MIN_MINUTES, le=START_TIME_MAX_MINUTES)
     event_duration_minutes: int = Field(..., ge=1, le=500)
     day: Optional[str] = Field(None, min_length=3, max_length=3)
 

--- a/docs/architecture/canonical-paths.md
+++ b/docs/architecture/canonical-paths.md
@@ -138,7 +138,7 @@ Legacy course-mapping routes may still exist for compatibility; Race Configurati
 - Relying on module names containing `new_`, `legacy`, or `old` to decide delete vs keep.
 - Fabricated report metadata (`window_s = 30`, `bin_km = 0.2` TODOs in `new_density_report.py`) — fix in Phase 5.
 - Host-specific absolute paths (`/Users/.../runflow`) duplicated in code — Phase 4.
-- Multiple conflicting start-time ranges in docs/tests vs validators — Phase 2.
+- Start-time contract unified in `app.core.v2.start_time` (300–1200) — Phase 2 ✓.
 
 ---
 

--- a/docs/architecture/deprecation-ledger.md
+++ b/docs/architecture/deprecation-ledger.md
@@ -42,7 +42,7 @@ Update this file in the same PR that changes disposition or removes a module.
 | Course-mapping legacy DOM (`course-legacy-*`, hidden recipes) | Partially hidden | `course_mapping.js`, `segment_recipes.js` | **investigate** | Phase 9 | Smoke preferred Build workflow first | TBD |
 | Host path `/Users/jthompson/Documents/runflow` | Duplicated rewrite sites | constants, `analysis_submit`, `ui.py`, scripts, compose | **remove** literals | Phase 4 | Typed settings + PathMapper | Phase 4 |
 | Hardcoded `window_s=30` / `bin_km=0.2` in `new_density_report` | Fabricated metadata | density MD context | **remove** fallback or fail-fast | Phase 5 | Provenance from analysis.json | Phase 5 |
-| Start-time docs/tests claiming 0–1439 | Conflict with live 300–1200 | `models.Event` docstring, `test_hardcoded_values` | **fix** to one contract | Phase 2 | Operating hours 300–1200 is current product rule | Phase 2 |
+| Start-time docs/tests claiming 0–1439 | ~~Conflict~~ **FIXED** | `app.core.v2.start_time` is SSOT | **keep** contract | Phase 2 ✓ | Operating hours 300–1200 | — |
 
 ---
 
@@ -50,6 +50,7 @@ Update this file in the same PR that changes disposition or removes a module.
 
 | Module / symbol | Removed in | Notes |
 |-----------------|------------|-------|
+| Conflicting 0–1439 start-time docs/tests | Phase 2 | Canonical module `app.core.v2.start_time` (300–1200) |
 | `app/routes/reports.py` | Phase 1 | Empty `/reports` router |
 | `app/routes/api_flow.py` | Phase 1 | Wildcard shim → `app.api.flow` |
 | `app/routes/api_bidirectional.py` | Phase 1 | Wildcard shim → `app.api.bidirectional` |

--- a/docs/architecture/domain-glossary.md
+++ b/docs/architecture/domain-glossary.md
@@ -29,7 +29,7 @@
 | `window_seconds` | bare `window_s` at core boundaries (adapters may alias) |
 | `event_duration_minutes` | bare `event_duration` when unit unclear |
 | `step_km` / `bin_km` | mix without documenting which is spatial resolution |
-| `start_time` minutes after midnight | document range once (Phase 2: **300–1200** operating hours) |
+| `start_time` | Minutes after midnight; **canonical range 300–1200** (05:00–20:00). SSOT: `app.core.v2.start_time` |
 
 ## ID pairs (not always synonyms)
 

--- a/tests/unit/test_hardcoded_values.py
+++ b/tests/unit/test_hardcoded_values.py
@@ -72,18 +72,26 @@ class TestStartTimeValidation:
         assert exc_info.value.code == 400
         assert "start_time" in exc_info.value.message.lower()
     
-    def test_validate_start_times_accepts_arbitrary_times(self):
-        """Test that arbitrary start times are accepted."""
+    def test_validate_start_times_accepts_operating_hours(self):
+        """Test that start times within 300–1200 (05:00–20:00) are accepted."""
         events = [
-            {"name": "custom1", "day": "sat", "start_time": 300},  # 05:00
+            {"name": "custom1", "day": "sat", "start_time": 300},  # 05:00 boundary
             {"name": "custom2", "day": "sat", "start_time": 900},  # 15:00
-            {"name": "custom3", "day": "sun", "start_time": 0},    # 00:00
-            {"name": "custom4", "day": "sun", "start_time": 1439}, # 23:59
+            {"name": "custom3", "day": "sun", "start_time": 1200},  # 20:00 boundary
         ]
-        
+
         # Should not raise
         validate_start_times(events)
-    
+
+    def test_validate_start_times_rejects_outside_operating_hours(self):
+        """Test that times outside 300–1200 are rejected (incl. midnight / end of day)."""
+        for bad in (-1, 0, 299, 1201, 1439, 1440):
+            events = [{"name": "invalid", "day": "sun", "start_time": bad}]
+            with pytest.raises(ValidationError) as exc_info:
+                validate_start_times(events)
+            assert exc_info.value.code == 400
+            assert "300" in exc_info.value.message and "1200" in exc_info.value.message
+
     def test_validate_start_times_rejects_invalid_range(self):
         """Test that out-of-range start times are rejected."""
         events = [

--- a/tests/unit/test_issue798_phase2_start_time.py
+++ b/tests/unit/test_issue798_phase2_start_time.py
@@ -1,0 +1,55 @@
+"""
+Issue #798 Phase 2: canonical start-time contract (300–1200 operating hours).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from app.core.v2.models import Day, Event
+from app.core.v2.start_time import (
+    START_TIME_MAX_MINUTES,
+    START_TIME_MIN_MINUTES,
+    StartTimeValidationError,
+    validate_start_minute,
+)
+from app.core.v2.validation import ValidationError, validate_start_times
+
+
+def test_canonical_bounds():
+    assert START_TIME_MIN_MINUTES == 300
+    assert START_TIME_MAX_MINUTES == 1200
+
+
+@pytest.mark.parametrize("minute", [300, 420, 900, 1200])
+def test_validate_start_minute_accepts_boundaries(minute):
+    assert validate_start_minute(minute, event_name="full") == minute
+
+
+@pytest.mark.parametrize("minute", [-1, 0, 299, 1201, 1439, 1440])
+def test_validate_start_minute_rejects_outside_operating_hours(minute):
+    with pytest.raises(StartTimeValidationError) as exc_info:
+        validate_start_minute(minute, event_name="full")
+    assert exc_info.value.code == 400
+
+
+def test_event_post_init_enforces_contract():
+    Event(name="full", day=Day.SUN, start_time=420, gpx_file="a.gpx", runners_file="a.csv")
+    with pytest.raises(StartTimeValidationError):
+        Event(name="full", day=Day.SUN, start_time=0, gpx_file="a.gpx", runners_file="a.csv")
+
+
+def test_validate_start_times_wraps_as_validation_error():
+    with pytest.raises(ValidationError) as exc_info:
+        validate_start_times([{"name": "full", "start_time": 299}])
+    assert exc_info.value.code == 400
+
+
+def test_api_model_and_package_schedule_use_same_bounds():
+    from app.api.models.v2 import V2EventRequest
+    from app.routes.api_config_packages import RunPackageAnalysisEventSchedule
+
+    for model in (V2EventRequest, RunPackageAnalysisEventSchedule):
+        schema = model.model_json_schema()["properties"]["start_time"]
+        assert schema["minimum"] == START_TIME_MIN_MINUTES
+        assert schema["maximum"] == START_TIME_MAX_MINUTES

--- a/tests/unit/test_ssot_failfast.py
+++ b/tests/unit/test_ssot_failfast.py
@@ -52,8 +52,8 @@ def test_flow_segments_require_flow_type() -> None:
             "direction": ["uni"],
         }
     )
-    event_a = Event(name="full", day=Day.SUN, start_time=0, gpx_file="full.gpx", runners_file="full.csv")
-    event_b = Event(name="half", day=Day.SUN, start_time=0, gpx_file="half.gpx", runners_file="half.csv")
+    event_a = Event(name="full", day=Day.SUN, start_time=420, gpx_file="full.gpx", runners_file="full.csv")
+    event_b = Event(name="half", day=Day.SUN, start_time=440, gpx_file="half.gpx", runners_file="half.csv")
 
     with pytest.raises(ValueError, match="flow_type is required"):
         create_flow_segments_from_flow_csv(flow_rows, event_a, event_b, segments_df)


### PR DESCRIPTION
## Summary
- Add `app.core.v2.start_time` as the SSOT for event start times (300–1200 / 05:00–20:00)
- Wire `Event`, v2 validation, API/package Pydantic models, and analysis config helpers to that contract
- Fix tests that incorrectly accepted 0–1439; add Phase 2 regression coverage

Closes nothing yet — continues [Issue #798](https://github.com/thomjeff/run-density/issues/798).

## Test plan
- [x] `pytest tests/unit/test_issue798_phase2_start_time.py tests/unit/test_hardcoded_values.py::TestStartTimeValidation tests/unit/test_validation.py::TestValidateStartTimes tests/unit/test_ssot_failfast.py::test_flow_segments_require_flow_type`
- [ ] Spot-check analyze / package run-analysis rejects start_time outside 300–1200


Made with [Cursor](https://cursor.com)