### PR TITLE
Issue #798 closeout: green tests + Tabler doc sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #798 closeout — tests & Tabler docs
+- Fix Phase 1 router test: allow legitimate `GET /reports` UI page; walk nested FastAPI routers
+- Update obsolete flow ordering tests to the fail-fast `events` contract (no pair-fallback helper)
+- Align developer guide + `tabler_spike.css` with Tabler-only chrome; stop appending `?ui=tabler`
+
 ### Issue #798 Phase 9 — Large-module decomposition (stretch)
 - Extracted bin hotspot coarsening helpers to `app/core/bin/hotspots.py`
 - `app.density_report` re-exports the same callables (no behavior change)

--- a/docs/dev-guides/developer-guide.md
+++ b/docs/dev-guides/developer-guide.md
@@ -60,9 +60,9 @@ The application uses server-side rendering with Jinja2 templates and vanilla Jav
 - **Templates:** Jinja2 templates in `frontend/templates/pages/`
 - **JavaScript:** Vanilla JavaScript in `frontend/static/js/`
 - **Mapping:** Leaflet (via CDN: `https://unpkg.com/leaflet@1.9.4/`)
-- **Admin chrome (opt-in):** [Tabler](https://tabler.io/) `@tabler/core@1.4.0` (MIT, open source) via jsDelivr CDN when `?ui=tabler` — see [Frontend UI Contract → Tabler](frontend-ui.md#tabler-ui-issue-796--third-party-admin-chrome)
+- **Admin chrome:** [Tabler](https://tabler.io/) `@tabler/core@1.4.0` (MIT, open source) via jsDelivr CDN — sole shell on pages that extend `base.html` (`html.rf-tabler`). See [Frontend UI Contract → Tabler](frontend-ui.md#tabler-ui-issue-798-phase-7--sole-admin-chrome)
 - **Styling:** Hand-rolled CSS — shared contract in `frontend/static/css/common.css` (see [Frontend UI Contract](frontend-ui.md)); Tabler remaps in `frontend/static/css/tabler_spike.css`
-- **No Build Tooling:** No webpack, vite, or npm dependencies (CDN only for Leaflet + optional Tabler)
+- **No Build Tooling:** No webpack, vite, or npm dependencies (CDN only for Leaflet + Tabler)
 
 ### Implementation Guidelines
 

--- a/docs/dev-guides/frontend-ui.md
+++ b/docs/dev-guides/frontend-ui.md
@@ -55,7 +55,7 @@ Provides Results sub-nav + run banner / empty CTA. Styles: `.rf-results-*` in `c
 
 ## Tabler UI (Issue #798 Phase 7) — sole admin chrome
 
-**[Tabler](https://tabler.io/)** (`@tabler/core`) is an open-source admin dashboard UI kit (MIT License). Runflow loads it **always** from the jsDelivr CDN on pages that extend `base.html` — there is still no npm/webpack step. Classic dual-chrome was removed in Issue #798 Phase 7; `?ui=tabler` is no longer required (JS may still append it for back-compat).
+**[Tabler](https://tabler.io/)** (`@tabler/core`) is an open-source admin dashboard UI kit (MIT License). Runflow loads it **always** from the jsDelivr CDN on pages that extend `base.html` — there is still no npm/webpack step. Classic dual-chrome was removed in Issue #798 Phase 7; `?ui=tabler` is not required and should not be reintroduced as a chrome gate.
 
 ### What we load
 

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -1,6 +1,6 @@
 /**
- * Tabler chrome spike — light horizontal shell (Issue #796).
- * Opt-in via ?ui=tabler. Default (classic) UI unchanged.
+ * Tabler chrome remaps — sole admin shell (Issue #796 / #798 Phase 7).
+ * Always loaded from base.html with html.rf-tabler. Classic dual-chrome removed.
  */
 
 html.rf-tabler,

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -301,7 +301,7 @@
                         return;
                     }
                     localStorage.setItem("selected_config_id", configId);
-                    link.href = "/config?config_id=" + encodeURIComponent(configId) + "&ui=tabler";
+                    link.href = "/config?config_id=" + encodeURIComponent(configId);
                     link.title = "Open package " + configId;
                     link.hidden = false;
                 })
@@ -387,16 +387,14 @@
                     const params = new URLSearchParams();
                     params.set("run_id", runId);
                     if (day) params.set("day", day);
-                    params.set("ui", "tabler");
                     window.location.href = "/overview?" + params.toString();
                 })
                 .catch(function () {
-                    window.location.href = "/overview?run_id=" + encodeURIComponent(runId) + "&ui=tabler";
+                    window.location.href = "/overview?run_id=" + encodeURIComponent(runId);
                 });
         }
 
         function updateNavLinks(day, runId) {
-            const tablerUi = document.documentElement.classList.contains("rf-tabler");
             document.querySelectorAll("nav a, .navbar-nav a, .navbar-brand a").forEach(a => {
                 const href = a.getAttribute("href");
                 if (!href || href === "/logout" || href === "/health-check" || href === "#") return;
@@ -426,16 +424,13 @@
                     }
                     newHref = setQueryParam(newHref, "config_id", null);
                 }
-                if (tablerUi) {
-                    newHref = setQueryParam(newHref, "ui", "tabler");
-                } else {
-                    newHref = setQueryParam(newHref, "ui", null);
-                }
+                // Drop legacy chrome gate if present in stored/copied links
+                newHref = setQueryParam(newHref, "ui", null);
                 a.setAttribute("href", newHref);
             });
             const viewAll = document.getElementById("rf-runs-view-all");
-            if (viewAll && tablerUi) {
-                viewAll.setAttribute("href", "/dashboard?ui=tabler");
+            if (viewAll) {
+                viewAll.setAttribute("href", "/dashboard");
             }
             syncTablerRunNav(runId, day);
         }
@@ -479,13 +474,12 @@
             if (changed && newUrl !== window.location.pathname + window.location.search) {
                 window.history.replaceState({}, "", newUrl);
             }
-            // Back-compat: keep ui=tabler in URL if already Tabler (always-on chrome)
-            if (document.documentElement.classList.contains("rf-tabler")) {
-                const p2 = new URLSearchParams(window.location.search);
-                if (p2.get("ui") !== "tabler") {
-                    p2.set("ui", "tabler");
-                    window.history.replaceState({}, "", window.location.pathname + "?" + p2.toString());
-                }
+            // Strip legacy ?ui=tabler chrome gate from Build URLs
+            const p2 = new URLSearchParams(window.location.search);
+            if (p2.has("ui")) {
+                p2.delete("ui");
+                const qs = p2.toString();
+                window.history.replaceState({}, "", window.location.pathname + (qs ? "?" + qs : ""));
             }
             // Keep last Results run in top-bar views while authoring
             const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;

--- a/tests/unit/test_hardcoded_values.py
+++ b/tests/unit/test_hardcoded_values.py
@@ -127,53 +127,51 @@ class TestStartTimeValidation:
 
 class TestFlowOrderingUsesFlowCsv:
     """Test that flow ordering comes from flow.csv, not start_time."""
-    
+
     def test_flow_csv_is_authoritative_for_ordering(self):
         """Verify that flow.csv ordering is preserved, not start_time ordering."""
         from app.core.v2.flow import load_flow_csv, extract_event_pairs_from_flow_csv
-        
-        # Load flow.csv
+
         flow_df = load_flow_csv("data/flow.csv")
-        
-        # Extract pairs from flow.csv
-        pairs = extract_event_pairs_from_flow_csv(flow_df)
-        
-        # Verify pairs preserve flow.csv ordering (not start_time)
-        # This is tested by ensuring the function doesn't reorder based on start_time
-        assert len(pairs) > 0, "flow.csv should contain event pairs"
-        
-        # Check that pairs match flow.csv event_a/event_b ordering
-        for event_a, event_b in pairs:
-            # Find matching rows in flow.csv
-            matching_rows = flow_df[
-                (flow_df['event_a'].str.lower() == event_a.name.lower()) &
-                (flow_df['event_b'].str.lower() == event_b.name.lower())
-            ]
-            
-            # If found in flow.csv, ordering should match
-            if not matching_rows.empty:
-                # The pair should exist in flow.csv with this exact ordering
-                assert len(matching_rows) > 0, \
-                    f"Pair ({event_a.name}, {event_b.name}) should be in flow.csv"
-    
-    def test_fallback_logs_warning(self):
-        """Test that fallback to start_time ordering logs a warning."""
-        import logging
-        from app.core.v2.flow import generate_event_pairs_fallback
-        
-        # Create events with different start times
+
+        # Build Event objects for every name referenced in flow.csv
+        names = sorted(
+            {
+                str(n).strip().lower()
+                for col in ("event_a", "event_b")
+                for n in flow_df[col].dropna().tolist()
+                if str(n).strip()
+            }
+        )
+        # Valid operating-hours start times (ordering must still follow flow.csv)
         events = [
-            Event(name="late", day=Day.SUN, start_time=500),
-            Event(name="early", day=Day.SUN, start_time=400),
+            Event(
+                name=name,
+                day=Day.SUN,
+                start_time=420 + (i * 20),
+                gpx_file=f"{name}.gpx",
+                runners_file=f"{name}_runners.csv",
+            )
+            for i, name in enumerate(names)
         ]
-        
-        # Capture log messages
-        with pytest.LogCapture() as log:
-            pairs = generate_event_pairs_fallback(events)
-            
-            # Verify warning is logged
-            assert len(pairs) > 0
-            # Note: Actual warning is logged in analyze_temporal_flow_segments_v2 when fallback is used
+
+        pairs = extract_event_pairs_from_flow_csv(flow_df, events)
+        assert len(pairs) > 0, "flow.csv should contain event pairs"
+
+        for event_a, event_b in pairs:
+            matching_rows = flow_df[
+                (flow_df["event_a"].str.lower() == event_a.name.lower())
+                & (flow_df["event_b"].str.lower() == event_b.name.lower())
+            ]
+            assert not matching_rows.empty, (
+                f"Pair ({event_a.name}, {event_b.name}) should be in flow.csv"
+            )
+
+    def test_no_start_time_pair_fallback_helper(self):
+        """Issue #553 / #798: flow processing is fail-fast — no generated pair fallback."""
+        import app.core.v2.flow as flow_mod
+
+        assert not hasattr(flow_mod, "generate_event_pairs_fallback")
 
 
 class TestNoHardcodedRunnerCounts:

--- a/tests/unit/test_issue798_phase1_routers.py
+++ b/tests/unit/test_issue798_phase1_routers.py
@@ -5,6 +5,23 @@ Issue #798 Phase 1: composition root imports canonical routers (no empty/shim mo
 from __future__ import annotations
 
 import importlib.util
+from typing import Iterable, List
+
+
+def _collect_route_paths(routes: Iterable) -> List[str]:
+    """Flatten FastAPI/_IncludedRouter nested route tables to path strings."""
+    paths: List[str] = []
+    for route in routes:
+        path = getattr(route, "path", None)
+        if path is not None:
+            paths.append(path)
+        original = getattr(route, "original_router", None)
+        if original is not None and hasattr(original, "routes"):
+            paths.extend(_collect_route_paths(original.routes))
+        nested = getattr(route, "routes", None)
+        if nested:
+            paths.extend(_collect_route_paths(nested))
+    return paths
 
 
 def test_legacy_router_shim_modules_removed():
@@ -23,21 +40,24 @@ def test_canonical_flow_and_bidirectional_routers_importable():
     assert len(bi_router.routes) > 0
 
 
-def test_main_registers_flow_routes_without_empty_reports_prefix():
+def test_main_keeps_reports_ui_page_without_empty_reports_router_module():
+    """
+    Phase 1 removed empty ``app.routes.reports`` — not the authenticated UI page.
+
+    ``GET /reports`` from ``app.routes.ui`` remains the Reports workspace.
+    Reports JSON/API remains under ``/api/reports``.
+    """
     from app.main import app
+    from app.routes.ui import reports as ui_reports_endpoint
 
-    paths = []
-    for route in app.routes:
-        path = getattr(route, "path", None)
-        if path is not None:
-            paths.append(path)
+    paths = _collect_route_paths(app.routes)
 
-    # Empty /reports shim must be gone; UI reports API remains under /api/reports
-    assert not any(p == "/reports" or p.startswith("/reports/") for p in paths)
-    assert any("/api/" in p and "flow" in p for p in paths) or any(
-        getattr(r, "path", "").endswith("/flow") or "flow" in getattr(r, "path", "")
-        for r in app.routes
-    )
+    assert "/reports" in paths
+    assert any(p == "/api/reports" or p.startswith("/api/reports/") for p in paths)
+    assert any("flow" in p for p in paths)
+
+    # UI page handler still lives on the ui router (not a deleted empty module)
+    assert ui_reports_endpoint.__module__ == "app.routes.ui"
 
 
 def test_dead_flow_csv_audit_helpers_removed():

--- a/tests/unit/test_issue798_phase7_tabler_only.py
+++ b/tests/unit/test_issue798_phase7_tabler_only.py
@@ -31,6 +31,8 @@ def test_base_html_always_tabler_no_classic(base_source: str):
     assert "Race Density & Flow Intelligence</div>" not in base_source  # classic tagline
     assert "{% if not tabler_ui %}" not in base_source
     assert 'href="/overview?ui=tabler"' not in base_source
+    assert 'params.set("ui", "tabler")' not in base_source
+    assert "Opt-in via ?ui=tabler" not in base_source
 
 
 def test_base_html_jinja_render_smoke():


### PR DESCRIPTION
## Summary
Addresses the post-completion review blockers for [#798](https://github.com/thomjeff/run-density/issues/798):

1. Phase 1 router test now allows legitimate `GET /reports` (UI) while still proving empty `app.routes.reports` is gone (walks nested FastAPI routers)
2. `test_hardcoded_values` flow tests updated for `extract_event_pairs_from_flow_csv(..., events)` and fail-fast (no `generate_event_pairs_fallback`)
3. Developer guide + `tabler_spike.css` header aligned with Tabler-only; `base.html` stops appending `?ui=tabler`

## Test plan
- [x] `pytest` Issue #798 unit suite + `test_hardcoded_values.py` → **57 passed**


Made with [Cursor](https://cursor.com)