### PR TITLE
Issue #798 Phase 8: race defaults → templates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Issue #798 Phase 8 — Race defaults → package templates
+- Added `app/core/race_templates/` (`sample_fredericton` + `RACE_TEMPLATE` env)
+- Moved suggested schedules, hotspot segment IDs, map center, and v1 durations out of “universal” constants semantics
+- Doc: `docs/architecture/race-templates.md`
+- Regression: `tests/unit/test_issue798_phase8_race_templates.py`
+
 ### Issue #798 Phase 7 — Tabler-only frontend chrome
 - `frontend/templates/base.html` always loads Tabler CDN CSS/JS + `common.css` + `tabler_spike.css` (`html.rf-tabler`)
 - Removed Classic dual-chrome branch (inline classic styles, classic header/nav/main/footer) and the Classic UI exit control

--- a/app/core/config_package/package_analysis.py
+++ b/app/core/config_package/package_analysis.py
@@ -20,13 +20,10 @@ from app.core.v2.start_time import (
 )
 
 # UI-only suggestions when opening the run-analysis dialog (not applied server-side).
-SUGGESTED_EVENT_SCHEDULE: Dict[str, Dict[str, int]] = {
-    "full": {"start_time": 420, "event_duration_minutes": 390},
-    "half": {"start_time": 440, "event_duration_minutes": 180},
-    "10k": {"start_time": 460, "event_duration_minutes": 120},
-    "elite": {"start_time": 480, "event_duration_minutes": 45},
-    "open": {"start_time": 510, "event_duration_minutes": 75},
-}
+# Issue #798 Phase 8: from race template (override via RACE_TEMPLATE env).
+from app.core.race_templates import get_suggested_event_schedule
+
+SUGGESTED_EVENT_SCHEDULE: Dict[str, Dict[str, int]] = dict(get_suggested_event_schedule())
 
 
 def _format_start_time(minutes: int) -> str:

--- a/app/core/race_templates/__init__.py
+++ b/app/core/race_templates/__init__.py
@@ -1,0 +1,49 @@
+"""
+Sample / package race templates (Issue #798 Phase 8).
+
+Algorithm defaults stay in ``app.utils.constants``. Race-specific schedules,
+hotspot segment IDs, and map centers live here so they are not universal law.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Mapping, Set
+
+from app.core.race_templates.sample_fredericton import SAMPLE_FREDERICTON
+
+# Registry of named templates (extend when adding races).
+RACE_TEMPLATES: Dict[str, Dict[str, Any]] = {
+    "sample_fredericton": SAMPLE_FREDERICTON,
+}
+
+DEFAULT_RACE_TEMPLATE_ID = "sample_fredericton"
+
+
+def get_race_template(template_id: str | None = None) -> Dict[str, Any]:
+    """Return a race template dict (defaults to sample_fredericton)."""
+    from app.utils.env import env_str
+
+    tid = (template_id or env_str("RACE_TEMPLATE", DEFAULT_RACE_TEMPLATE_ID)).strip()
+    if tid not in RACE_TEMPLATES:
+        raise KeyError(
+            f"Unknown race template '{tid}'. Known: {sorted(RACE_TEMPLATES)}"
+        )
+    return RACE_TEMPLATES[tid]
+
+
+def get_suggested_event_schedule() -> Mapping[str, Dict[str, int]]:
+    return get_race_template()["suggested_event_schedule"]
+
+
+def get_hotspot_segments() -> Set[str]:
+    return set(get_race_template()["hotspot_segments"])
+
+
+def get_map_center() -> tuple[float, float]:
+    center = get_race_template()["map_center"]
+    return float(center["lat"]), float(center["lon"])
+
+
+def get_v1_event_duration_minutes() -> Mapping[str, int]:
+    """V1-only adapter durations (do not use for v2 analysis.json paths)."""
+    return get_race_template()["v1_event_duration_minutes"]

--- a/app/core/race_templates/sample_fredericton.py
+++ b/app/core/race_templates/sample_fredericton.py
@@ -1,0 +1,37 @@
+"""
+Sample Fredericton Marathon-shaped defaults (Issue #798 Phase 8).
+
+UI suggestions and legacy map/hotspot helpers may use this template.
+v2 analysis always prefers package / request payloads over these values.
+"""
+
+from __future__ import annotations
+
+SAMPLE_FREDERICTON = {
+    "id": "sample_fredericton",
+    "label": "Sample Fredericton Marathon (illustrative)",
+    # UI-only suggestions when opening run-analysis (not applied server-side unless chosen).
+    "suggested_event_schedule": {
+        "full": {"start_time": 420, "event_duration_minutes": 390},
+        "half": {"start_time": 440, "event_duration_minutes": 180},
+        "10k": {"start_time": 460, "event_duration_minutes": 120},
+        "elite": {"start_time": 480, "event_duration_minutes": 45},
+        "open": {"start_time": 510, "event_duration_minutes": 75},
+    },
+    # Segments preserved preferentially during bin coarsening (sample course IDs).
+    "hotspot_segments": {"F1", "H1", "J1", "J4", "J5", "K1", "L1"},
+    "map_center": {"lat": 45.9620, "lon": -66.6500},
+    # Deprecated v1 API durations (capitalized keys for legacy payloads).
+    "v1_event_duration_minutes": {
+        "elite": 45,
+        "open": 75,
+        "10k": 120,
+        "half": 180,
+        "full": 390,
+        "Elite": 45,
+        "Open": 75,
+        "10K": 120,
+        "Half": 180,
+        "Full": 390,
+    },
+}

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -3,7 +3,16 @@ Application Constants
 
 This module contains all application-wide constants to avoid magic numbers
 and improve maintainability.
+
+Issue #798 Phase 8: race-specific schedules/hotspots/map center come from
+``app.core.race_templates`` (not treated as universal algorithm law).
 """
+
+from app.core.race_templates import (
+    get_hotspot_segments,
+    get_map_center,
+    get_v1_event_duration_minutes,
+)
 
 # Time conversion constants
 SECONDS_PER_MINUTE = 60.0
@@ -80,24 +89,8 @@ DISTANCE_BIN_SIZE_KM = 0.1  # 100m distance bins
 # Day short codes for v2 (Issue #495)
 DAY_SHORT_CODES = ['fri', 'sat', 'sun', 'mon']
 
-# Event durations in minutes (DEPRECATED - Issue #553 Phase 4.3)
-# Event durations now come from analysis.json per-event configuration.
-# This constant is kept for backward compatibility with v1 API only.
-# v2 API uses event_duration_minutes from request payload → analysis.json.
-# TODO: Remove after v1 API is fully deprecated.
-EVENT_DURATION_MINUTES = {
-    "elite": 45,   # Elite marathon ~45 minutes
-    "open": 75,   # Open marathon ~75 minutes
-    "10k": 120,   # 10K race ~2 hours
-    "half": 180,  # Half marathon ~3 hours
-    "full": 390,  # Full marathon ~6.5 hours
-    # Support both lowercase (v2) and capitalized (v1) keys
-    "Elite": 45,
-    "Open": 75,
-    "10K": 120,
-    "Half": 180,
-    "Full": 390,
-}
+# Issue #798 Phase 8: race-specific durations live in race templates (v1 adapter only).
+EVENT_DURATION_MINUTES = dict(get_v1_event_duration_minutes())
 
 # Mapping event names to day of the week (REMOVED - Issue #553 Phase 4.1)
 # v2 uses Event.day property and analysis.json instead of these constants.
@@ -123,18 +116,9 @@ MAX_BIN_GENERATION_TIME_SECONDS = 120  # P95 target per ChatGPT performance plan
 BIN_HARD_LIMIT_SECONDS = 180  # Absolute ceiling before failover per ChatGPT
 BIN_SCHEMA_VERSION = "1.0.0"  # Schema version for validation (updated per ChatGPT)
 
-# Hotspot preservation for bin dataset generation (ChatGPT final optimizations)
-HOTSPOT_SEGMENTS = {
-    "F1",   # Bridge approaches - critical for reopening decisions
-    "H1",   # Trail/Aberdeen critical counterflow area
-    "J1", "J4", "J5",  # Bridge/Mill complex - high traffic convergence
-    "K1",   # Bridge/Mill to Station - major throughput area
-    "L1"    # Trail/Aberdeen counterflow - operational decisions
-}
-
-# Map center coordinates (Fredericton, NB)
-MAP_CENTER_LAT = 45.9620
-MAP_CENTER_LON = -66.6500
+# Issue #798 Phase 8: hotspot IDs + map center from active race template (not universal law).
+HOTSPOT_SEGMENTS = get_hotspot_segments()
+MAP_CENTER_LAT, MAP_CENTER_LON = get_map_center()
 MAP_DEFAULT_ZOOM = 14
 
 # Map tile provider

--- a/docs/README.md
+++ b/docs/README.md
@@ -39,6 +39,7 @@ This documentation is organized by audience and topic for easy navigation.
 | [Canonical paths](architecture/canonical-paths.md) | Supported API → pipeline → report call graphs (Issue #798) |
 | [Deprecation ledger](architecture/deprecation-ledger.md) | Live vs remove vs rename dispositions (Issue #798) |
 | [Domain glossary](architecture/domain-glossary.md) | Runflow vocabulary (Issue #798) |
+| [Race templates](architecture/race-templates.md) | Sample-race defaults vs algorithm constants (Issue #798 Phase 8) |
 | [Docker Development](dev-guides/docker-dev.md) | Docker development workflow |
 | [Leg Library & Corridor Pairing](dev-guides/segment-library-2027.md) | Leg platform internals (org library, recipes, pairing, sync) |
 | [Quick Reference](reference/quick-reference.md) | Variable names, terminology, standards (v2.0.2+) |

--- a/docs/architecture/deprecation-ledger.md
+++ b/docs/architecture/deprecation-ledger.md
@@ -37,8 +37,8 @@ Update this file in the same PR that changes disposition or removes a module.
 | `app/routes/api_flow.py` | ~~Wildcard re-export~~ **REMOVED** | — | **remove** ✓ | Phase 1 | `main` imports `app.api.flow` | Phase 1 |
 | `app/routes/api_bidirectional.py` | ~~Wildcard re-export~~ **REMOVED** | — | **remove** ✓ | Phase 1 | `main` imports `app.api.bidirectional` | Phase 1 |
 | `app/core/flow/flow.py` `_ShardWriter` | ~~Unused~~ **REMOVED** | — | **remove** ✓ | Phase 1 | Also `_write_index_csv`, `_write_topk_csv` | Phase 1 |
-| `app/utils/constants.py` `EVENT_DURATION_MINUTES` | Deprecated dict; capitalized dupes | v1 compatibility risk | **investigate** → remove or v1-only adapter | Phase 8 | Confirm v1 endpoint retirement | TBD |
-| `HOTSPOT_SEGMENTS` / map center constants | Sample-race / city defaults | bin generation / maps | **rename/move** to template data | Phase 8 | Not universal domain law | — |
+| `app/utils/constants.py` `EVENT_DURATION_MINUTES` | ~~Deprecated dict~~ **templated** | v1 adapter via `race_templates` | **shim** via constants re-export | Phase 8 ✓ | Prefer analysis.json for v2 | when v1 gone |
+| `HOTSPOT_SEGMENTS` / map center constants | ~~Sample-race globals~~ **templated** | `race_templates.sample_fredericton` | **keep** as template data | Phase 8 ✓ | Override via `RACE_TEMPLATE` | — |
 | Classic UI chrome (`base.html` else branch) | ~~Dual chrome~~ **FIXED/removed** | — | **remove** ✓ | Phase 7 | Tabler-only in `base.html`; Git for rollback | Phase 7 |
 | Course-mapping legacy DOM (`course-legacy-*`, hidden recipes) | Partially hidden | `course_mapping.js`, `segment_recipes.js` | **investigate** | Phase 9 | Smoke preferred Build workflow first | TBD |
 | Host path `/Users/jthompson/Documents/runflow` | ~~Duplicated~~ **FIXED** | `path_mapper` + `RUNFLOW_ROOT` | **keep** env contract | Phase 4 ✓ | Compose `.env` / `.env.example` | — |

--- a/docs/architecture/race-templates.md
+++ b/docs/architecture/race-templates.md
@@ -1,0 +1,15 @@
+# Race templates (Issue #798 Phase 8)
+
+Race-specific UI suggestions, hotspot segment IDs, map centers, and legacy v1
+event durations live under `app/core/race_templates/`.
+
+| Env | Meaning |
+|-----|---------|
+| `RACE_TEMPLATE` | Template id (default: `sample_fredericton`) |
+
+**v2 analysis** still takes start times / durations from the request / package /
+`analysis.json`. Template schedules are **UI suggestions only** unless the user
+applies them in the run-analysis dialog.
+
+To add another race: create `app/core/race_templates/<id>.py` and register it in
+`RACE_TEMPLATES` in `__init__.py`.

--- a/tests/unit/test_issue798_phase8_race_templates.py
+++ b/tests/unit/test_issue798_phase8_race_templates.py
@@ -1,0 +1,49 @@
+"""Issue #798 Phase 8: race-specific defaults live in templates, not as universal law."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from app.core.race_templates import (
+    DEFAULT_RACE_TEMPLATE_ID,
+    get_hotspot_segments,
+    get_map_center,
+    get_suggested_event_schedule,
+    get_v1_event_duration_minutes,
+)
+from app.utils import constants as C
+
+
+def test_sample_template_has_expected_shape():
+    schedule = get_suggested_event_schedule()
+    assert "full" in schedule
+    assert schedule["full"]["start_time"] == 420
+    hotspots = get_hotspot_segments()
+    assert "F1" in hotspots
+    lat, lon = get_map_center()
+    assert abs(lat - 45.9620) < 1e-6
+    assert abs(lon - (-66.6500)) < 1e-6
+    durations = get_v1_event_duration_minutes()
+    assert durations["full"] == 390
+
+
+def test_constants_reexport_template_values():
+    assert C.EVENT_DURATION_MINUTES["full"] == 390
+    assert "F1" in C.HOTSPOT_SEGMENTS
+    assert abs(C.MAP_CENTER_LAT - 45.9620) < 1e-6
+
+
+def test_package_analysis_uses_template_schedule():
+    from app.core.config_package.package_analysis import SUGGESTED_EVENT_SCHEDULE
+
+    assert SUGGESTED_EVENT_SCHEDULE["elite"]["start_time"] == 480
+
+
+def test_no_hardcoded_fredericton_schedule_block_in_package_analysis():
+    text = Path("app/core/config_package/package_analysis.py").read_text(encoding="utf-8")
+    assert "SUGGESTED_EVENT_SCHEDULE: Dict[str, Dict[str, int]] = {" not in text
+    assert "get_suggested_event_schedule" in text
+
+
+def test_default_template_id():
+    assert DEFAULT_RACE_TEMPLATE_ID == "sample_fredericton"


### PR DESCRIPTION
## Summary
- Add `app/core/race_templates/` with `sample_fredericton` and `RACE_TEMPLATE` selection
- Wire suggested schedules, hotspot segments, map center, and v1 durations through templates
- Document in `docs/architecture/race-templates.md`

Continues [Issue #798](https://github.com/thomjeff/run-density/issues/798).

## Test plan
- [x] `pytest tests/unit/test_issue798_phase8_race_templates.py`


Made with [Cursor](https://cursor.com)