### PR TITLE
Issue #798 Phase 9: extract bin hotspot helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #798 Phase 9 — Large-module decomposition (stretch)
+- Extracted bin hotspot coarsening helpers to `app/core/bin/hotspots.py`
+- `app.density_report` re-exports the same callables (no behavior change)
+- Regression: `tests/unit/test_issue798_phase9_hotspots_extract.py`
+
 ### Issue #798 Phase 8 — Race defaults → package templates
 - Added `app/core/race_templates/` (`sample_fredericton` + `RACE_TEMPLATE` env)
 - Moved suggested schedules, hotspot segment IDs, map center, and v1 durations out of “universal” constants semantics

--- a/app/core/bin/__init__.py
+++ b/app/core/bin/__init__.py
@@ -6,5 +6,6 @@ Contains bin-level analysis, geometry processing, and flagging logic.
 Modules:
 - summary.py - Bin summary generation
 - geometry.py - Bin polygon generation
-- flags.py - Bin flagging logic
+- provenance.py - Report window/bin metadata from bins artifacts
+- hotspots.py - Hotspot preservation / coarsening policy (Issue #798 Phase 9)
 """

--- a/app/core/bin/hotspots.py
+++ b/app/core/bin/hotspots.py
@@ -1,0 +1,39 @@
+"""
+Hotspot preservation helpers for bin coarsening (Issue #798 Phase 9).
+
+Extracted from ``app.density_report`` so race-template hotspot IDs and coarsening
+policy live beside other bin core modules.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from app.utils.constants import HOTSPOT_SEGMENTS
+
+
+def is_hotspot(seg_id: str, peak_los: Optional[str] = None) -> bool:
+    """True when a segment should keep finer bin resolution during coarsening."""
+    if seg_id in HOTSPOT_SEGMENTS:
+        return True
+    if peak_los and peak_los >= "D":
+        return True
+    return False
+
+
+def coarsen_plan(
+    seg_id: str,
+    current_bin_km: float,
+    current_dt_s: int,
+    peak_los: Optional[str] = None,
+) -> Tuple[float, int]:
+    """
+    Determine coarsening strategy (hotspot preservation policy).
+
+    Hotspots keep current resolution; others widen time first, then space.
+    """
+    if is_hotspot(seg_id, peak_los):
+        return current_bin_km, current_dt_s
+    coarsened_dt = max(current_dt_s, 120)
+    coarsened_bin = max(current_bin_km, 0.2)
+    return coarsened_bin, coarsened_dt

--- a/app/density_report.py
+++ b/app/density_report.py
@@ -78,30 +78,8 @@ def check_time_budget(start_time: float, budget_s: int = 60) -> None:
     if time.monotonic() - start_time > budget_s:
         raise TimeoutError("bin_generation_budget_exceeded")
 
-def is_hotspot(seg_id: str, peak_los: str = None) -> bool:
-    """Determine if segment is a hotspot requiring preserved resolution per ChatGPT specification."""
-    
-    # Static hotspot list (fastest to implement)
-    if seg_id in HOTSPOT_SEGMENTS:
-        return True
-    
-    # Dynamic hotspot detection based on LOS
-    if peak_los and peak_los >= 'D':
-        return True
-        
-    return False
-
-def coarsen_plan(seg_id: str, current_bin_km: float, current_dt_s: int, peak_los: str = None) -> tuple[float, int]:
-    """Determine coarsening strategy per ChatGPT hotspot preservation policy."""
-    if is_hotspot(seg_id, peak_los):
-        # Keep hotspots at high resolution
-        return current_bin_km, current_dt_s
-    
-    # Non-hotspot coarsening policy: temporal first, then spatial
-    coarsened_dt = max(current_dt_s, 120)  # Widen time windows first
-    coarsened_bin = max(current_bin_km, 0.2)  # Then spatial if needed
-    
-    return coarsened_bin, coarsened_dt
+# Issue #798 Phase 9: hotspot helpers live in app.core.bin.hotspots
+from app.core.bin.hotspots import coarsen_plan, is_hotspot  # noqa: E402,F401
 
 # Import storage service for persistent file storage
 # Issue #466 Step 2: Storage consolidated to app.storage

--- a/docs/architecture/deprecation-ledger.md
+++ b/docs/architecture/deprecation-ledger.md
@@ -31,7 +31,7 @@ Update this file in the same PR that changes disposition or removes a module.
 | `app/new_density_template_engine.py` | **shim** | → `…density.template_engine` | **shim** | Phase 6 ✓ | Remove after one release | next release |
 | `app/new_flagging.py` | **shim** | → `…density.flagging` | **shim** | Phase 6 ✓ | Remove after one release | next release |
 | `app/core/reports/density/*` | **LIVE** canonical | v2 reports, `save_bins`, façade | **keep** | Phase 6 ✓ | Public API in package `__init__` | — |
-| `app/density_report.py` | **LIVE** façade + legacy helpers | v2 reports, bins, `main.py` legacy endpoints | **keep** then thin | Phase 6 / 9 | `generate_density_report_markdown` (+ alias) | — |
+| `app/density_report.py` | **LIVE** façade + legacy helpers | v2 reports, bins, `main.py` legacy endpoints | **keep** then thin | Phase 6 / 9 ✓ | Hotspot helpers → `app.core.bin.hotspots` | — |
 | `app/flow_report.py` | **LIVE** | v2 `generate_flow_report_v2` | **keep** | — | Flow.md path deprecated; CSV kept | — |
 | `app/routes/reports.py` | ~~Empty router~~ **REMOVED** | — | **remove** ✓ | Phase 1 | Frontend uses `api_reports` | Phase 1 |
 | `app/routes/api_flow.py` | ~~Wildcard re-export~~ **REMOVED** | — | **remove** ✓ | Phase 1 | `main` imports `app.api.flow` | Phase 1 |
@@ -57,6 +57,8 @@ Update this file in the same PR that changes disposition or removes a module.
 | Fabricated report `window_s`/`bin_km` | Phase 5 | Resolved from `bins.parquet` via `app.core.bin.provenance` |
 | Classic UI chrome (`base.html` else branch) | Phase 7 | Tabler-only cutover; opt-in `?ui=tabler` no longer required |
 | Live `new_*` density stack moved | Phase 6 | Canonical under `app/core/reports/density/`; old paths are shims |
+| Race schedules / hotspots / map center as globals | Phase 8 | `app/core/race_templates/` + `docs/architecture/race-templates.md` |
+| Bin hotspot coarsening helpers | Phase 9 | Extracted to `app/core/bin/hotspots.py` (density_report re-exports) |
 | `app/routes/reports.py` | Phase 1 | Empty `/reports` router |
 | `app/routes/api_flow.py` | Phase 1 | Wildcard shim → `app.api.flow` |
 | `app/routes/api_bidirectional.py` | Phase 1 | Wildcard shim → `app.api.bidirectional` |

--- a/tests/unit/test_issue798_phase9_hotspots_extract.py
+++ b/tests/unit/test_issue798_phase9_hotspots_extract.py
@@ -1,0 +1,25 @@
+"""Issue #798 Phase 9: cohesive extraction of bin hotspot coarsening helpers."""
+
+from __future__ import annotations
+
+from app.core.bin.hotspots import coarsen_plan, is_hotspot
+from app.density_report import coarsen_plan as façade_coarsen
+from app.density_report import is_hotspot as façade_hotspot
+
+
+def test_hotspot_from_template_ids():
+    assert is_hotspot("F1") is True
+    assert is_hotspot("ZZ_NOT_A_HOTSPOT") is False
+    assert is_hotspot("ZZ_NOT_A_HOTSPOT", peak_los="E") is True
+
+
+def test_coarsen_plan_preserves_hotspots():
+    assert coarsen_plan("F1", 0.1, 60) == (0.1, 60)
+    bin_km, dt = coarsen_plan("ZZ", 0.1, 60)
+    assert bin_km >= 0.2
+    assert dt >= 120
+
+
+def test_density_report_reexports_same_callables():
+    assert façade_hotspot is is_hotspot
+    assert façade_coarsen is coarsen_plan


### PR DESCRIPTION
## Summary
- Extract `is_hotspot` / `coarsen_plan` to `app/core/bin/hotspots.py`
- Keep identical callables re-exported from `app.density_report`
- Completes the stretch Phase 9 item for Issue #798 with one cohesive extraction

Closes [Issue #798](https://github.com/thomjeff/run-density/issues/798) (all phases 0–9 landed).

## Test plan
- [x] `pytest tests/unit/test_issue798_phase9_hotspots_extract.py`


Made with [Cursor](https://cursor.com)