### PR TITLE
Issue #798 Phase 5: report bin/window provenance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #798 Phase 5 — Report configuration provenance
+- Density report `window_s` / `bin_km` resolved from `bins.parquet` (`app.core.bin.provenance`)
+- Removed fabricated `30` / `0.2` TODOs from `new_density_report` / template defaults
+- Regression: `tests/unit/test_issue798_phase5_bin_provenance.py`
+
 ### Issue #798 Phase 4 — Typed path / deployment settings
 - Added `app.utils.path_mapper` (env-backed `RUNFLOW_ROOT` / `RUNFLOW_ROOT_HOST` / `RUNFLOW_ROOT_CONTAINER`)
 - Removed machine-specific `/Users/.../runflow` literals from app, Makefile, compose, and scripts

--- a/app/core/bin/provenance.py
+++ b/app/core/bin/provenance.py
@@ -1,0 +1,73 @@
+"""
+Resolve density-report bin/window metadata from analysis artifacts (Issue #798 Phase 5).
+
+Never invent silent defaults such as window_s=30 / bin_km=0.2 for live reports.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Tuple
+
+import pandas as pd
+
+
+class BinProvenanceError(ValueError):
+    """Bins artifacts do not contain enough information for report metadata."""
+
+
+def resolve_bin_report_params(bins_df: pd.DataFrame) -> Dict[str, Any]:
+    """
+    Derive report methodology params from ``bins.parquet`` columns.
+
+    Returns:
+        Dict with:
+          - ``bin_km`` / ``step_km``: spatial bin size (km)
+          - ``window_s`` / ``window_seconds``: temporal window (seconds)
+    """
+    if bins_df is None or bins_df.empty:
+        raise BinProvenanceError("bins DataFrame is empty; cannot resolve bin/window provenance")
+
+    bin_km = _resolve_bin_km(bins_df)
+    window_seconds = _resolve_window_seconds(bins_df)
+    return {
+        "bin_km": bin_km,
+        "step_km": bin_km,
+        "window_s": window_seconds,
+        "window_seconds": window_seconds,
+    }
+
+
+def _resolve_bin_km(bins_df: pd.DataFrame) -> float:
+    if "bin_size_km" not in bins_df.columns:
+        raise BinProvenanceError(
+            "bins.parquet missing 'bin_size_km'; cannot set report bin size without inventing a value"
+        )
+    series = pd.to_numeric(bins_df["bin_size_km"], errors="coerce").dropna()
+    if series.empty:
+        raise BinProvenanceError("bins.parquet has no usable bin_size_km values")
+    unique = sorted({round(float(v), 6) for v in series.unique()})
+    if len(unique) == 1:
+        return float(unique[0])
+    # Prefer modal value when coarsening left mixed sizes; still artifact-backed.
+    mode_vals = series.mode()
+    if mode_vals.empty:
+        raise BinProvenanceError(f"ambiguous bin_size_km values: {unique}")
+    return float(round(float(mode_vals.iloc[0]), 6))
+
+
+def _resolve_window_seconds(bins_df: pd.DataFrame) -> int:
+    if "t_start" not in bins_df.columns or "t_end" not in bins_df.columns:
+        raise BinProvenanceError(
+            "bins.parquet missing t_start/t_end; cannot set report window without inventing a value"
+        )
+    starts = pd.to_datetime(bins_df["t_start"], utc=True, errors="coerce")
+    ends = pd.to_datetime(bins_df["t_end"], utc=True, errors="coerce")
+    deltas = (ends - starts).dt.total_seconds().dropna()
+    deltas = deltas[deltas > 0]
+    if deltas.empty:
+        raise BinProvenanceError("bins.parquet has no positive (t_end - t_start) windows")
+    # Median is robust if a few irregular rows exist
+    seconds = int(round(float(deltas.median())))
+    if seconds <= 0:
+        raise BinProvenanceError(f"resolved non-positive window_seconds={seconds}")
+    return seconds

--- a/app/new_density_report.py
+++ b/app/new_density_report.py
@@ -542,17 +542,21 @@ def generate_new_density_report(
     }
     logger.info(f"✅ Statistics computed: {stats.get('flagged_bins', 0)}/{stats.get('total_bins', 0)} flagged")
     
-    # Create report context
-    # Issue #600: Always load rulebook for context (needed for threshold display)
+    # Create report context — Issue #798 Phase 5: bin/window from bins artifacts only
+    from app.core.bin.provenance import resolve_bin_report_params
+
     rulebook = load_density_rulebook()
     flagging_config = create_flagging_config(rulebook, bins_df)
+    bin_params = resolve_bin_report_params(bins_df)
     
     context = {
         'schema_version': '1.0.0',
         'report_date': datetime.now().strftime('%Y-%m-%d %H:%M:%S'),
         'app_version': app_version,
-        'window_s': 30,  # TODO: Get from actual data
-        'bin_km': 0.2,   # TODO: Get from actual data
+        'window_s': bin_params['window_s'],
+        'window_seconds': bin_params['window_seconds'],
+        'bin_km': bin_params['bin_km'],
+        'step_km': bin_params['step_km'],
         'rulebook': rulebook,
         'rate_warn_threshold': flagging_config.rate_warn_threshold,
         'rate_critical_threshold': flagging_config.rate_critical_threshold,

--- a/app/new_density_template_engine.py
+++ b/app/new_density_template_engine.py
@@ -250,9 +250,14 @@ class NewDensityTemplateEngine:
     
     def _generate_methodology_inputs(self, context: Dict[str, Any]) -> str:
         """Generate methodology and inputs section."""
+        if "window_s" not in context or "bin_km" not in context:
+            raise KeyError(
+                "Report context missing window_s/bin_km; resolve from bins artifacts "
+                "(app.core.bin.provenance) before rendering"
+            )
         lines = [
             "## Methodology & Inputs",
-            f"- **Window Size:** {context.get('window_s', 30)} s; **Bin Size:** {context.get('bin_km', 0.2)} km",
+            f"- **Window Size:** {context['window_s']} s; **Bin Size:** {context['bin_km']} km",
             "",
             "### LOS and Rate Triggers (from Rulebook)",
             "- **LOS thresholds** define crowding levels based on density (p/m²) only (rate does not affect LOS):",

--- a/docs/architecture/deprecation-ledger.md
+++ b/docs/architecture/deprecation-ledger.md
@@ -41,7 +41,7 @@ Update this file in the same PR that changes disposition or removes a module.
 | Classic UI chrome (`base.html` else branch) | Dual chrome with Tabler | all pages without `ui=tabler` | **remove** | Phase 7 | Product: Tabler-only; Git for rollback | Phase 7 |
 | Course-mapping legacy DOM (`course-legacy-*`, hidden recipes) | Partially hidden | `course_mapping.js`, `segment_recipes.js` | **investigate** | Phase 9 | Smoke preferred Build workflow first | TBD |
 | Host path `/Users/jthompson/Documents/runflow` | ~~Duplicated~~ **FIXED** | `path_mapper` + `RUNFLOW_ROOT` | **keep** env contract | Phase 4 ✓ | Compose `.env` / `.env.example` | — |
-| Hardcoded `window_s=30` / `bin_km=0.2` in `new_density_report` | Fabricated metadata | density MD context | **remove** fallback or fail-fast | Phase 5 | Provenance from analysis.json | Phase 5 |
+| Hardcoded `window_s=30` / `bin_km=0.2` in `new_density_report` | ~~Fabricated~~ **FIXED** | `app.core.bin.provenance` | **keep** artifact-backed | Phase 5 ✓ | Fail-fast if bins lack columns | — |
 | Start-time docs/tests claiming 0–1439 | ~~Conflict~~ **FIXED** | `app.core.v2.start_time` is SSOT | **keep** contract | Phase 2 ✓ | Operating hours 300–1200 | — |
 
 ---
@@ -53,6 +53,7 @@ Update this file in the same PR that changes disposition or removes a module.
 | Conflicting 0–1439 start-time docs/tests | Phase 2 | Canonical module `app.core.v2.start_time` (300–1200) |
 | Domain glossary stub | Phase 3 | Expanded field alias map + agent guidance; FastAPI title → Runflow |
 | Host `/Users/.../runflow` literals | Phase 4 | `app.utils.path_mapper` + `RUNFLOW_ROOT` env; compose `.env.example` |
+| Fabricated report `window_s`/`bin_km` | Phase 5 | Resolved from `bins.parquet` via `app.core.bin.provenance` |
 | `app/routes/reports.py` | Phase 1 | Empty `/reports` router |
 | `app/routes/api_flow.py` | Phase 1 | Wildcard shim → `app.api.flow` |
 | `app/routes/api_bidirectional.py` | Phase 1 | Wildcard shim → `app.api.bidirectional` |

--- a/tests/unit/test_issue798_phase5_bin_provenance.py
+++ b/tests/unit/test_issue798_phase5_bin_provenance.py
@@ -1,0 +1,126 @@
+"""
+Issue #798 Phase 5: density report bin/window provenance from bins artifacts.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pandas as pd
+import pytest
+
+from app.core.bin.provenance import BinProvenanceError, resolve_bin_report_params
+
+
+def _sample_bins(bin_km: float = 0.2, window_s: int = 120, n: int = 4) -> pd.DataFrame:
+    t0 = datetime(2026, 7, 1, 11, 0, tzinfo=timezone.utc)
+    rows = []
+    for i in range(n):
+        start = t0 + timedelta(seconds=i * window_s)
+        end = start + timedelta(seconds=window_s)
+        rows.append(
+            {
+                "bin_size_km": bin_km,
+                "t_start": start.isoformat().replace("+00:00", "Z"),
+                "t_end": end.isoformat().replace("+00:00", "Z"),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def test_resolve_bin_report_params_from_bins():
+    params = resolve_bin_report_params(_sample_bins(bin_km=0.2, window_s=120))
+    assert params["bin_km"] == 0.2
+    assert params["step_km"] == 0.2
+    assert params["window_s"] == 120
+    assert params["window_seconds"] == 120
+
+
+def test_resolve_rejects_empty_and_missing_columns():
+    with pytest.raises(BinProvenanceError):
+        resolve_bin_report_params(pd.DataFrame())
+    with pytest.raises(BinProvenanceError):
+        resolve_bin_report_params(pd.DataFrame({"bin_size_km": [0.2]}))
+    with pytest.raises(BinProvenanceError):
+        resolve_bin_report_params(
+            pd.DataFrame(
+                {
+                    "t_start": ["2026-07-01T11:00:00Z"],
+                    "t_end": ["2026-07-01T11:02:00Z"],
+                }
+            )
+        )
+
+
+def test_new_density_report_context_uses_artifact_values(tmp_path, monkeypatch):
+    """Context must not invent 30s / 0.2km when bins say otherwise."""
+    from app import new_density_report as ndr
+
+    bins_df = _sample_bins(bin_km=0.15, window_s=90)
+    bins_df["flag_severity"] = "none"
+    bins_df["segment_id"] = "A1"
+    segments_df = pd.DataFrame({"seg_id": ["A1"], "width_m": [4.0]})
+    segment_windows_df = pd.DataFrame()
+
+    monkeypatch.setattr(
+        ndr,
+        "load_parquet_sources",
+        lambda *a, **k: {
+            "bins": bins_df,
+            "segments": segments_df,
+            "segment_windows": segment_windows_df,
+        },
+    )
+    monkeypatch.setattr(ndr, "load_segment_metrics_from_json", lambda p: {"A1": {"peak_rate": 0.0}})
+    monkeypatch.setattr(ndr, "load_flags_from_json", lambda p: {"A1": {"worst_severity": "none"}})
+    monkeypatch.setattr(
+        ndr,
+        "convert_json_to_segment_summary",
+        lambda *a, **k: pd.DataFrame(
+            {
+                "segment_id": ["A1"],
+                "total_bins": [1],
+                "flagged_bins": [0],
+                "worst_severity": ["none"],
+                "peak_los": ["A"],
+                "peak_density": [0.0],
+                "peak_rate_per_m_per_min": [0.0],
+            }
+        ),
+    )
+
+    class _FakeEngine:
+        def generate_report(self, context, **kwargs):
+            assert context["window_s"] == 90
+            assert context["bin_km"] == 0.15
+            assert context["window_seconds"] == 90
+            return "# report"
+
+    monkeypatch.setattr(ndr, "NewDensityTemplateEngine", _FakeEngine)
+    monkeypatch.setattr(ndr, "load_density_rulebook", lambda: {})
+    monkeypatch.setattr(
+        ndr,
+        "create_flagging_config",
+        lambda *a, **k: type("C", (), {"rate_warn_threshold": 1.0, "rate_critical_threshold": 2.0})(),
+    )
+
+    metrics = tmp_path / "segment_metrics.json"
+    metrics.write_text("{}")
+    results = ndr.generate_new_density_report(
+        reports_dir=tmp_path,
+        segment_metrics_path=metrics,
+        app_version="test",
+    )
+    assert results["context"]["window_s"] == 90
+    assert results["context"]["bin_km"] == 0.15
+
+
+def test_no_fabricated_window_bin_literals_in_new_density_report():
+    from pathlib import Path
+
+    text = Path("app/new_density_report.py").read_text(encoding="utf-8")
+    assert "window_s': 30" not in text
+    assert 'window_s": 30' not in text
+    assert "bin_km': 0.2" not in text
+    assert 'bin_km": 0.2' not in text
+    assert "TODO: Get from actual data" not in text


### PR DESCRIPTION
## Summary
- Add `app.core.bin.provenance` to resolve `window_s` / `bin_km` from `bins.parquet`
- Wire live density report context; remove fabricated 30s / 0.2km defaults
- Template requires artifact-backed values

Continues [Issue #798](https://github.com/thomjeff/run-density/issues/798).

## Test plan
- [x] `pytest tests/unit/test_issue798_phase5_bin_provenance.py`


Made with [Cursor](https://cursor.com)