### PR TITLE
Issue #798 Phase 3: domain glossary & naming alignment

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #798 Phase 3 — Domain glossary & naming alignment
+- Expanded `docs/architecture/domain-glossary.md` with field alias map and agent guidance
+- FastAPI app title set to **Runflow** (stop new `run-density` runtime identity)
+- Light regression: `tests/unit/test_issue798_phase3_glossary.py`
+
 ### Issue #798 Phase 2 — Canonical start-time contract
 - Added `app/core/v2/start_time.py` (300–1200 operating hours, 05:00–20:00)
 - Wired validators / Pydantic models / package analysis / `Event` to the shared helper

--- a/app/main.py
+++ b/app/main.py
@@ -113,7 +113,7 @@ class FlowAuditRequest(BaseModel):
 
 # Issue #550: Dynamic version from git tag with fallback
 APP_VERSION = get_version()
-app = FastAPI(title="run-density", version=APP_VERSION)
+app = FastAPI(title="Runflow", version=APP_VERSION)
 GIT_SHA = os.getenv("GIT_SHA", "local")
 BUILD_AT = os.getenv("BUILD_AT", datetime.datetime.now(datetime.timezone.utc).isoformat() + "Z")
 

--- a/docs/architecture/deprecation-ledger.md
+++ b/docs/architecture/deprecation-ledger.md
@@ -51,6 +51,7 @@ Update this file in the same PR that changes disposition or removes a module.
 | Module / symbol | Removed in | Notes |
 |-----------------|------------|-------|
 | Conflicting 0–1439 start-time docs/tests | Phase 2 | Canonical module `app.core.v2.start_time` (300–1200) |
+| Domain glossary stub | Phase 3 | Expanded field alias map + agent guidance; FastAPI title → Runflow |
 | `app/routes/reports.py` | Phase 1 | Empty `/reports` router |
 | `app/routes/api_flow.py` | Phase 1 | Wildcard shim → `app.api.flow` |
 | `app/routes/api_bidirectional.py` | Phase 1 | Wildcard shim → `app.api.bidirectional` |

--- a/docs/architecture/domain-glossary.md
+++ b/docs/architecture/domain-glossary.md
@@ -1,14 +1,14 @@
-# Domain glossary (Issue #798 Phase 3 stub)
+# Domain glossary (Issue #798 Phase 3)
 
-**Status:** stub published in Phase 0 so agents have a single vocabulary target.  
-**Phase 3** expands field maps (API / CSV / internal / frontend) and enforcement.
+**Status:** canonical vocabulary for agents and humans.  
+**Product rule:** prefer these names in new code; keep legacy wire names only at adapters.
 
 ## Product vs repository
 
 | Name | Use |
 |------|-----|
-| **Runflow** | Product / UX / runtime paths (`runflow/`, `/runflow/v2`) |
-| **run-density** | GitHub repository name (historical). Do not introduce new runtime identifiers with this name. |
+| **Runflow** | Product / UX / runtime paths (`runflow/`, `/runflow/v2`), env `RUNFLOW_*`, UI events (`runflow:*`) |
+| **run-density** | GitHub repository name (historical). **Do not introduce new runtime identifiers with this name.** Existing Docker / Cloud Run / older GCS labels may still say `run-density` — treat as debt, rename opportunistically. |
 
 ## Core nouns
 
@@ -16,25 +16,55 @@
 |------|---------|
 | **Course** | Named frozen distance snapshot (e.g. 10K University) composed from legs |
 | **Leg** | Reusable route unit in the org (or package) library; may appear in multiple courses/recipes |
-| **Segment** | Analysis interval along a course after export/build (often `seg_id` in artifacts) |
+| **Segment** | Analysis interval along a course after export/build (artifact key: `seg_id`) |
 | **Zone** | Operational classification on a location after package build |
-| **Location** | Point of interest on a leg/course (`loc_id` crew-facing; stable `location_key` internal) |
-| **Configuration package** | Race package: assigned courses, runners, resources, analysis launch |
+| **Location** | Point of interest on a leg/course (`loc_id` crew-facing; stable `location_key` for authoring) |
+| **Configuration package** | Race package: assigned courses, runners, resources, analysis launch (`runflow/config/{config_id}/`) |
 | **Run** | One analysis execution under `runflow/analysis/{run_id}/` |
 
 ## Units (prefer explicit suffixes in internal code)
 
 | Prefer | Avoid as ambiguous |
 |--------|--------------------|
-| `window_seconds` | bare `window_s` at core boundaries (adapters may alias) |
-| `event_duration_minutes` | bare `event_duration` when unit unclear |
-| `step_km` / `bin_km` | mix without documenting which is spatial resolution |
+| `window_seconds` / `dt_seconds` (core) | bare `window_s` at **new** core APIs (adapters may still emit `window_s` / `effective_window_s`) |
+| `event_duration_minutes` | bare `event_duration` on API / analysis.json |
+| `step_km` (config) | inventing a third spatial name; `bin_km` / `bin_size_km` are boundary aliases of step |
 | `start_time` | Minutes after midnight; **canonical range 300–1200** (05:00–20:00). SSOT: `app.core.v2.start_time` |
 
-## ID pairs (not always synonyms)
+## ID pairs (not synonyms)
 
-- **leg_id** — library route identity  
-- **seg_id** / **segment_id** — analysis segment identity (may derive from legs after build)  
-- **loc_id** vs **location_id** — prefer `loc_id` in crew-facing CSV; document aliases at adapters  
+| Identity | Meaning | Do not confuse with |
+|----------|---------|---------------------|
+| `leg_id` | Library route identity (legacy read: `chunk_id`) | `seg_id` — one leg can produce many analysis segments |
+| `seg_id` | Analysis segment identity in CSV / flow / audit | `segment_id` — bins/UI adapter alias of `seg_id` |
+| `loc_id` | Crew-facing numeric location id (CSV); package JSON often stores the same value as `id` | `location_key` — short authoring key, not crew CSV identity |
+| `location_key` | Stable 5-char authoring key (`leg_loc_key` on leg-scoped rows) | `loc_id` |
 
-Full alias tables land in Phase 3.
+## Field alias map
+
+| Term (canonical internal) | Wire / CSV / API aliases | Frontend aliases | Adapter strategy | Example paths |
+|---------------------------|--------------------------|------------------|------------------|---------------|
+| `seg_id` | CSV/artifacts: `seg_id`. Bins / some JSON: `segment_id` | `seg_id`; local JS `segId` | Dual-read or rename **only** in bins/UI adapters. New CSV/exports stay `seg_id`. Do not invent new writers of `segment_id` as SSOT. | `app/core/artifacts/frontend.py`; `app/routes/api_density.py`; `app/core/v2/bins.py` |
+| `leg_id` | Package/org API `{leg_id}`; segment rows may carry `leg_id` | `legId`; `source_leg_id` | Distinct noun. Resolve `leg_id` → current `seg_id` at apply/export. Never rename legs to segments. | `app/core/course/segment_library.py`; `app/core/config_package/legs.py` |
+| `loc_id` | CSV: `loc_id`. Package JSON: numeric `id` (same value). Helpers may say `location_id` in function names | Map: `loc_id`; editor may use `id` | Export always `loc_id`. Function names may say `location_id` without changing the wire key. | `app/core/locations/schema.py`; `app/core/config_package/location_ids.py` |
+| `location_key` | Authoring key; `leg_loc_key` on leg rows | Grid “Key” | Keep separate from `loc_id`. Match course↔leg by key; crew reports keep numeric `loc_id`. | `app/core/config_package/location_keys.py` |
+| Temporal bin width | Core: `dt_seconds`. Metadata: `effective_window_s`, `window_s`, `time_window_s`. Map API may use `window_seconds` for display length | Report MD context `window_s` | Prefer `*_seconds` in new core APIs. Adapters may accept `window_s`. Phase 5 removes fabricated `window_s=30`. | `app/density_report.py`; `app/api/models/report.py`; `app/new_density_report.py` |
+| `step_km` | Density config: `step_km`. v1 API: `stepKm`. Results often mirror as `bin_km` / `bin_size_km` | — | Canonical **config** name is `step_km`. Treat `bin_*` as boundary/result aliases until a dedicated rename. | `app/core/density/models.py`; `app/core/density/compute.py` |
+| `runflow` | Paths `runflow/…`, API `/runflow/v2`, env `RUNFLOW_*`, GCS bucket `runflow` | `window.runflowDay`, `runflow:context-ready` | Canonical runtime namespace. Do not add new `run-density` runtime IDs. | `app/utils/constants.py`; `app/main.py` |
+| `event_duration_minutes` | API + `analysis.json`: `event_duration_minutes`. Internal maps: `event_durations` (minutes) | Analysis forms use full name | Wire stays unit-suffixed. `actual_event_duration` (HH:MM) is a **different** derived metric. | `app/api/models/v2.py`; `app/core/v2/timings.py` |
+
+## Guidance for agents
+
+1. **Read this file before inventing synonyms** for course/leg/segment/location/run/package fields.  
+2. **Preserve legacy wire names only at adapters** (bins UI, map payloads, temporary report metadata).  
+3. **New core APIs** under `app/core/` should use unit-suffixed names (`*_seconds`, `*_minutes`, `*_km`).  
+4. **Product name is Runflow**; repository may stay `run-density`.  
+5. **`seg_id` ≠ `leg_id`**, **`location_key` ≠ `loc_id`**, **`actual_event_duration` ≠ `event_duration_minutes`**.  
+6. Start-time range is **not** full-day 0–1439 — use `app.core.v2.start_time`.  
+7. Cross-check [quick-reference.md](../reference/quick-reference.md) and [canonical-paths.md](canonical-paths.md).
+
+## Light enforcement
+
+- Regression: `tests/unit/test_issue798_phase3_glossary.py` asserts this doc stays present with required sections.  
+- FastAPI app title is **Runflow** (not `run-density`).  
+- Deeper renames of `bin_km` / Docker `run-density-dev` are deferred (Phases 4–6 / later).

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -22,6 +22,9 @@ This guide consolidates essential reference information for developers working w
 
 ## Variable Naming
 
+Canonical product vocabulary (course / leg / segment / aliases): see
+[`docs/architecture/domain-glossary.md`](../architecture/domain-glossary.md) (Issue #798 Phase 3).
+
 ### Critical Naming Rules
 
 **Always use these exact field names to avoid bugs:**
@@ -57,7 +60,7 @@ This guide consolidates essential reference information for developers working w
 
 | Field | Units | Example | Source |
 |-------|-------|---------|--------|
-| `start_time` | minutes from midnight | `420` (7:00 AM), `480` (8:00 AM) | API request → `analysis.json` |
+| `start_time` | minutes from midnight (**300–1200** operating hours; see `app.core.v2.start_time`) | `420` (7:00 AM), `480` (8:00 AM) | API request → `analysis.json` |
 | `start_times` | dict | `{'elite': 480, 'open': 510}` | `analysis.json` → `get_all_start_times()` |
 | `start_offset` | seconds | `30.0` | Runner data |
 | `pace` | minutes per km | `5.5` | Runner data |

--- a/tests/unit/test_issue798_phase3_glossary.py
+++ b/tests/unit/test_issue798_phase3_glossary.py
@@ -1,0 +1,60 @@
+"""
+Issue #798 Phase 3: domain glossary present and light naming enforcement.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GLOSSARY = REPO_ROOT / "docs" / "architecture" / "domain-glossary.md"
+
+
+REQUIRED_HEADINGS = (
+    "## Product vs repository",
+    "## Core nouns",
+    "## Field alias map",
+    "## Guidance for agents",
+)
+
+REQUIRED_PHRASES = (
+    "Runflow",
+    "run-density",
+    "seg_id",
+    "leg_id",
+    "loc_id",
+    "location_key",
+    "event_duration_minutes",
+    "step_km",
+    "app.core.v2.start_time",
+    "300–1200",
+)
+
+
+def test_domain_glossary_exists_with_required_sections():
+    text = GLOSSARY.read_text(encoding="utf-8")
+    assert "Issue #798 Phase 3" in text
+    for heading in REQUIRED_HEADINGS:
+        assert heading in text, f"Missing glossary section: {heading}"
+    for phrase in REQUIRED_PHRASES:
+        assert phrase in text, f"Missing glossary phrase: {phrase}"
+
+
+def test_fastapi_title_is_runflow():
+    from app.main import app
+
+    assert app.title == "Runflow"
+
+
+def test_core_v2_avoids_new_bare_event_duration_api_fields():
+    """
+    Cheap guard: analysis.json / API validation should keep the unit-suffixed wire name.
+    Internal dict keys like event_durations (plural) are allowed.
+    """
+    from app.api.models.v2 import V2EventRequest
+
+    fields = V2EventRequest.model_fields
+    assert "event_duration_minutes" in fields
+    assert "event_duration" not in fields


### PR DESCRIPTION
## Summary
- Expand `docs/architecture/domain-glossary.md` with field alias map + agent guidance
- Point quick-reference at the glossary; note start-time operating hours
- Set FastAPI title to **Runflow**
- Add light regression tests

Continues [Issue #798](https://github.com/thomjeff/run-density/issues/798).

## Test plan
- [x] `pytest tests/unit/test_issue798_phase3_glossary.py`
- [ ] Confirm OpenAPI /docs shows title Runflow after restart


Made with [Cursor](https://cursor.com)