### PR TITLE
Paired Locations UX and 2027 pass/location identity (#810, #811)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Locations report — include `location_key`
+- `Locations.csv` now includes `location_key` immediately after `loc_id` (falls back to `leg_loc_key` when needed)
+- Package export `locations.csv` includes `location_key` from course snapshots (same fallback)
+- Locations UI table shows **Key** between **ID** and **Location** (from report/API data)
+- Helps identify paired reverse-leg duplicates that share the same authoring key
+
 ### Issue #798 closeout — tests & Tabler docs
 - Fix Phase 1 router test: allow legitimate `GET /reports` UI page; walk nested FastAPI routers
 - Update obsolete flow ordering tests to the fail-fast `events` contract (no pair-fallback helper)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,25 @@
 
 ## [Unreleased]
 
+### 2027 location / pass identity
+- **`loc_id`**: short human Location number (phone / UI / one-pager)
+- **`pass_id`**: timed instance (outbound/return and unpaired rows)
+- **`pass_key`**: opaque Crockford unifier (system join; not volunteer-facing)
+- Package pipeline input: **`passes.csv`** (replaces package `locations.csv`)
+- Analysis reports: **`Passes.csv`** (one row per pass) + **`Locations.csv`** (consolidated earliest/latest per Location)
+- One-pager HTML: `/{loc_id}.html` (human Location id)
+
+### Issue #810 — paired reverse-leg Locations
+- One Location in map + Course Resource Timing table when rows share `pass_key` / legacy `location_key` (Outbound + Return times)
+- Loc sheets: one sheet per Location with Outbound/Return sections
+- Leg map Add/Edit location popup: **Create One-Pager** checkbox (`onepage` y/n); Save closes popup immediately
+- `ensure_location_key` preserves intentional shared keys on paired reverse legs (no longer re-keys the second pin)
+- Loc sheet generation treats blank/`nan` `day` as matching the selected day (so onepage=y rows are not skipped)
+- Build race exports / location merge stamps package `event_day` onto course locations (org legs stay day-agnostic)
+- Package export includes `pass_key` / `loc_id` / `pass_id` on pass rows
+
 ### Locations report — include `location_key`
-- `Locations.csv` now includes `location_key` immediately after `loc_id` (falls back to `leg_loc_key` when needed)
-- Package export `locations.csv` includes `location_key` from course snapshots (same fallback)
-- Locations UI table shows **Key** between **ID** and **Location** (from report/API data)
-- Helps identify paired reverse-leg duplicates that share the same authoring key
+- (Superseded by 2027 identity: prefer `pass_key` + human `loc_id`; legacy `location_key` still accepted on read)
 
 ### Issue #798 closeout — tests & Tabler docs
 - Fix Phase 1 router test: allow legitimate `GET /reports` UI page; walk nested FastAPI routers

--- a/app/api/models/v2.py
+++ b/app/api/models/v2.py
@@ -93,7 +93,7 @@ class V2AnalyzeRequest(BaseModel):
                 "description": "Scenario to test 10k on Saturday",
                 "data_dir": "/app/data",
                 "segments_file": "segments.csv",
-                "locations_file": "locations.csv",
+                "locations_file": "passes.csv",
                 "flow_file": "flow.csv",
                 "events": [
                     {

--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -27,6 +27,7 @@ from app.core.config_package.segment_recipes import (
 )
 from app.core.config_package.storage import (
     load_config_course,
+    load_config_manifest,
     resolve_config_package_path,
     save_config_course,
     validate_config_id,
@@ -61,14 +62,17 @@ _LEG_LOC_PRESERVE_FIELDS = (
     "lat",
     "lon",
     "placement",
-    "location_key",
+    "pass_key",
+    "location_key",  # legacy alias
+    "loc_id",
     "notes",
     "buffer",
     "interval",
     "zone",
     "equipment",
     "contact",
-    "proxy_loc_id",
+    "proxy_pass_id",
+    "proxy_loc_id",  # legacy alias
     "proxy_leg_loc_key",
     "day",
     "onepage",
@@ -89,8 +93,10 @@ _RACE_EXPORT_PRESERVE_FIELDS = (
     "zone",
     "equipment",
     "contact",
+    "proxy_pass_id",
     "proxy_loc_id",
     "proxy_leg_loc_key",
+    "loc_id",
     "day",
     "onepage",
     "resources",
@@ -98,8 +104,56 @@ _RACE_EXPORT_PRESERVE_FIELDS = (
 
 _LEG_LOC_EXPORT_FIELDS = _LEG_LOC_PRESERVE_FIELDS
 
+_BLANK_LOCATION_DAYS = frozenset({"", "nan", "none", "null"})
+
 _LEG_ID_RE = re.compile(r"^\d{2,3}$")
 LEG_EXPORT_VERSION = 2
+
+
+def package_event_day(config_id: str) -> str:
+    """Race day short code from package manifest (default ``sun``)."""
+    try:
+        manifest = load_config_manifest(config_id)
+    except FileNotFoundError:
+        return "sun"
+    day = str(manifest.get("event_day") or "").strip().lower()
+    if day in _BLANK_LOCATION_DAYS:
+        return "sun"
+    return day
+
+
+def stamp_locations_with_package_day(
+    locations: Sequence[Dict[str, Any]],
+    event_day: str,
+    *,
+    overwrite: bool = True,
+) -> int:
+    """
+    Stamp package ``event_day`` onto location rows.
+
+    Org/course legs are day-agnostic and reusable across sat/sun packages; the
+    package owns race day. Call this when merging legs into a package course or
+    exporting ``locations.csv``.
+
+    When ``overwrite`` is True (default), every location gets ``event_day``.
+    When False, only blank/``nan`` days are filled.
+    """
+    day = str(event_day or "").strip().lower()
+    if day in _BLANK_LOCATION_DAYS:
+        day = "sun"
+    updated = 0
+    for loc in locations:
+        if not isinstance(loc, dict):
+            continue
+        cur = str(loc.get("day") or "").strip().lower()
+        if overwrite:
+            if cur != day:
+                loc["day"] = day
+                updated += 1
+        elif cur in _BLANK_LOCATION_DAYS:
+            loc["day"] = day
+            updated += 1
+    return updated
 
 
 def _normalize_segment_schema(schema: Any) -> str:
@@ -1169,7 +1223,9 @@ def merge_leg_locations_into_course(
     for loc in course.get("locations") or []:
         if not isinstance(loc, dict) or loc.get("source") != "leg":
             continue
-        loc_key = str(loc.get("location_key") or "").strip()
+        from app.core.locations.identity import effective_pass_key
+
+        loc_key = effective_pass_key(loc)
         if loc_key:
             existing_by_loc_key[loc_key] = loc
         leg_key = str(loc.get("leg_loc_key") or "").strip()
@@ -1206,11 +1262,18 @@ def merge_leg_locations_into_course(
             )
         ):
             key = leg_loc_key(leg_id, i)
-            loc_key = str(loc.get("location_key") or "").strip()
+            loc_key = str(
+                loc.get("pass_key") or loc.get("location_key") or ""
+            ).strip()
             prev = existing_by_loc_key.get(loc_key) if loc_key else None
             if prev is None:
                 prev = existing_by_leg_loc_key.get(key)
             on_course = loc["loc_type"] in ON_COURSE_LOCATION_TYPES
+            inherited_key = ""
+            if prev:
+                inherited_key = str(
+                    prev.get("pass_key") or prev.get("location_key") or ""
+                ).strip()
             row: Dict[str, Any] = {
                 "loc_label": loc["loc_label"],
                 "loc_type": loc["loc_type"],
@@ -1218,20 +1281,26 @@ def merge_leg_locations_into_course(
                 "lon": loc["lon"],
                 "leg_id": leg_id,
                 "leg_loc_key": key,
-                "location_key": loc_key or (prev.get("location_key") if prev else ""),
+                "pass_key": loc_key or inherited_key,
+                "location_key": loc_key or inherited_key,
                 "placement": loc.get("placement", "along"),
                 "source": "leg",
                 "seg_id": seg_id if on_course else "",
             }
-            if not row["location_key"]:
+            if not row["pass_key"]:
                 ensure_location_key(row, used_loc_keys)
+                row["pass_key"] = row.get("location_key") or ""
             for ev, flag in event_flags.items():
                 row[ev] = flag
             for ev in COURSE_EVENT_IDS:
                 row.setdefault(ev, "n")
 
             for field in preserve_fields:
-                if on_course and field in ("proxy_loc_id", "proxy_leg_loc_key"):
+                if on_course and field in (
+                    "proxy_loc_id",
+                    "proxy_pass_id",
+                    "proxy_leg_loc_key",
+                ):
                     continue
                 if field in row and row[field] not in (None, ""):
                     continue
@@ -1244,16 +1313,23 @@ def merge_leg_locations_into_course(
                     row[field] = val
 
             if prev:
-                prev_id = parse_location_id(prev.get("id", prev.get("loc_id")))
+                prev_id = parse_location_id(prev.get("pass_id", prev.get("id")))
                 if prev_id is not None and prev_id > 0 and prev_id not in used_ids:
                     row["id"] = prev_id
+                    row["pass_id"] = prev_id
                     used_ids.add(prev_id)
                 else:
-                    row["id"] = allocate_location_id(used_ids)
+                    new_id = allocate_location_id(used_ids)
+                    row["id"] = new_id
+                    row["pass_id"] = new_id
                 for field in preserve_fields:
                     if field in _LEG_OWNED_PLACEMENT_FIELDS:
                         continue
-                    if on_course and field in ("proxy_loc_id", "proxy_leg_loc_key"):
+                    if on_course and field in (
+                        "proxy_loc_id",
+                        "proxy_pass_id",
+                        "proxy_leg_loc_key",
+                    ):
                         continue
                     if field not in prev:
                         continue
@@ -1265,7 +1341,9 @@ def merge_leg_locations_into_course(
                     if val not in (None, ""):
                         row[field] = val
             else:
-                row["id"] = allocate_location_id(used_ids)
+                new_id = allocate_location_id(used_ids)
+                row["id"] = new_id
+                row["pass_id"] = new_id
             _sanitize_location_proxy_timing(row)
             locations.append(row)
 
@@ -1273,6 +1351,10 @@ def merge_leg_locations_into_course(
     _resolve_location_proxy_leg_keys(locations)
     for loc in locations:
         _sanitize_location_proxy_timing(loc)
+    stamp_locations_with_package_day(locations, package_event_day(cid))
+    from app.core.locations.identity import stamp_pass_identity
+
+    stamp_pass_identity(locations)
     course["locations"] = locations
     save_config_course(cid, course)
 

--- a/app/core/config_package/location_keys.py
+++ b/app/core/config_package/location_keys.py
@@ -34,14 +34,22 @@ def ensure_location_key(
     loc: Dict[str, Any],
     used: Optional[Set[str]] = None,
 ) -> str:
-    """Ensure ``loc`` has a valid ``location_key``; return the key."""
+    """
+    Ensure ``loc`` has a valid ``location_key``; return the key.
+
+    Issue #810: a valid existing key is always preserved, even if already present
+    in ``used``. Paired reverse legs intentionally share one key for the same
+    physical Location. Newly allocated keys are added to ``used`` when provided.
+    """
     existing = str(loc.get("location_key") or "").strip()
-    taken = {str(k).strip() for k in (used or set()) if k}
-    if is_valid_location_key(existing) and existing not in taken:
+    taken = used if used is not None else set()
+    if is_valid_location_key(existing):
         loc["location_key"] = existing
-        taken.add(existing)
+        if used is not None:
+            used.add(existing)
         return existing
     key = generate_location_key(taken)
     loc["location_key"] = key
-    taken.add(key)
+    if used is not None:
+        used.add(key)
     return key

--- a/app/core/config_package/package_analysis.py
+++ b/app/core/config_package/package_analysis.py
@@ -187,9 +187,12 @@ def build_package_analyze_payload(
         f"{day}-all": ", ".join(names) for day, names in sorted(by_day.items())
     }
 
-    locations_file = "locations.csv"
+    locations_file = "passes.csv"
     if not (package_path / locations_file).is_file():
-        raise ValueError("Missing locations.csv in package root")
+        if (package_path / "locations.csv").is_file():
+            locations_file = "locations.csv"
+        else:
+            raise ValueError("Missing passes.csv (or legacy locations.csv) in package root")
 
     desc = str(description or manifest.get("label") or cid).strip()[:254]
 

--- a/app/core/config_package/storage.py
+++ b/app/core/config_package/storage.py
@@ -52,7 +52,8 @@ INDEX_NAME = "index.json"
 PACKAGE_SIGNAL_FILES = (
     "segments.csv",
     "flow.csv",
-    "locations.csv",
+    "passes.csv",
+    "locations.csv",  # legacy signal during cutover
     COURSE_WORKSPACE_NAME,
     CONFIG_MANIFEST_NAME,
 )
@@ -115,14 +116,20 @@ def package_readiness(package_path: Path) -> Dict[str, Any]:
         if p.is_file() and not p.name.startswith(".")
     )
     missing = []
-    for required in ("segments.csv", "flow.csv", "locations.csv"):
+    has_passes = (package_path / "passes.csv").is_file() or (
+        package_path / "locations.csv"
+    ).is_file()
+    for required in ("segments.csv", "flow.csv"):
         if not (package_path / required).is_file():
             missing.append(required)
+    if not has_passes:
+        missing.append("passes.csv")
     has_runners = any(package_path.glob("*_runners.csv"))
     has_gpx = any(package_path.glob("*.gpx"))
     analyze_ready = (
         (package_path / "segments.csv").is_file()
         and (package_path / "flow.csv").is_file()
+        and has_passes
         and has_runners
         and has_gpx
     )
@@ -833,13 +840,24 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
         enrich_segments_event_distances(segments, COURSE_EVENT_IDS)
 
     from app.core.config_package.legs import (
+        package_event_day,
         refresh_location_seg_ids_from_segments,
+        stamp_locations_with_package_day,
         validate_locations_for_export,
     )
+    from app.core.locations.identity import stamp_pass_identity
 
     locations = course.get("locations") or []
-    if refresh_location_seg_ids_from_segments(locations, segments):
-        course["locations"] = locations
+    day_stamped = stamp_locations_with_package_day(
+        locations, package_event_day(cid)
+    )
+    stamp_pass_identity(locations)
+    seg_refreshed = refresh_location_seg_ids_from_segments(locations, segments)
+    course["locations"] = locations
+    if day_stamped or seg_refreshed:
+        save_config_course(cid, course)
+    else:
+        # Always persist pass identity fields when stamped
         save_config_course(cid, course)
 
     loc_errors = validate_locations_for_export(course)
@@ -861,15 +879,27 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
     target.write_text(csv_content, encoding="utf-8")
     _validate_exported_segments_file(target)
 
-    locations_target = package_path / "locations.csv"
+    locations_target = package_path / "passes.csv"
     locations_backup_path: Optional[Path] = None
     locations = course.get("locations") or []
     resource_codes = load_package_resource_codes(cid)
     locations_csv = build_locations_csv(course, resource_codes=resource_codes)
     if locations_target.is_file():
         stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
-        locations_backup_path = package_path / f"locations.csv.bak.{stamp}"
+        locations_backup_path = package_path / f"passes.csv.bak.{stamp}"
         shutil.copy2(locations_target, locations_backup_path)
+    # Migrate legacy locations.csv → passes.csv once
+    legacy_locations = package_path / "locations.csv"
+    if legacy_locations.is_file() and not locations_target.is_file():
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        legacy_locations.rename(
+            package_path / f"locations.csv.bak.{stamp}"
+        )
+    elif legacy_locations.is_file():
+        # Keep a backup of the old name for operators; canonical file is passes.csv
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        shutil.copy2(legacy_locations, package_path / f"locations.csv.bak.{stamp}")
+        legacy_locations.unlink()
     locations_target.write_text(locations_csv, encoding="utf-8")
 
     from app.core.config_package.segment_recipes import export_package_flow_and_gpx_files
@@ -877,7 +907,7 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
     flow_gpx = export_package_flow_and_gpx_files(cid)
 
     logger.info(
-        "Exported segments.csv (%s rows) and locations.csv (%s rows) for config package %s",
+        "Exported segments.csv (%s rows) and passes.csv (%s rows) for config package %s",
         len(segments),
         len(locations),
         cid,
@@ -889,6 +919,7 @@ def export_config_package_segments(config_id: str) -> Dict[str, Any]:
         "segments_backup_path": str(backup_path) if backup_path else None,
         "segment_count": len(segments),
         "locations_path": str(locations_target),
+        "passes_path": str(locations_target),
         "locations_backup_path": str(locations_backup_path) if locations_backup_path else None,
         "location_count": len(locations),
         "flow_gpx": flow_gpx,

--- a/app/core/course/export.py
+++ b/app/core/course/export.py
@@ -302,7 +302,8 @@ def build_locations_csv(
     course: Dict[str, Any],
     resource_codes: Optional[List[str]] = None,
 ) -> str:
-    """Build full locations.csv from course.locations (Issue #765 pipeline schema)."""
+    """Build passes.csv content from course.locations (2027 pass-level schema)."""
+    from app.core.locations.identity import stamp_pass_identity
     from app.core.locations.schema import (
         location_to_csv_row,
         locations_csv_columns,
@@ -319,14 +320,15 @@ def build_locations_csv(
     else:
         codes = [normalize_resource_code(c) for c in registry]
 
+    locations = [loc for loc in (course.get("locations") or []) if isinstance(loc, dict)]
+    stamp_pass_identity(locations)
+    course["locations"] = locations
+
     columns = locations_csv_columns(codes)
-    locations = course.get("locations") or []
     out = io.StringIO()
     w = csv.DictWriter(out, fieldnames=columns, extrasaction="ignore")
     w.writeheader()
     for i, loc in enumerate(locations):
-        if not isinstance(loc, dict):
-            continue
         w.writerow(location_to_csv_row(loc, codes))
     return out.getvalue()
 

--- a/app/core/locations/identity.py
+++ b/app/core/locations/identity.py
@@ -1,0 +1,177 @@
+"""
+Location / pass identity (2027 terminology).
+
+- ``loc_id``: short human integer for a Location (phone / UI / one-pager)
+- ``pass_id``: timed instance (course.json ``id``; package/analysis pass rows)
+- ``pass_key``: opaque Crockford unifier for passes at the same Location (system join)
+
+``leg_loc_key`` remains the leg-library pin identity (``{leg_id}:{index}``).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, MutableMapping, Optional, Sequence, Set
+
+from app.core.config_package.location_ids import (
+    allocate_location_id,
+    assign_unique_location_ids,
+    parse_location_id,
+)
+from app.core.config_package.location_keys import (
+    ensure_location_key,
+    is_valid_location_key,
+)
+
+
+def effective_pass_key(row: MutableMapping[str, Any]) -> str:
+    """Return trimmed pass_key (legacy location_key / leg_loc_key fallback)."""
+    for field in ("pass_key", "location_key", "leg_loc_key"):
+        raw = row.get(field)
+        if raw is None:
+            continue
+        text = str(raw).strip()
+        if text and text.lower() not in ("nan", "none", "null"):
+            return text
+    return ""
+
+
+def get_pass_id(row: MutableMapping[str, Any]) -> Optional[int]:
+    """Pass instance id from ``pass_id`` or course ``id`` (not human ``loc_id``)."""
+    for field in ("pass_id", "id"):
+        parsed = parse_location_id(row.get(field))
+        if parsed is not None and parsed > 0:
+            return parsed
+    return None
+
+
+def get_loc_id(row: MutableMapping[str, Any]) -> Optional[int]:
+    """Human Location id when present as ``loc_id``."""
+    parsed = parse_location_id(row.get("loc_id"))
+    if parsed is not None and parsed > 0:
+        return parsed
+    return None
+
+
+def migrate_pass_key_fields(loc: MutableMapping[str, Any]) -> None:
+    """Normalize ``pass_key`` from legacy ``location_key`` on a course/pass row."""
+    pk = str(loc.get("pass_key") or "").strip()
+    if not pk or pk.lower() in ("nan", "none", "null"):
+        legacy = str(loc.get("location_key") or "").strip()
+        if legacy and legacy.lower() not in ("nan", "none", "null"):
+            loc["pass_key"] = legacy
+    if loc.get("pass_key"):
+        # Keep legacy field in sync for older UI/readers during cutover.
+        loc["location_key"] = loc["pass_key"]
+
+
+def migrate_proxy_pass_fields(loc: MutableMapping[str, Any]) -> None:
+    """Normalize ``proxy_pass_id`` from legacy ``proxy_loc_id``."""
+    if loc.get("proxy_pass_id") not in (None, ""):
+        return
+    legacy = loc.get("proxy_loc_id")
+    if legacy not in (None, ""):
+        loc["proxy_pass_id"] = legacy
+
+
+def ensure_pass_key(loc: Dict[str, Any], used: Optional[Set[str]] = None) -> str:
+    """Ensure a valid Crockford ``pass_key`` (shared keys allowed for paired passes)."""
+    migrate_pass_key_fields(loc)
+    # Promote a Crockford-shaped leg_loc_key when pass_key is still empty
+    if not is_valid_location_key(loc.get("pass_key") or loc.get("location_key")):
+        leg = str(loc.get("leg_loc_key") or "").strip()
+        if is_valid_location_key(leg):
+            loc["pass_key"] = leg
+            loc["location_key"] = leg
+    if loc.get("pass_key") and not loc.get("location_key"):
+        loc["location_key"] = loc["pass_key"]
+    key = ensure_location_key(loc, used)
+    loc["pass_key"] = key
+    loc["location_key"] = key
+    return key
+
+
+def stamp_pass_identity(locations: Sequence[Dict[str, Any]]) -> None:
+    """
+    Stamp pass_id / pass_key / loc_id on course location rows in place.
+
+    - ``id`` and ``pass_id`` are unique per timed pass
+    - ``pass_key`` groups passes at the same Location
+    - ``loc_id`` is a stable short int shared by all rows with the same pass_key
+    """
+    locs: List[Dict[str, Any]] = [loc for loc in locations if isinstance(loc, dict)]
+    if not locs:
+        return
+
+    used_keys: Set[str] = set()
+    for loc in locs:
+        migrate_pass_key_fields(loc)
+        migrate_proxy_pass_fields(loc)
+        # Prefer existing valid pass_key when collecting used set for allocation
+        existing = str(loc.get("pass_key") or loc.get("location_key") or "").strip()
+        if is_valid_location_key(existing):
+            used_keys.add(existing)
+
+    for loc in locs:
+        ensure_pass_key(loc, used_keys)
+
+    assign_unique_location_ids(locs)
+    for loc in locs:
+        pid = parse_location_id(loc.get("id"))
+        if pid is not None:
+            loc["pass_id"] = pid
+            loc["id"] = pid
+        # proxy: prefer proxy_pass_id; keep proxy_loc_id alias for older editors
+        migrate_proxy_pass_fields(loc)
+        if loc.get("proxy_pass_id") not in (None, ""):
+            loc["proxy_loc_id"] = loc["proxy_pass_id"]
+
+    _assign_human_loc_ids(locs)
+
+
+def _assign_human_loc_ids(locs: Sequence[Dict[str, Any]]) -> None:
+    """Assign human ``loc_id`` per distinct ``pass_key`` (preserve existing when consistent)."""
+    key_groups: Dict[str, List[Dict[str, Any]]] = {}
+    singles: List[Dict[str, Any]] = []
+    for loc in locs:
+        key = effective_pass_key(loc)
+        if key:
+            key_groups.setdefault(key, []).append(loc)
+        else:
+            singles.append(loc)
+
+    key_to_loc_id: Dict[str, int] = {}
+    used_loc_ids: Set[int] = set()
+
+    for key, group in key_groups.items():
+        loc_ids = [get_loc_id(r) for r in group]
+        unique = {i for i in loc_ids if i is not None}
+        if len(group) >= 2 and len(unique) == 1:
+            # Paired passes already share a human loc_id
+            shared = next(iter(unique))
+            key_to_loc_id[key] = shared
+            used_loc_ids.add(shared)
+            continue
+        if len(group) == 1 and loc_ids[0] is not None:
+            lid = loc_ids[0]
+            pid = get_pass_id(group[0])
+            # Legacy CSV: loc_id was the pass instance — treat as unset
+            if lid != pid:
+                key_to_loc_id[key] = lid
+                used_loc_ids.add(lid)
+
+    for key in sorted(key_groups.keys()):
+        if key not in key_to_loc_id:
+            key_to_loc_id[key] = allocate_location_id(used_loc_ids)
+
+    for loc in locs:
+        key = effective_pass_key(loc)
+        if key:
+            loc["loc_id"] = key_to_loc_id[key]
+            continue
+        # No pass_key: 1:1 loc_id per pass (allocate if missing / legacy)
+        lid = get_loc_id(loc)
+        pid = get_pass_id(loc)
+        if lid is not None and lid != pid and lid not in used_loc_ids:
+            used_loc_ids.add(lid)
+            continue
+        loc["loc_id"] = allocate_location_id(used_loc_ids)

--- a/app/core/locations/pairing.py
+++ b/app/core/locations/pairing.py
@@ -1,0 +1,348 @@
+"""
+Paired reverse-leg pass helpers (Issue #810 / 2027 identity).
+
+Multiple pass rows sharing a ``pass_key`` are passes at the same Location.
+Outbound = earlier ``first_runner``; return = later ``first_runner``.
+
+Terminology:
+- ``loc_id`` — human Location number (shared by paired passes)
+- ``pass_id`` — timed instance
+- ``pass_key`` — opaque unifier (system join; not volunteer-facing)
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from typing import Any, Dict, Iterable, List, MutableMapping, Optional, Sequence, Tuple
+
+from app.core.locations.identity import effective_pass_key
+
+logger = logging.getLogger(__name__)
+
+
+def effective_location_key(row: MutableMapping[str, Any]) -> str:
+    """Alias for effective_pass_key (legacy name)."""
+    return effective_pass_key(row)
+
+
+def time_to_seconds(value: Any) -> Optional[int]:
+    """Parse HH:MM[:SS] (or pandas-ish) into seconds since midnight."""
+    if value is None:
+        return None
+    if isinstance(value, float) and math.isnan(value):
+        return None
+    text = str(value).strip()
+    if not text or text.upper() in ("NA", "NAN", "NONE", "NULL"):
+        return None
+    parts = text.split(":")
+    try:
+        if len(parts) == 2:
+            h, m = int(parts[0]), int(parts[1])
+            return h * 3600 + m * 60
+        if len(parts) >= 3:
+            h, m, s = int(parts[0]), int(parts[1]), int(float(parts[2]))
+            return h * 3600 + m * 60 + s
+    except (TypeError, ValueError):
+        return None
+    return None
+
+
+def min_time_str(values: Iterable[Any]) -> Optional[str]:
+    """Earliest HH:MM:SS among values; preserve original string of the winner."""
+    best: Optional[Tuple[int, str]] = None
+    for value in values:
+        sec = time_to_seconds(value)
+        if sec is None:
+            continue
+        text = str(value).strip()
+        if best is None or sec < best[0]:
+            best = (sec, text)
+    return best[1] if best else None
+
+
+def max_time_str(values: Iterable[Any]) -> Optional[str]:
+    """Latest HH:MM:SS among values; preserve original string of the winner."""
+    best: Optional[Tuple[int, str]] = None
+    for value in values:
+        sec = time_to_seconds(value)
+        if sec is None:
+            continue
+        text = str(value).strip()
+        if best is None or sec > best[0]:
+            best = (sec, text)
+    return best[1] if best else None
+
+
+def _row_pass_id(row: MutableMapping[str, Any]) -> Any:
+    for field in ("pass_id", "id"):
+        raw = row.get(field)
+        if raw is None or raw == "":
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return raw
+    # Legacy report rows used loc_id as the instance id
+    raw = row.get("loc_id")
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return raw
+
+
+def annotate_location_passes(rows: Sequence[MutableMapping[str, Any]]) -> None:
+    """
+    Mutate report rows in place: set ``pass`` and ``same_pass_as``.
+
+    Also mirrors ``same_location_as`` for older importers during cutover.
+    """
+    by_key: Dict[str, List[MutableMapping[str, Any]]] = {}
+    for row in rows:
+        key = effective_pass_key(row)
+        if key:
+            row["pass_key"] = key
+            row.setdefault("location_key", key)
+        row["pass"] = ""
+        row["same_pass_as"] = ""
+        row["same_location_as"] = ""
+        if not key:
+            continue
+        by_key.setdefault(key, []).append(row)
+
+    for key, group in by_key.items():
+        if len(group) < 2:
+            continue
+        if len(group) > 2:
+            logger.warning(
+                "pass_key=%s has %s rows (expected 2); "
+                "assigning passes by first_runner order",
+                key,
+                len(group),
+            )
+
+        def sort_key(r: MutableMapping[str, Any]) -> Tuple[int, int]:
+            fr = time_to_seconds(r.get("first_runner"))
+            try:
+                pid = int(_row_pass_id(r) or 10**9)
+            except (TypeError, ValueError):
+                pid = 10**9
+            return (fr if fr is not None else 10**9, pid)
+
+        ordered = sorted(group, key=sort_key)
+        outbound = ordered[0]
+        outbound_id = _row_pass_id(outbound)
+
+        for i, row in enumerate(ordered):
+            role = "outbound" if i == 0 else "return"
+            row["pass"] = role
+            if role == "outbound":
+                peer = ordered[1] if len(ordered) > 1 else None
+                peer_id = _row_pass_id(peer) if peer else ""
+                row["same_pass_as"] = peer_id if peer_id is not None else ""
+            else:
+                row["same_pass_as"] = outbound_id if outbound_id is not None else ""
+            row["same_location_as"] = row["same_pass_as"]
+
+
+def group_rows_by_location_key(
+    rows: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """
+    Collapse flat pass rows into Location-centric groups for UI / sheets.
+
+    Each group dict includes ``loc_id`` (human), ``pass_key``, ``pass_ids``,
+    ``passes``, and combined earliest/latest timing windows.
+    """
+    working = [dict(r) for r in rows]
+    annotate_location_passes(working)
+
+    singles: List[Dict[str, Any]] = []
+    by_key: Dict[str, List[Dict[str, Any]]] = {}
+    for row in working:
+        key = effective_pass_key(row)
+        if not key:
+            singles.append(_singleton_group(row))
+            continue
+        by_key.setdefault(key, []).append(row)
+
+    groups: List[Dict[str, Any]] = list(singles)
+    for key, group in by_key.items():
+        if len(group) == 1:
+            groups.append(_singleton_group(group[0], pass_key=key))
+            continue
+        groups.append(_paired_group(key, group))
+
+    def sort_loc(g: Dict[str, Any]) -> int:
+        try:
+            return int(g.get("loc_id") or g.get("primary_loc_id") or 0)
+        except (TypeError, ValueError):
+            return 0
+
+    groups.sort(key=sort_loc)
+    return groups
+
+
+def consolidate_location_rows(
+    pass_rows: Sequence[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """
+    Build Locations.csv rows (one per loc_id) from Passes.csv-style rows.
+
+    Combined window = earliest first_runner / loc_start and latest last_runner / loc_end.
+    """
+    groups = group_rows_by_location_key(pass_rows)
+    out: List[Dict[str, Any]] = []
+    for g in groups:
+        passes = g.get("passes") or []
+        pass_ids = []
+        for p in passes:
+            pid = _row_pass_id(p)
+            if pid is not None and pid != "":
+                pass_ids.append(pid)
+        row = {
+            "loc_id": g.get("loc_id") if g.get("loc_id") is not None else g.get("primary_loc_id"),
+            "pass_key": g.get("pass_key") or g.get("location_key") or "",
+            "pass_ids": ",".join(str(p) for p in pass_ids),
+            "pass_count": len(passes),
+            "loc_label": g.get("loc_label"),
+            "day": next((p.get("day") for p in passes if p.get("day")), ""),
+            "loc_type": g.get("loc_type"),
+            "lat": g.get("lat"),
+            "lon": g.get("lon"),
+            "zone": g.get("zone"),
+            "first_runner": g.get("first_runner"),
+            "last_runner": g.get("last_runner"),
+            "loc_start": g.get("loc_start"),
+            "loc_end": g.get("loc_end"),
+            "peak_start": g.get("peak_start"),
+            "peak_end": g.get("peak_end"),
+            "flag": g.get("flag"),
+            "onepage": g.get("onepage"),
+            "notes": g.get("notes"),
+        }
+        for k, v in g.items():
+            if k.endswith("_count") or k.endswith("_mins"):
+                row[k] = v
+        out.append(row)
+    return out
+
+
+def _human_loc_id(row: Dict[str, Any]) -> Any:
+    raw = row.get("loc_id")
+    # If this is a legacy pass-only row, loc_id may actually be pass_id;
+    # prefer explicit human field when pass_id is also present and differs.
+    pass_id = row.get("pass_id")
+    if pass_id is not None and raw is not None:
+        try:
+            if int(raw) != int(pass_id):
+                return int(raw)
+            return int(raw)  # may still be human if already stamped
+        except (TypeError, ValueError):
+            return raw
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return raw
+
+
+def _singleton_group(
+    row: Dict[str, Any], *, pass_key: Optional[str] = None
+) -> Dict[str, Any]:
+    key = pass_key if pass_key is not None else effective_pass_key(row)
+    loc_id = _human_loc_id(row)
+    pass_id = _row_pass_id(row)
+    return {
+        "pass_key": key,
+        "location_key": key,
+        "loc_id": loc_id,
+        "loc_label": row.get("loc_label"),
+        "loc_type": row.get("loc_type"),
+        "zone": row.get("zone"),
+        "lat": row.get("lat"),
+        "lon": row.get("lon"),
+        "primary_loc_id": loc_id,
+        "loc_ids": [loc_id],
+        "pass_ids": [pass_id],
+        "passes": [row],
+        "paired": False,
+        "first_runner": row.get("first_runner"),
+        "last_runner": row.get("last_runner"),
+        "loc_start": row.get("loc_start"),
+        "loc_end": row.get("loc_end"),
+        "peak_start": row.get("peak_start"),
+        "peak_end": row.get("peak_end"),
+        "flag": row.get("flag"),
+        "onepage": row.get("onepage"),
+        "notes": row.get("notes"),
+        **{k: row[k] for k in row if k.endswith("_count") or k.endswith("_mins")},
+    }
+
+
+def _paired_group(key: str, group: List[Dict[str, Any]]) -> Dict[str, Any]:
+    ordered = sorted(
+        group,
+        key=lambda r: (
+            0 if str(r.get("pass") or "") == "outbound" else 1,
+            time_to_seconds(r.get("first_runner")) or 10**9,
+        ),
+    )
+    primary = ordered[0]
+    loc_id = _human_loc_id(primary)
+    # Prefer shared human loc_id from any row that differs from its pass_id
+    for r in ordered:
+        candidate = _human_loc_id(r)
+        pid = _row_pass_id(r)
+        try:
+            if candidate is not None and int(candidate) != int(pid):
+                loc_id = int(candidate)
+                break
+        except (TypeError, ValueError):
+            pass
+
+    pass_ids = [_row_pass_id(r) for r in ordered]
+
+    merged_counts: Dict[str, Any] = {}
+    for r in ordered:
+        for k, v in r.items():
+            if k.endswith("_count") or k.endswith("_mins"):
+                try:
+                    num = float(v) if v is not None and str(v) not in ("", "nan") else 0
+                except (TypeError, ValueError):
+                    num = 0
+                prev = merged_counts.get(k, 0) or 0
+                try:
+                    merged_counts[k] = max(float(prev), num)
+                except (TypeError, ValueError):
+                    merged_counts[k] = num
+
+    return {
+        "pass_key": key,
+        "location_key": key,
+        "loc_id": loc_id,
+        "loc_label": primary.get("loc_label"),
+        "loc_type": primary.get("loc_type"),
+        "zone": primary.get("zone"),
+        "lat": primary.get("lat"),
+        "lon": primary.get("lon"),
+        "primary_loc_id": loc_id,
+        "loc_ids": [loc_id],
+        "pass_ids": pass_ids,
+        "passes": ordered,
+        "paired": True,
+        "first_runner": min_time_str(r.get("first_runner") for r in ordered),
+        "last_runner": max_time_str(r.get("last_runner") for r in ordered),
+        "loc_start": min_time_str(r.get("loc_start") for r in ordered),
+        "loc_end": max_time_str(r.get("loc_end") for r in ordered),
+        "peak_start": min_time_str(r.get("peak_start") for r in ordered),
+        "peak_end": max_time_str(r.get("peak_end") for r in ordered),
+        "flag": any(
+            r.get("flag") in (True, "true", "True", "Y", "y", 1, "1") for r in ordered
+        ),
+        "onepage": "y"
+        if any(str(r.get("onepage", "")).strip().lower() == "y" for r in ordered)
+        else primary.get("onepage"),
+        "notes": primary.get("notes")
+        or next((r.get("notes") for r in ordered if r.get("notes")), ""),
+        **merged_counts,
+    }

--- a/app/core/locations/schema.py
+++ b/app/core/locations/schema.py
@@ -24,6 +24,7 @@ _RESOURCE_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,15}$")
 
 LOCATIONS_CSV_PREFIX_COLUMNS: List[str] = [
     "loc_id",
+    "location_key",
     "loc_label",
     "loc_type",
     "lat",
@@ -164,6 +165,18 @@ def _sync_resources_dict(
     return resources
 
 
+def _export_location_key(normalized: Dict[str, Any]) -> str:
+    """Stable authoring key for pipeline CSV (falls back to leg_loc_key)."""
+    for field in ("location_key", "leg_loc_key"):
+        raw = normalized.get(field)
+        if raw is None or raw == "":
+            continue
+        text = str(raw).strip()
+        if text and text.lower() != "nan":
+            return text
+    return ""
+
+
 def normalize_location_record(
     loc: Dict[str, Any],
     resource_codes: Sequence[str],
@@ -233,6 +246,7 @@ def location_to_csv_row(
     normalized = normalize_location_record(loc, resource_codes)
     row: Dict[str, Any] = {
         "loc_id": normalized["id"],
+        "location_key": _export_location_key(normalized),
         "loc_label": normalized.get("loc_label", ""),
         "loc_type": normalized.get("loc_type", "course"),
         "lat": normalized.get("lat", ""),

--- a/app/core/locations/schema.py
+++ b/app/core/locations/schema.py
@@ -22,14 +22,16 @@ DEFAULT_PACKAGE_RESOURCES: List[Dict[str, str]] = [
 
 _RESOURCE_CODE_RE = re.compile(r"^[a-z][a-z0-9_]{0,15}$")
 
-LOCATIONS_CSV_PREFIX_COLUMNS: List[str] = [
+# Package / pipeline pass-level CSV (one row per timed pass).
+PASSES_CSV_PREFIX_COLUMNS: List[str] = [
+    "pass_id",
     "loc_id",
-    "location_key",
+    "pass_key",
     "loc_label",
     "loc_type",
     "lat",
     "lon",
-    "proxy_loc_id",
+    "proxy_pass_id",
     "seg_id",
     "day",
     "zone",
@@ -41,6 +43,9 @@ LOCATIONS_CSV_PREFIX_COLUMNS: List[str] = [
     "buffer",
     "interval",
 ]
+
+# Back-compat alias used by older call sites during cutover.
+LOCATIONS_CSV_PREFIX_COLUMNS: List[str] = PASSES_CSV_PREFIX_COLUMNS
 
 LOCATIONS_CSV_SUFFIX_COLUMNS: List[str] = [
     "onepage",
@@ -96,14 +101,19 @@ def ensure_manifest_resources(manifest: Dict[str, Any]) -> List[Dict[str, str]]:
     return registry
 
 
-def locations_csv_columns(resource_codes: Sequence[str]) -> List[str]:
+def passes_csv_columns(resource_codes: Sequence[str]) -> List[str]:
     codes = [normalize_resource_code(c) for c in resource_codes]
     count_cols = [count_column(c) for c in codes]
     return (
-        list(LOCATIONS_CSV_PREFIX_COLUMNS)
+        list(PASSES_CSV_PREFIX_COLUMNS)
         + count_cols
         + list(LOCATIONS_CSV_SUFFIX_COLUMNS)
     )
+
+
+def locations_csv_columns(resource_codes: Sequence[str]) -> List[str]:
+    """Alias: package pipeline CSV is pass-level (see passes_csv_columns)."""
+    return passes_csv_columns(resource_codes)
 
 
 def _yn(value: Any, default: str = "n") -> str:
@@ -123,7 +133,12 @@ def _default_location_fields() -> Dict[str, Any]:
         "loc_type": "course",
         "lat": "",
         "lon": "",
-        "proxy_loc_id": "",
+        "proxy_pass_id": "",
+        "proxy_loc_id": "",  # legacy alias of proxy_pass_id
+        "pass_key": "",
+        "location_key": "",  # legacy alias of pass_key
+        "loc_id": "",
+        "pass_id": "",
         "seg_id": "",
         "day": "",
         "zone": "",
@@ -165,9 +180,9 @@ def _sync_resources_dict(
     return resources
 
 
-def _export_location_key(normalized: Dict[str, Any]) -> str:
-    """Stable authoring key for pipeline CSV (falls back to leg_loc_key)."""
-    for field in ("location_key", "leg_loc_key"):
+def _export_pass_key(normalized: Dict[str, Any]) -> str:
+    """Opaque pass_key for pipeline CSV (falls back to legacy location_key / leg_loc_key)."""
+    for field in ("pass_key", "location_key", "leg_loc_key"):
         raw = normalized.get(field)
         if raw is None or raw == "":
             continue
@@ -183,19 +198,38 @@ def normalize_location_record(
     *,
     index: int = 0,
 ) -> Dict[str, Any]:
-    """Normalize a course.json location object for editor + export."""
+    """Normalize a course.json location (pass) object for editor + export."""
     if not isinstance(loc, dict):
         raise ValueError("location must be an object")
+
+    from app.core.locations.identity import (
+        effective_pass_key,
+        get_loc_id,
+        get_pass_id,
+        migrate_pass_key_fields,
+        migrate_proxy_pass_fields,
+    )
 
     defaults = _default_location_fields()
     out: Dict[str, Any] = dict(defaults)
     out.update(loc)
+    migrate_pass_key_fields(out)
+    migrate_proxy_pass_fields(out)
 
-    loc_id = out.get("id", out.get("loc_id", index + 1))
-    try:
-        out["id"] = int(loc_id)
-    except (TypeError, ValueError):
-        out["id"] = index + 1
+    pass_id = get_pass_id(out)
+    if pass_id is None:
+        pass_id = index + 1
+    out["id"] = pass_id
+    out["pass_id"] = pass_id
+
+    human_loc = get_loc_id(out)
+    if human_loc is not None:
+        out["loc_id"] = human_loc
+
+    pk = effective_pass_key(out)
+    if pk:
+        out["pass_key"] = pk
+        out["location_key"] = pk
 
     if out.get("loc_description") and not out.get("notes"):
         out["notes"] = str(out.pop("loc_description")).strip()
@@ -213,6 +247,7 @@ def normalize_location_record(
             out[key] = defaults[key]
 
     for key in (
+        "proxy_pass_id",
         "proxy_loc_id",
         "seg_id",
         "day",
@@ -221,6 +256,7 @@ def normalize_location_record(
         "contact",
         "notes",
         "loc_label",
+        "pass_key",
         "location_key",
         "leg_loc_key",
         "leg_id",
@@ -232,6 +268,11 @@ def normalize_location_record(
         else:
             out[key] = str(out[key]).strip() if key != "loc_label" else str(out[key])
 
+    if out.get("proxy_pass_id") and not out.get("proxy_loc_id"):
+        out["proxy_loc_id"] = out["proxy_pass_id"]
+    if out.get("proxy_loc_id") and not out.get("proxy_pass_id"):
+        out["proxy_pass_id"] = out["proxy_loc_id"]
+
     if not out.get("loc_type"):
         out["loc_type"] = "course"
 
@@ -242,16 +283,20 @@ def normalize_location_record(
 def location_to_csv_row(
     loc: Dict[str, Any], resource_codes: Sequence[str]
 ) -> Dict[str, Any]:
-    """Build a dict keyed by locations.csv column names."""
+    """Build a dict keyed by passes.csv column names (pass-level pipeline input)."""
     normalized = normalize_location_record(loc, resource_codes)
+    pass_id = normalized.get("pass_id") or normalized.get("id")
+    human_loc = normalized.get("loc_id", "")
+    proxy = normalized.get("proxy_pass_id") or normalized.get("proxy_loc_id") or ""
     row: Dict[str, Any] = {
-        "loc_id": normalized["id"],
-        "location_key": _export_location_key(normalized),
+        "pass_id": pass_id,
+        "loc_id": human_loc,
+        "pass_key": _export_pass_key(normalized),
         "loc_label": normalized.get("loc_label", ""),
         "loc_type": normalized.get("loc_type", "course"),
         "lat": normalized.get("lat", ""),
         "lon": normalized.get("lon", ""),
-        "proxy_loc_id": normalized.get("proxy_loc_id", ""),
+        "proxy_pass_id": proxy,
         "seg_id": normalized.get("seg_id", ""),
         "day": normalized.get("day", ""),
         "zone": normalized.get("zone", ""),
@@ -268,3 +313,7 @@ def location_to_csv_row(
     for code in resource_codes:
         row[count_column(code)] = resources.get(code, 0)
     return row
+
+
+# Back-compat name
+pass_to_csv_row = location_to_csv_row

--- a/app/core/v2/reports.py
+++ b/app/core/v2/reports.py
@@ -36,17 +36,32 @@ def write_combined_locations_csv(run_dir: Path) -> Optional[Path]:
     Returns:
         Path to combined CSV, or None if no per-day reports existed.
     """
+    return _write_combined_day_report_csv(
+        run_dir, filename="Locations.csv", sort_col="loc_id"
+    )
+
+
+def write_combined_passes_csv(run_dir: Path) -> Optional[Path]:
+    """Merge ``{day}/reports/Passes.csv`` into ``run_dir/Passes.csv``."""
+    return _write_combined_day_report_csv(
+        run_dir, filename="Passes.csv", sort_col="pass_id"
+    )
+
+
+def _write_combined_day_report_csv(
+    run_dir: Path, *, filename: str, sort_col: str
+) -> Optional[Path]:
     import pandas as pd
 
     frames: List[pd.DataFrame] = []
     for day_code in DAY_ORDER:
-        path = run_dir / day_code / "reports" / "Locations.csv"
+        path = run_dir / day_code / "reports" / filename
         if not path.exists():
             continue
         try:
             df = pd.read_csv(path)
         except Exception as e:
-            logger.warning("Issue #749: Could not read %s: %s", path, e)
+            logger.warning("Could not read %s: %s", path, e)
             continue
         if df.empty:
             continue
@@ -60,14 +75,17 @@ def write_combined_locations_csv(run_dir: Path) -> Optional[Path]:
     combined["_sort_day"] = combined["day"].astype(str).str.lower().map(
         lambda d: DAY_ORDER.index(d) if d in DAY_ORDER else len(DAY_ORDER)
     )
-    combined["_sort_loc"] = pd.to_numeric(combined["loc_id"], errors="coerce")
+    if sort_col in combined.columns:
+        combined["_sort_id"] = pd.to_numeric(combined[sort_col], errors="coerce")
+    else:
+        combined["_sort_id"] = pd.to_numeric(combined.get("loc_id"), errors="coerce")
     combined = combined.sort_values(
-        by=["_sort_day", "_sort_loc"], ascending=[True, True], na_position="last"
+        by=["_sort_day", "_sort_id"], ascending=[True, True], na_position="last"
     )
-    combined = combined.drop(columns=["_sort_day", "_sort_loc"])
-    out_path = run_dir / "Locations.csv"
+    combined = combined.drop(columns=["_sort_day", "_sort_id"])
+    out_path = run_dir / filename
     combined.to_csv(out_path, index=False)
-    logger.info("Issue #749: Wrote combined locations report: %s (%s rows)", out_path, len(combined))
+    logger.info("Wrote combined %s: %s (%s rows)", filename, out_path, len(combined))
     return out_path
 
 
@@ -348,6 +366,7 @@ def generate_reports_per_day(
     try:
         from app.utils.run_id import get_run_directory
         write_combined_locations_csv(get_run_directory(run_id))
+        write_combined_passes_csv(get_run_directory(run_id))
     except Exception as e:
         logger.warning("Issue #749: Combined Locations.csv not written: %s", e)
     

--- a/app/io/loader.py
+++ b/app/io/loader.py
@@ -57,47 +57,36 @@ def load_runners_by_event(runners_path: str):
 
 def load_locations(path: str):
     """
-    Load locations.csv with validation and normalization.
-    
-    Issue #277: Locations report input file.
-    
-    Args:
-        path: Path to locations.csv file
-        
-    Returns:
-        DataFrame with normalized location data
-        
-    Raises:
-        FileNotFoundError: If locations.csv file does not exist
+    Load passes.csv / locations.csv with validation and normalization.
+
+    2027 identity: ``pass_id`` (timed instance), ``loc_id`` (human Location),
+    ``pass_key`` (opaque unifier). Legacy files that used ``loc_id`` as the
+    instance id are upgraded in-memory.
     """
     from pathlib import Path
-    
+
     file_path = Path(path)
     if not file_path.exists():
         raise FileNotFoundError(
-            f"locations.csv not found at {file_path.absolute()}. "
-            f"Issue #277 requires locations.csv in the data/ directory. "
-            f"Please ensure the file exists with columns: loc_id, loc_label, loc_type, lat, lon, seg_id, zone, full, half, 10K, elite, open, buffer, interval, notes"
+            f"locations/passes file not found at {file_path.absolute()}. "
+            f"Expected passes.csv (or legacy locations.csv) with pass_id/loc_id columns."
         )
-    
+
     df = pd.read_csv(path)
-    
-    # One-pager flag: canonical column name is ``onepage`` (y/n). Use this in locations.csv
-    # so locations_results.json and Loc Sheets use a single field (Issue #735).
-    
+    df = normalize_passes_input_dataframe(df)
+
+    # One-pager flag: canonical column name is ``onepage`` (y/n).
+
     # Normalize event flags (y/n)
-    # Issue #553 Phase 4.2: Normalize known event columns, plus dynamically discover others
     known_events = ["full", "half", "10K", "elite", "open"]
     for ev in known_events:
         if ev in df.columns:
             df[ev] = df[ev].map(_yn)
-    
-    # Dynamic discovery: normalize any other columns that look like event flags
+
     for col in df.columns:
         if col.lower() in ["full", "half", "10k", "elite", "open"] and col not in known_events:
             df[col] = df[col].map(_yn)
-    
-    # Ensure numeric columns are numeric
+
     if "lat" in df.columns:
         df["lat"] = pd.to_numeric(df["lat"], errors="coerce")
     if "lon" in df.columns:
@@ -106,33 +95,72 @@ def load_locations(path: str):
         df["buffer"] = pd.to_numeric(df["buffer"], errors="coerce")
     if "interval" in df.columns:
         df["interval"] = pd.to_numeric(df["interval"], errors="coerce")
-    
-    # Issue #589: Normalize all *_count fields to numeric
-    # Dynamically detect all columns ending with "_count"
+
     count_columns = [col for col in df.columns if col.endswith("_count")]
     for col in count_columns:
         df[col] = pd.to_numeric(df[col], errors="coerce")
-        # Fill NaN with 0 (validation will catch invalid values, but this prevents errors during processing)
         df[col] = df[col].fillna(0)
-    
-    # Issue #589: Normalize loc_direction (optional field, empty string if missing)
+
     if "loc_direction" in df.columns:
         df["loc_direction"] = df["loc_direction"].fillna("").astype(str)
     else:
-        df["loc_direction"] = ""  # Add column with empty strings if missing
-    
-    # Parse seg_id field (comma-separated) - Issue #277: CSV uses "seg_id" column
+        df["loc_direction"] = ""
+
     if "seg_id" in df.columns:
         df["seg_id"] = df["seg_id"].fillna("").astype(str)
-        # Handle quoted values like "A1,G1" by removing quotes and splitting
         df["segments_list"] = df["seg_id"].apply(
             lambda x: [s.strip().strip('"') for s in str(x).replace('"', '').split(",") if s.strip()] if x else []
         )
     elif "segments" in df.columns:
-        # Fallback to "segments" if present
         df["segments"] = df["segments"].fillna("").astype(str)
         df["segments_list"] = df["segments"].apply(
             lambda x: [s.strip() for s in str(x).split(",") if s.strip()] if x else []
         )
-    
+
     return df
+
+
+def normalize_passes_input_dataframe(df: pd.DataFrame) -> pd.DataFrame:
+    """Upgrade legacy location CSV columns to pass_id / loc_id / pass_key."""
+    out = df.copy()
+
+    if "pass_key" not in out.columns and "location_key" in out.columns:
+        out["pass_key"] = out["location_key"]
+
+    if "proxy_pass_id" not in out.columns and "proxy_loc_id" in out.columns:
+        out["proxy_pass_id"] = out["proxy_loc_id"]
+    if "proxy_loc_id" not in out.columns and "proxy_pass_id" in out.columns:
+        out["proxy_loc_id"] = out["proxy_pass_id"]
+
+    legacy_instance = "pass_id" not in out.columns and "loc_id" in out.columns
+    if legacy_instance:
+        out["pass_id"] = out["loc_id"]
+
+    needs_human_loc = (
+        "loc_id" not in out.columns
+        or legacy_instance
+        or out["loc_id"].isna().all()
+    )
+    if needs_human_loc:
+        records = out.to_dict(orient="records")
+        from app.core.locations.identity import stamp_pass_identity
+
+        for rec in records:
+            pid = rec.get("pass_id")
+            if pid is not None and pid == pid:  # not NaN
+                rec["id"] = pid
+                rec["pass_id"] = pid
+            if legacy_instance:
+                rec.pop("loc_id", None)
+        stamp_pass_identity(records)
+        stamped = pd.DataFrame(records)
+        for col in ("pass_id", "loc_id", "pass_key", "id", "location_key"):
+            if col in stamped.columns:
+                out[col] = stamped[col].values
+
+    if "pass_key" in out.columns and "location_key" not in out.columns:
+        out["location_key"] = out["pass_key"]
+    if "proxy_pass_id" in out.columns and "proxy_loc_id" not in out.columns:
+        out["proxy_loc_id"] = out["proxy_pass_id"]
+
+    return out

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -817,8 +817,20 @@ def generate_location_report(
         # Issue #589: Field order matches loc_expected.csv specification
         # Issue #749: day column after loc_label (explicit when CSV opened standalone)
         # Issue #598: Add flag fields for flag propagation
+        # Locations fixes: include stable location_key for paired-leg / cross-distance identity
+        location_key = ""
+        for field in ("location_key", "leg_loc_key"):
+            raw_key = location.get(field)
+            if raw_key is None or (isinstance(raw_key, float) and pd.isna(raw_key)):
+                continue
+            text = str(raw_key).strip()
+            if text and text.lower() != "nan":
+                location_key = text
+                break
+
         report_row = {
             "loc_id": loc_id,
+            "location_key": location_key,
             "loc_label": loc_label,
             "day": day or "",
             "loc_type": loc_type,
@@ -1234,8 +1246,9 @@ def generate_location_report(
     
     # Issue #589: Reorder columns to match expected order
     # Base fields (in order from loc_expected.csv)
+    # Locations fixes: location_key after loc_id for paired-leg identity in the CSV
     base_fields = [
-        "loc_id", "loc_label", "day", "loc_type", "loc_direction",
+        "loc_id", "location_key", "loc_label", "day", "loc_type", "loc_direction",
         "lat", "lon", "zone",
         "buffer", "interval",
         "first_runner", "peak_start", "peak_end", "last_runner",

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -126,7 +126,7 @@ def seg_id_effectively_empty(seg_id_value: Any) -> bool:
 
 
 def proxy_loc_id_is_set(proxy_val: Any) -> bool:
-    """Issue #751: True when ``proxy_loc_id`` should be treated as present."""
+    """Issue #751: True when ``proxy_pass_id`` / legacy ``proxy_loc_id`` is present."""
     if proxy_val is None:
         return False
     if pd.isna(proxy_val):
@@ -138,11 +138,12 @@ def proxy_loc_id_is_set(proxy_val: Any) -> bool:
 
 def location_has_proxy_and_seg_conflict(location: pd.Series) -> bool:
     """
-    Issue #751: Both ``proxy_loc_id`` and ``seg_id`` are set — ambiguous configuration.
-
-    Caller must not apply proxy timing or segment modeling without explicit resolution.
+    Issue #751: Both ``proxy_pass_id`` (or legacy ``proxy_loc_id``) and ``seg_id`` are set.
     """
-    if not proxy_loc_id_is_set(location.get("proxy_loc_id")):
+    proxy = location.get("proxy_pass_id")
+    if not proxy_loc_id_is_set(proxy):
+        proxy = location.get("proxy_loc_id")
+    if not proxy_loc_id_is_set(proxy):
         return False
     return not seg_id_effectively_empty(location.get("seg_id"))
 
@@ -807,39 +808,41 @@ def generate_location_report(
     locations_by_id = {}
     
     for _, location in locations_df.iterrows():
-        loc_id = location.get("loc_id")
+        pass_id = location.get("pass_id")
+        if pass_id is None or (isinstance(pass_id, float) and pd.isna(pass_id)):
+            pass_id = location.get("loc_id")
+        human_loc_id = location.get("loc_id")
         loc_label = location.get("loc_label", "")
         loc_type = location.get("loc_type", "").lower()
         
-        logger.info(f"Processing location {loc_id}: {loc_label}")
+        logger.info(f"Processing pass {pass_id} (loc_id={human_loc_id}): {loc_label}")
         
         # Initialize report row
-        # Issue #589: Field order matches loc_expected.csv specification
-        # Issue #749: day column after loc_label (explicit when CSV opened standalone)
-        # Issue #598: Add flag fields for flag propagation
-        # Locations fixes: include stable location_key for paired-leg / cross-distance identity
-        location_key = ""
-        for field in ("location_key", "leg_loc_key"):
+        # 2027: pass_id = timed instance; loc_id = human Location; pass_key = opaque unifier
+        pass_key = ""
+        for field in ("pass_key", "location_key", "leg_loc_key"):
             raw_key = location.get(field)
             if raw_key is None or (isinstance(raw_key, float) and pd.isna(raw_key)):
                 continue
             text = str(raw_key).strip()
             if text and text.lower() != "nan":
-                location_key = text
+                pass_key = text
                 break
 
         report_row = {
-            "loc_id": loc_id,
-            "location_key": location_key,
+            "pass_id": pass_id,
+            "loc_id": human_loc_id,
+            "pass_key": pass_key,
+            "location_key": pass_key,  # legacy alias
             "loc_label": loc_label,
             "day": day or "",
             "loc_type": loc_type,
-            "loc_direction": location.get("loc_direction", ""),  # Issue #589: Add this
+            "loc_direction": location.get("loc_direction", ""),
             "lat": location.get("lat"),
             "lon": location.get("lon"),
             "zone": location.get("zone", ""),
-            "buffer": location.get("buffer", 0),  # Issue #589: Add to output (already used in calculation)
-            "interval": location.get("interval", 5),  # Issue #589: Add to output (already used in calculation)
+            "buffer": location.get("buffer", 0),
+            "interval": location.get("interval", 5),
             "first_runner": None,
             "peak_start": None,
             "peak_end": None,
@@ -847,10 +850,8 @@ def generate_location_report(
             "loc_start": format_time_hhmmss(loc_start_base_sec),
             "loc_end": None,
             "duration": None,
-            "timing_source": "modeled",  # Default to modeled, will be updated for proxy-based traffic locations
-            # Issue #589: Resource counts and minutes will be added dynamically below
+            "timing_source": "modeled",
             "notes": location.get("notes", ""),
-            # Issue #598: Flag propagation fields
             "flag": False,
             "flagged_seg_id": None,
             "flag_severity": None,
@@ -858,25 +859,27 @@ def generate_location_report(
             "flag_note": None
         }
         
-        # Issue #751: proxy_loc_id + seg_id both set — ambiguous; fail this row for timing
+        # Issue #751: proxy_pass_id + seg_id both set — ambiguous; fail this row for timing
         if location_has_proxy_and_seg_conflict(location):
             report_row["timing_source"] = "error:proxy_and_seg"
-            extra = "Issue #751: set only proxy_loc_id or seg_id, not both."
+            extra = "Issue #751: set only proxy_pass_id or seg_id, not both."
             base_notes = location.get("notes", "")
             if base_notes and str(base_notes).strip():
                 report_row["notes"] = f"{base_notes} ({extra})"
             else:
                 report_row["notes"] = extra
             logger.error(
-                "Location %s (%s): proxy_loc_id and seg_id are both set; ambiguous configuration (Issue #751).",
-                loc_id,
+                "Pass %s (%s): proxy_pass_id and seg_id are both set; ambiguous configuration (Issue #751).",
+                pass_id,
                 loc_label,
             )
             report_rows.append(report_row)
-            locations_by_id[loc_id] = report_row
+            locations_by_id[pass_id] = report_row
             continue
         
         # Check if timing_source is set to proxy:n in input locations.csv
+        # (keep using pass_id as loc_id alias in nested code via binding)
+        loc_id = pass_id
         # This handles locations that should copy timing from another location
         timing_source = location.get("timing_source", "")
         if pd.notna(timing_source) and isinstance(timing_source, str) and timing_source.startswith("proxy:"):
@@ -923,25 +926,28 @@ def generate_location_report(
                 )
                 report_row["timing_source"] = "error:invalid_proxy_format"
         
-        proxy_loc_id = location.get("proxy_loc_id")
+        proxy_loc_id = location.get("proxy_pass_id")
+        if proxy_loc_id is None or (isinstance(proxy_loc_id, float) and pd.isna(proxy_loc_id)) or proxy_loc_id == "":
+            proxy_loc_id = location.get("proxy_loc_id")
         
         # Issue #598: Propagate flags from segments
         # 1. Get seg_id(s) for this location (direct or via proxy)
         location_seg_ids = []
         seg_id_value = location.get("seg_id")
+        pass_lookup_col = "pass_id" if "pass_id" in locations_df.columns else "loc_id"
         
         if pd.notna(seg_id_value) and seg_id_value != "":
             # Direct seg_id match
             location_seg_ids = parse_segment_ids(seg_id_value)
         elif pd.notna(proxy_loc_id) and proxy_loc_id != "":
-            # Proxy location: use proxy location's seg_id
-            proxy_location_row = locations_df[locations_df['loc_id'] == proxy_loc_id]
+            # Proxy pass: use proxy pass's seg_id
+            proxy_location_row = locations_df[locations_df[pass_lookup_col] == proxy_loc_id]
             if not proxy_location_row.empty:
                 proxy_seg_id = proxy_location_row.iloc[0].get("seg_id")
                 if pd.notna(proxy_seg_id) and proxy_seg_id != "":
                     location_seg_ids = parse_segment_ids(proxy_seg_id)
                     logger.debug(
-                        f"Location {loc_id} ({loc_label}): Using proxy location {proxy_loc_id}'s seg_id: {location_seg_ids}"
+                        f"Location {loc_id} ({loc_label}): Using proxy pass {proxy_loc_id}'s seg_id: {location_seg_ids}"
                     )
         
         # 2. Check if ANY of the location's segment IDs are flagged
@@ -998,7 +1004,7 @@ def generate_location_report(
         )
         
         if not arrival_times:
-            loc_row = locations_df[locations_df['loc_id'] == loc_id]
+            loc_row = locations_df[locations_df['pass_id' if 'pass_id' in locations_df.columns else 'loc_id'] == loc_id]
             if not loc_row.empty:
                 loc = loc_row.iloc[0]
                 logger.warning(
@@ -1053,7 +1059,7 @@ def generate_location_report(
     # This ensures proxy locations are available when needed
     for i, report_row in enumerate(report_rows):
         loc_id = report_row["loc_id"]
-        location_row = locations_df[locations_df['loc_id'] == loc_id]
+        location_row = locations_df[locations_df['pass_id' if 'pass_id' in locations_df.columns else 'loc_id'] == loc_id]
         
         if location_row.empty:
             continue
@@ -1104,25 +1110,27 @@ def generate_location_report(
                 )
                 report_row["timing_source"] = "error:invalid_proxy_format"
     
-    # Issue #751 / #479: Process proxy_loc_id when seg_id is empty (all loc_types)
-    # Build lookup dictionary for all processed locations (refresh after second pass)
-    locations_by_id = {row["loc_id"]: row for row in report_rows}
+    # Issue #751 / #479: Process proxy_pass_id when seg_id is empty (all loc_types)
+    # Build lookup dictionary for all processed passes (refresh after second pass)
+    locations_by_id = {row["pass_id"]: row for row in report_rows}
     
     for report_row in report_rows:
         if report_row.get("timing_source") == "error:proxy_and_seg":
             continue
         
-        loc_id = report_row["loc_id"]
-        location_row = locations_df[locations_df['loc_id'] == loc_id]
+        loc_id = report_row["pass_id"]
+        location_row = locations_df[locations_df['pass_id' if 'pass_id' in locations_df.columns else 'loc_id'] == loc_id]
         
         if location_row.empty:
             continue
         
         location = location_row.iloc[0]
-        proxy_loc_id = location.get("proxy_loc_id")
+        proxy_loc_id = location.get("proxy_pass_id")
+        if not proxy_loc_id_is_set(proxy_loc_id):
+            proxy_loc_id = location.get("proxy_loc_id")
         
         logger.debug(
-            "Location %s: proxy_loc_id=%s, type=%s, isna=%s",
+            "Pass %s: proxy_pass_id=%s, type=%s, isna=%s",
             loc_id,
             proxy_loc_id,
             type(proxy_loc_id),
@@ -1131,7 +1139,7 @@ def generate_location_report(
         
         if not proxy_loc_id_is_set(proxy_loc_id):
             logger.debug(
-                "Location %s: No proxy_loc_id, keeping timing_source as modeled",
+                "Pass %s: No proxy_pass_id, keeping timing_source as modeled",
                 loc_id,
             )
             continue
@@ -1219,9 +1227,9 @@ def generate_location_report(
             
             # Add each resource count field
             for count_col in count_columns:
-                # Get count value from original location data
-                loc_id = report_row["loc_id"]
-                location_row = locations_df[locations_df['loc_id'] == loc_id]
+                # Get count value from original pass data
+                loc_id = report_row.get("pass_id", report_row.get("loc_id"))
+                location_row = locations_df[locations_df['pass_id' if 'pass_id' in locations_df.columns else 'loc_id'] == loc_id]
                 
                 if not location_row.empty:
                     location = location_row.iloc[0]
@@ -1241,47 +1249,74 @@ def generate_location_report(
                 mins_value = count_value * duration_minutes
                 report_row[mins_col] = int(mins_value) if mins_value >= 0 else 0
     
-    # Create DataFrame and save
+    # Annotate paired passes; write Passes.csv (instance) + Locations.csv (consolidated)
+    from app.core.locations.pairing import (
+        annotate_location_passes,
+        consolidate_location_rows,
+    )
+
+    annotate_location_passes(report_rows)
+
     report_df = pd.DataFrame(report_rows)
-    
-    # Issue #589: Reorder columns to match expected order
-    # Base fields (in order from loc_expected.csv)
-    # Locations fixes: location_key after loc_id for paired-leg identity in the CSV
+
     base_fields = [
-        "loc_id", "location_key", "loc_label", "day", "loc_type", "loc_direction",
+        "pass_id", "loc_id", "pass_key", "pass", "same_pass_as",
+        "loc_label", "day",
+        "loc_type", "loc_direction",
         "lat", "lon", "zone",
         "buffer", "interval",
         "first_runner", "peak_start", "peak_end", "last_runner",
         "loc_start", "loc_end", "duration",
-        "timing_source"
+        "timing_source",
+        # legacy aliases kept at end of base for importers mid-cutover
+        "location_key", "same_location_as",
     ]
-    
-    # Dynamically detect all *_count and *_mins fields (in alphabetical order for consistency)
+
     count_fields = sorted([col for col in report_df.columns if col.endswith("_count")])
     mins_fields = sorted([col for col in report_df.columns if col.endswith("_mins")])
-    
-    # Build final column order: base fields, then all *_count, then all *_mins, then notes
-    expected_columns = base_fields + count_fields + mins_fields + ["notes"]
-    
-    # Reorder DataFrame (only include columns that exist)
+
+    expected_columns = base_fields + count_fields + mins_fields + [
+        "notes", "flag", "flagged_seg_id", "flag_severity", "flag_worst_los", "flag_note"
+    ]
+
     final_columns = [col for col in expected_columns if col in report_df.columns]
-    # Add any remaining columns that weren't in expected list (for backward compatibility)
     remaining_cols = [col for col in report_df.columns if col not in final_columns]
     final_columns = final_columns + remaining_cols
-    
+
     report_df = report_df[final_columns]
-    
-    # Get output path
+
+    # Passes.csv — bottom-up timed instances (agencies / YSSR)
+    passes_full, passes_rel = get_report_paths("Passes", "csv", output_dir)
+    Path(passes_full).parent.mkdir(parents=True, exist_ok=True)
+    report_df.to_csv(passes_full, index=False)
+    logger.info(f"Passes report saved to: {passes_full}")
+
+    # Locations.csv — consolidated Location view (UI mirror)
+    location_rows = consolidate_location_rows(report_df.to_dict(orient="records"))
+    locations_df_out = pd.DataFrame(location_rows)
+    loc_base = [
+        "loc_id", "pass_key", "pass_ids", "pass_count", "loc_label", "day",
+        "loc_type", "lat", "lon", "zone",
+        "first_runner", "last_runner", "loc_start", "loc_end",
+        "peak_start", "peak_end", "flag", "onepage", "notes",
+    ]
+    loc_counts = sorted([c for c in locations_df_out.columns if c.endswith("_count") or c.endswith("_mins")])
+    loc_cols = [c for c in loc_base + loc_counts if c in locations_df_out.columns]
+    loc_cols += [c for c in locations_df_out.columns if c not in loc_cols]
+    locations_df_out = locations_df_out[loc_cols]
+
     full_path, relative_path = get_report_paths("Locations", "csv", output_dir)
     Path(full_path).parent.mkdir(parents=True, exist_ok=True)
-    
-    report_df.to_csv(full_path, index=False)
-    logger.info(f"Location report saved to: {full_path}")
-    
+    locations_df_out.to_csv(full_path, index=False)
+    logger.info(f"Locations report saved to: {full_path}")
+
     return {
         "ok": True,
         "file_path": full_path,
         "relative_path": relative_path,
+        "passes_path": passes_full,
+        "passes_relative_path": passes_rel,
         "locations_processed": len(report_df),
+        "locations_consolidated": len(locations_df_out),
         "timestamp": datetime.now().isoformat()
     }

--- a/app/one_pager.py
+++ b/app/one_pager.py
@@ -65,9 +65,20 @@ def generate_location_onepagers(
     """
     Generate one-pager PDFs for locations flagged onepage='y'.
 
+    Issue #810: paired reverse-leg locations (shared location_key) produce one
+    sheet with Outbound + Return runner timings. HTML is written for each
+    loc_id in the group so existing /locsheets/.../{loc_id} URLs keep working.
+
     Returns:
-        Number of PDFs generated.
+        Number of Location sheets generated (paired counts as one).
     """
+    from app.core.locations.pairing import (
+        effective_location_key,
+        max_time_str,
+        min_time_str,
+        time_to_seconds,
+    )
+
     locations_data = _load_locations_results(locations_results_json_path)
     if not locations_data:
         logger.warning(
@@ -75,10 +86,10 @@ def generate_location_onepagers(
         )
         return 0
 
-    report_lookup = _load_locations_report(locations_report_csv_path)
+    report_lookup = _load_pass_timings_report(locations_report_csv_path)
     if not report_lookup:
         logger.warning(
-            f"Issue #702: Locations report not found or empty at {locations_report_csv_path}"
+            f"Issue #702: Passes/Locations report not found or empty at {locations_report_csv_path}"
         )
         return 0
 
@@ -89,23 +100,92 @@ def generate_location_onepagers(
     pdf_dir.mkdir(parents=True, exist_ok=True)
     html_dir.mkdir(parents=True, exist_ok=True)
 
-    count = 0
+    # Keys / ids that should emit a sheet (any pass with onepage=y)
+    sheet_keys: set[str] = set()
+    sheet_solo_ids: set[int] = set()
+    by_key: Dict[str, List[Dict[str, Any]]] = {}
+    by_id: Dict[int, Dict[str, Any]] = {}
+
     for location in locations_data:
-        if not _is_onepager_location(location, day):
+        loc_day = str(location.get("day", "")).strip().lower()
+        if loc_day and loc_day != str(day).strip().lower():
             continue
-
-        loc_id = location.get("loc_id")
-        if loc_id is None:
-            logger.warning("Issue #702: Skipping location with missing loc_id")
+        pid = _pass_instance_id(location)
+        if pid is None:
             continue
+        by_id[pid] = location
+        key = effective_location_key(location)
+        if key:
+            by_key.setdefault(key, []).append(location)
+        if _is_onepager_location(location, day):
+            if key:
+                sheet_keys.add(key)
+            else:
+                sheet_solo_ids.add(pid)
 
-        report_row = report_lookup.get(int(loc_id))
-        if not report_row:
-            logger.warning(
-                f"Issue #702: No Locations.csv row found for loc_id={loc_id}, skipping one-pager"
+    sheet_specs: List[Dict[str, Any]] = []
+
+    for key in sorted(sheet_keys):
+        members = by_key.get(key) or []
+        passes: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+        for loc in members:
+            pid = _pass_instance_id(loc)
+            if pid is None:
+                continue
+            report_row = report_lookup.get(pid)
+            if not report_row:
+                continue
+            passes.append((loc, report_row))
+        if not passes:
+            continue
+        passes.sort(
+            key=lambda pair: (
+                time_to_seconds(pair[1].get("first_runner"))
+                if time_to_seconds(pair[1].get("first_runner")) is not None
+                else 10**9,
+                _pass_instance_id(pair[0]) or 10**9,
             )
-            continue
+        )
+        primary_loc, primary_report = passes[0]
+        combined = dict(primary_report)
+        combined["loc_start"] = min_time_str(r.get("loc_start") for _, r in passes)
+        combined["loc_end"] = max_time_str(r.get("loc_end") for _, r in passes)
+        combined["first_runner"] = min_time_str(r.get("first_runner") for _, r in passes)
+        combined["last_runner"] = max_time_str(r.get("last_runner") for _, r in passes)
+        human_loc_id = _human_location_id(primary_loc, primary_report)
+        sheet_specs.append(
+            {
+                "location": {**primary_loc, "loc_id": human_loc_id},
+                "report_row": {**combined, "loc_id": human_loc_id},
+                "passes": passes,
+                "paired": len(passes) > 1,
+                "sheet_loc_id": human_loc_id,
+                "all_loc_ids": [human_loc_id],
+            }
+        )
 
+    for pid in sorted(sheet_solo_ids):
+        location = by_id.get(pid)
+        report_row = report_lookup.get(pid)
+        if not location or not report_row:
+            continue
+        human_loc_id = _human_location_id(location, report_row)
+        sheet_specs.append(
+            {
+                "location": {**location, "loc_id": human_loc_id},
+                "report_row": {**report_row, "loc_id": human_loc_id},
+                "passes": [(location, report_row)],
+                "paired": False,
+                "sheet_loc_id": human_loc_id,
+                "all_loc_ids": [human_loc_id],
+            }
+        )
+
+    count = 0
+    for spec in sheet_specs:
+        location = spec["location"]
+        report_row = spec["report_row"]
+        loc_id = spec["sheet_loc_id"]
         map_path = _build_map_path(maps_dir, location)
         try:
             _create_map_snapshot(location, map_path, radius_m=radius_m)
@@ -117,13 +197,66 @@ def generate_location_onepagers(
             _write_map_placeholder(map_path)
 
         pdf_path = _build_pdf_path(pdf_dir, location)
-        _render_onepager_pdf(location, report_row, map_path, pdf_path, day=day)
+        _render_onepager_pdf(
+            location,
+            report_row,
+            map_path,
+            pdf_path,
+            day=day,
+            passes=spec["passes"] if spec["paired"] else None,
+        )
+        # One HTML per human Location id (volunteer-facing)
         html_path = html_dir / f"{loc_id}.html"
-        _render_onepager_html(location, report_row, map_path, html_path, day=day)
+        _render_onepager_html(
+            location,
+            report_row,
+            map_path,
+            html_path,
+            day=day,
+            passes=spec["passes"] if spec["paired"] else None,
+            sheet_loc_ids=spec["all_loc_ids"],
+        )
         count += 1
 
     logger.info(f"Issue #702/#735: Generated {count} one-pagers (PDF + HTML) for day {day}")
     return count
+
+
+def _pass_instance_id(location: Dict[str, Any]) -> Optional[int]:
+    for field in ("pass_id", "id"):
+        raw = location.get(field)
+        if raw is None or raw == "":
+            continue
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            continue
+    raw = location.get("loc_id")
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def _human_location_id(
+    location: Dict[str, Any], report_row: Optional[Dict[str, Any]] = None
+) -> int:
+    for source in (location, report_row or {}):
+        raw = source.get("loc_id")
+        pid = source.get("pass_id")
+        try:
+            lid = int(raw)
+        except (TypeError, ValueError):
+            continue
+        try:
+            if pid is not None and int(pid) != lid:
+                return lid
+        except (TypeError, ValueError):
+            return lid
+        # If only loc_id present, treat as human id (already consolidated) or legacy pass
+        return lid
+    pid = _pass_instance_id(location)
+    return pid if pid is not None else 0
 
 
 def _load_locations_results(path: Path) -> List[Dict[str, Any]]:
@@ -136,28 +269,45 @@ def _load_locations_results(path: Path) -> List[Dict[str, Any]]:
     return data.get("locations", []) if isinstance(data, dict) else []
 
 
+def _load_pass_timings_report(path: Path) -> Dict[int, Dict[str, Any]]:
+    """Prefer Passes.csv (keyed by pass_id); fall back to Locations.csv / legacy loc_id."""
+    candidates = []
+    if path.name.lower() == "locations.csv":
+        candidates.append(path.parent / "Passes.csv")
+        candidates.append(path.parent / "passes.csv")
+    candidates.append(path)
+    if path.name.lower() == "passes.csv":
+        candidates.append(path.parent / "Locations.csv")
+
+    for candidate in candidates:
+        if not candidate.exists():
+            continue
+        try:
+            df = pd.read_csv(candidate)
+        except Exception as exc:
+            logger.warning(f"Issue #702: Failed to read {candidate}: {exc}")
+            continue
+        if df.empty:
+            continue
+        id_col = "pass_id" if "pass_id" in df.columns else "loc_id"
+        if id_col not in df.columns:
+            continue
+        df = df.replace([math.inf, -math.inf], None)
+        df[id_col] = pd.to_numeric(df[id_col], errors="coerce")
+        df = df.dropna(subset=[id_col])
+        df[id_col] = df[id_col].astype(int)
+        return df.set_index(id_col).to_dict("index")
+    return {}
+
+
 def _load_locations_report(path: Path) -> Dict[int, Dict[str, Any]]:
-    if not path.exists():
-        return {}
-
-    try:
-        df = pd.read_csv(path)
-    except Exception as exc:
-        logger.warning(f"Issue #702: Failed to read Locations.csv: {exc}")
-        return {}
-
-    if df.empty or "loc_id" not in df.columns:
-        return {}
-
-    df = df.replace([math.inf, -math.inf], None)
-    df["loc_id"] = pd.to_numeric(df["loc_id"], errors="coerce")
-    df = df.dropna(subset=["loc_id"])
-    df["loc_id"] = df["loc_id"].astype(int)
-    return df.set_index("loc_id").to_dict("index")
+    return _load_pass_timings_report(path)
 
 
 def _is_onepager_location(location: Dict[str, Any], day: str) -> bool:
-    loc_day = str(location.get("day", "")).strip().lower()
+    loc_day = str(location.get("day", "") or "").strip().lower()
+    if loc_day in ("", "nan", "none", "null"):
+        loc_day = ""
     if loc_day and loc_day != str(day).strip().lower():
         return False
 
@@ -303,6 +453,7 @@ def _render_onepager_pdf(
     map_path: Path,
     output_path: Path,
     day: str = "",
+    passes: Optional[List[Tuple[Dict[str, Any], Dict[str, Any]]]] = None,
 ) -> None:
     output_path.parent.mkdir(parents=True, exist_ok=True)
     c = canvas.Canvas(str(output_path), pagesize=_PAGE_SIZE)
@@ -313,7 +464,11 @@ def _render_onepager_pdf(
 
     loc_id = location.get("loc_id", "")
     loc_label = location.get("loc_label", "")
-    title = f"LOCATION: {loc_id} - {loc_label}"
+    if passes and len(passes) > 1:
+        ids = " / ".join(str(p[0].get("loc_id")) for p in passes)
+        title = f"LOCATION: {loc_label} ({ids})"
+    else:
+        title = f"LOCATION: {loc_id} - {loc_label}"
     y = _draw_text_block(c, title, font_bold, 16, _MARGIN, y, page_w - 2 * _MARGIN)
 
     loc_type = location.get("loc_type", "")
@@ -384,14 +539,37 @@ def _render_onepager_pdf(
             y - 2,
             page_w - 2 * _MARGIN,
         )
-        timings_lines = [
-            f"First: {_format_time(report_row.get('first_runner'))}",
-            f"Peak Start: {_format_time(report_row.get('peak_start'))}",
-            f"Peak End: {_format_time(report_row.get('peak_end'))}",
-            f"Last: {_format_time(report_row.get('last_runner'))}",
-        ]
-        for line in timings_lines:
-            y = _draw_text_block(c, f"- {line}", font_body, 12, _MARGIN + 16, y - 2, page_w - 2 * _MARGIN)
+        if passes and len(passes) > 1:
+            for idx, (_loc, prow) in enumerate(passes):
+                role = "Outbound" if idx == 0 else "Return"
+                pid = _loc.get("loc_id")
+                y = _draw_text_block(
+                    c,
+                    f"{role} (ID {pid}):",
+                    font_bold,
+                    12,
+                    _MARGIN + 16,
+                    y - 4,
+                    page_w - 2 * _MARGIN,
+                )
+                for line in (
+                    f"First: {_format_time(prow.get('first_runner'))}",
+                    f"Peak Start: {_format_time(prow.get('peak_start'))}",
+                    f"Peak End: {_format_time(prow.get('peak_end'))}",
+                    f"Last: {_format_time(prow.get('last_runner'))}",
+                ):
+                    y = _draw_text_block(
+                        c, f"- {line}", font_body, 12, _MARGIN + 28, y - 2, page_w - 2 * _MARGIN
+                    )
+        else:
+            timings_lines = [
+                f"First: {_format_time(report_row.get('first_runner'))}",
+                f"Peak Start: {_format_time(report_row.get('peak_start'))}",
+                f"Peak End: {_format_time(report_row.get('peak_end'))}",
+                f"Last: {_format_time(report_row.get('last_runner'))}",
+            ]
+            for line in timings_lines:
+                y = _draw_text_block(c, f"- {line}", font_body, 12, _MARGIN + 16, y - 2, page_w - 2 * _MARGIN)
 
     y = _draw_text_block(c, "EVENTS:", font_bold, 14, _MARGIN, y - _SECTION_GAP, page_w - 2 * _MARGIN)
     if is_proxy:
@@ -455,11 +633,17 @@ def _render_onepager_html(
     map_path: Path,
     output_path: Path,
     day: str = "",
+    passes: Optional[List[Tuple[Dict[str, Any], Dict[str, Any]]]] = None,
+    sheet_loc_ids: Optional[List[Any]] = None,
 ) -> None:
-    """Render one-pager as self-contained HTML (Issue #735)."""
+    """Render one-pager as self-contained HTML (Issue #735 / #810)."""
     loc_id = location.get("loc_id", "")
     loc_label = location.get("loc_label", "")
-    title = f"LOCATION: {loc_id} - {loc_label}"
+    if passes and len(passes) > 1:
+        ids = " / ".join(str(p[0].get("loc_id")) for p in passes)
+        title = f"LOCATION: {loc_label} ({ids})"
+    else:
+        title = f"LOCATION: {loc_id} - {loc_label}"
     loc_type = html.escape(str(location.get("loc_type", "")))
     resources = _extract_resources(location)
     lat = location.get("lat", "")
@@ -487,6 +671,24 @@ def _render_onepager_html(
 
     if is_proxy:
         runner_timings_html = "<p>This location is near the course, but not directly on one or more events' course.</p>"
+    elif passes and len(passes) > 1:
+        blocks = [
+            "<p>The predicted timing for the first and last runner to arrive at and depart from this location. "
+            "Outbound and Return are separate passes on paired reverse legs.</p>"
+        ]
+        for idx, (_loc, prow) in enumerate(passes):
+            role = "Outbound" if idx == 0 else "Return"
+            pid = html.escape(str(_loc.get("loc_id")))
+            blocks.append(f"<h3>{role} (ID {pid})</h3>")
+            blocks.append(
+                "<ul>"
+                f"<li>First: {html.escape(_format_time(prow.get('first_runner')))}</li>"
+                f"<li>Peak Start: {html.escape(_format_time(prow.get('peak_start')))}</li>"
+                f"<li>Peak End: {html.escape(_format_time(prow.get('peak_end')))}</li>"
+                f"<li>Last: {html.escape(_format_time(prow.get('last_runner')))}</li>"
+                "</ul>"
+            )
+        runner_timings_html = "\n".join(blocks)
     else:
         runner_timings_html = """
         <p>The predicted timing for the first and last runner to arrive at and depart from this location.
@@ -514,6 +716,7 @@ def _render_onepager_html(
         body {{ font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif; line-height: 1.6; color: #333; max-width: 800px; margin: 0 auto; padding: 1rem 2rem; }}
         h1 {{ font-size: 1.25rem; margin-bottom: 0.5rem; }}
         h2 {{ font-size: 1rem; margin-top: 1rem; margin-bottom: 0.25rem; }}
+        h3 {{ font-size: 0.95rem; margin-top: 0.75rem; margin-bottom: 0.25rem; }}
         p, ul {{ margin: 0.25rem 0; }}
         ul {{ padding-left: 1.5rem; }}
         .map {{ max-width: 100%; height: auto; margin: 0.5rem 0; border: 1px solid #ddd; }}

--- a/app/routes/api_reports.py
+++ b/app/routes/api_reports.py
@@ -184,6 +184,8 @@ async def get_reports_list(
                 
                 filename = report_file.name
                 report_descriptions = {
+                    "Locations.csv": "Consolidated Location report (one row per loc_id; combined windows)",
+                    "Passes.csv": "Pass-level report (one row per pass_id; outbound/return detail)",
                     "finish_times.csv": "Predicted finisher counts by 20-minute clock window (per event and all)",
                     "finish_area_demand.pdf": "Finish-area operational PDF: bar chart, cumulative curve, demand table (event=all)",
                 }

--- a/app/utils/loc_sheets_list.py
+++ b/app/utils/loc_sheets_list.py
@@ -1,15 +1,21 @@
 """
-Build Loc Sheets index entries for a day (Issue #735 / #740).
+Build Loc Sheets index entries for a day (Issue #735 / #740 / #810).
 
 Uses locations_results.json only: ``onepage`` must be ``y`` (see locations.csv / pipeline).
 Fallback: if none match, include locations that have a generated HTML one-pager on disk.
+
+Issue #810: paired reverse-leg locations (shared ``location_key``) appear once in the
+index, using the outbound (lowest) ``loc_id`` as the sheet link target. HTML is also
+written under each pair member's loc_id for direct URL compatibility.
 """
 from __future__ import annotations
 
 import json
 import logging
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Set
+
+from app.core.locations.pairing import effective_location_key
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +45,11 @@ def build_loc_sheet_entries(run_dir: Path, selected_day: str) -> List[Dict[str, 
 
     locations = data.get("locations") or []
     sheets: List[Dict[str, Any]] = []
+    seen_keys: Set[str] = set()
 
+    # Prefer grouping: any onepage=y member of a key emits one index row (min loc_id)
+    onepage_by_key: Dict[str, List[Dict[str, Any]]] = {}
+    onepage_solo: List[Dict[str, Any]] = []
     for loc in locations:
         if not isinstance(loc, dict):
             continue
@@ -47,6 +57,41 @@ def build_loc_sheet_entries(run_dir: Path, selected_day: str) -> List[Dict[str, 
             continue
         if not _is_onepage_y(loc):
             continue
+        key = effective_location_key(loc)
+        if key:
+            onepage_by_key.setdefault(key, []).append(loc)
+        else:
+            onepage_solo.append(loc)
+
+    for key, members in onepage_by_key.items():
+        # Include all day-matching members of this key for label/id (even if only one is onepage)
+        all_members = [
+            loc
+            for loc in locations
+            if isinstance(loc, dict)
+            and _day_matches(loc, selected_day)
+            and effective_location_key(loc) == key
+        ]
+        pool = all_members or members
+
+        def _lid(loc: Dict[str, Any]) -> int:
+            try:
+                return int(loc.get("loc_id"))
+            except (TypeError, ValueError):
+                return 10**9
+
+        primary = min(pool, key=_lid)
+        sheets.append(
+            {
+                "loc_id": primary.get("loc_id"),
+                "label": primary.get("loc_label", ""),
+                "location_key": key,
+                "loc_ids": sorted({_lid(m) for m in pool if _lid(m) < 10**9}),
+            }
+        )
+        seen_keys.add(key)
+
+    for loc in onepage_solo:
         sheets.append({"loc_id": loc.get("loc_id"), "label": loc.get("loc_label", "")})
 
     if sheets:
@@ -59,11 +104,16 @@ def build_loc_sheet_entries(run_dir: Path, selected_day: str) -> List[Dict[str, 
             continue
         if not _day_matches(loc, selected_day):
             continue
+        key = effective_location_key(loc)
+        if key and key in seen_keys:
+            continue
         lid = loc.get("loc_id")
         if lid is None or str(lid).strip() == "":
             continue
         lid_str = str(lid).strip()
         if html_dir.exists() and (html_dir / f"{lid_str}.html").is_file():
+            if key:
+                seen_keys.add(key)
             sheets.append({"loc_id": lid_str, "label": loc.get("loc_label", "")})
 
     sheets.sort(key=lambda x: (x["loc_id"] is None, x["loc_id"]))

--- a/docs/architecture/domain-glossary.md
+++ b/docs/architecture/domain-glossary.md
@@ -18,7 +18,8 @@
 | **Leg** | Reusable route unit in the org (or package) library; may appear in multiple courses/recipes |
 | **Segment** | Analysis interval along a course after export/build (artifact key: `seg_id`) |
 | **Zone** | Operational classification on a location after package build |
-| **Location** | Point of interest on a leg/course (`loc_id` crew-facing; stable `location_key` for authoring) |
+| **Location** | Point of interest on a course (`loc_id` human-facing; timed instances are passes) |
+| **Pass** | Timed instance at a Location (`pass_id`; outbound/return share one `loc_id`) |
 | **Configuration package** | Race package: assigned courses, runners, resources, analysis launch (`runflow/config/{config_id}/`) |
 | **Run** | One analysis execution under `runflow/analysis/{run_id}/` |
 
@@ -37,8 +38,10 @@
 |----------|---------|---------------------|
 | `leg_id` | Library route identity (legacy read: `chunk_id`) | `seg_id` — one leg can produce many analysis segments |
 | `seg_id` | Analysis segment identity in CSV / flow / audit | `segment_id` — bins/UI adapter alias of `seg_id` |
-| `loc_id` | Crew-facing numeric location id (CSV); package JSON often stores the same value as `id` | `location_key` — short authoring key, not crew CSV identity |
-| `location_key` | Stable 5-char authoring key (`leg_loc_key` on leg-scoped rows) | `loc_id` |
+| `loc_id` | Short human Location number (UI / phone / one-pager / Locations.csv) | `pass_id` — timed instance |
+| `pass_id` | Timed pass instance (Passes.csv; course.json often stores as `id`) | `loc_id` |
+| `pass_key` | Opaque Crockford unifier for passes at one Location (system join) | Do not verbalize; not volunteer UI |
+| `location_key` | Legacy alias of `pass_key` (still accepted on read) | — |
 
 ## Field alias map
 
@@ -47,7 +50,7 @@
 | `seg_id` | CSV/artifacts: `seg_id`. Bins / some JSON: `segment_id` | `seg_id`; local JS `segId` | Dual-read or rename **only** in bins/UI adapters. New CSV/exports stay `seg_id`. Do not invent new writers of `segment_id` as SSOT. | `app/core/artifacts/frontend.py`; `app/routes/api_density.py`; `app/core/v2/bins.py` |
 | `leg_id` | Package/org API `{leg_id}`; segment rows may carry `leg_id` | `legId`; `source_leg_id` | Distinct noun. Resolve `leg_id` → current `seg_id` at apply/export. Never rename legs to segments. | `app/core/course/segment_library.py`; `app/core/config_package/legs.py` |
 | `loc_id` | CSV: `loc_id`. Package JSON: numeric `id` (same value). Helpers may say `location_id` in function names | Map: `loc_id`; editor may use `id` | Export always `loc_id`. Function names may say `location_id` without changing the wire key. | `app/core/locations/schema.py`; `app/core/config_package/location_ids.py` |
-| `location_key` | Authoring key; `leg_loc_key` on leg rows | Grid “Key” | Keep separate from `loc_id`. Match course↔leg by key; crew reports keep numeric `loc_id`. | `app/core/config_package/location_keys.py` |
+| `pass_key` | Opaque Crockford unifier; `leg_loc_key` on leg rows | (hidden in volunteer UI) | Keep separate from `loc_id`. Match course↔leg by key; Locations report is human `loc_id`. | `app/core/locations/identity.py` |
 | Temporal bin width | Core: `dt_seconds`. Metadata: `effective_window_s`, `window_s`, `time_window_s`. Map API may use `window_seconds` for display length | Report MD context `window_s` | Prefer `*_seconds` in new core APIs. Adapters may accept `window_s`. Phase 5 removes fabricated `window_s=30`. | `app/density_report.py`; `app/api/models/report.py`; `app/new_density_report.py` |
 | `step_km` | Density config: `step_km`. v1 API: `stepKm`. Results often mirror as `bin_km` / `bin_size_km` | — | Canonical **config** name is `step_km`. Treat `bin_*` as boundary/result aliases until a dedicated rename. | `app/core/density/models.py`; `app/core/density/compute.py` |
 | `runflow` | Paths `runflow/…`, API `/runflow/v2`, env `RUNFLOW_*`, GCS bucket `runflow` | `window.runflowDay`, `runflow:context-ready` | Canonical runtime namespace. Do not add new `run-density` runtime IDs. | `app/utils/constants.py`; `app/main.py` |
@@ -59,7 +62,7 @@
 2. **Preserve legacy wire names only at adapters** (bins UI, map payloads, temporary report metadata).  
 3. **New core APIs** under `app/core/` should use unit-suffixed names (`*_seconds`, `*_minutes`, `*_km`).  
 4. **Product name is Runflow**; repository may stay `run-density`.  
-5. **`seg_id` ≠ `leg_id`**, **`location_key` ≠ `loc_id`**, **`actual_event_duration` ≠ `event_duration_minutes`**.  
+5. **`seg_id` ≠ `leg_id`**, **`pass_id` ≠ `loc_id`**, **`pass_key` ≠ `loc_id`**, **`actual_event_duration` ≠ `event_duration_minutes`**.  
 6. Start-time range is **not** full-day 0–1439 — use `app.core.v2.start_time`.  
 7. Cross-check [quick-reference.md](../reference/quick-reference.md) and [canonical-paths.md](canonical-paths.md).
 

--- a/docs/dev-guides/data-sources.md
+++ b/docs/dev-guides/data-sources.md
@@ -400,11 +400,17 @@ runner_id,event,pace,distance,start_offset,day
 
 **Required Columns**:
 - `loc_id`: Location identifier
+- `location_key`: Optional but recommended stable authoring key; exported from config packages when present (immediately after `loc_id` in package `locations.csv` and in `Locations.csv` reports)
 - `loc_label`: Human-readable label
 - `loc_type`: Location category; allowed values are **`LOCATION_TYPE_CHOICES`** in `app/utils/constants.py` (SSOT for Course Mapping and Locations UI).
 - `seg_id`: Associated segment ID(s); may be empty for off-course or proxy-only timing rows. After leg recipe changes, re-apply recipes so segment IDs stay aligned with `segments.csv` (Issue #774).
 - `proxy_loc_id`: Optional **integer** `loc_id` of another location (timing source). In config package authoring (#775), operators pick the source from a dropdown; export writes the numeric id at snapshot time. When set with **empty** `seg_id`, the locations report copies **operational** timing (`loc_end`, `duration`) from that `loc_id` for **all** `loc_type` values (`timing_source` becomes `proxy:<id>` in output). Issue #751. Alphanumeric proxy values are not supported in the analysis pipeline.
 - `timing_source`: Optional advanced override (e.g. `proxy:n`) when present in input
+
+**Optional authoring columns** (passed through to the Locations report when present):
+- `location_key`: Stable 5-character key shared across paired reverse legs / course snapshots (helps match duplicate `loc_id`s for the same physical place)
+
+**Locations report (`Locations.csv`)**: includes `location_key` immediately after `loc_id` when generating from package/input locations (empty string if the input row has no key).
 
 **Issue #751 — `proxy_loc_id` vs `seg_id` (locations report)**:
 - **`proxy_loc_id` set, `seg_id` empty:** skip runner arrival modeling for that row; apply operational window from the proxy location (same idea as former traffic-only behavior, now config-driven for every type).

--- a/docs/dev-guides/data-sources.md
+++ b/docs/dev-guides/data-sources.md
@@ -398,19 +398,26 @@ runner_id,event,pace,distance,start_offset,day
 
 **Source**: `locations.csv`
 
-**Required Columns**:
-- `loc_id`: Location identifier
-- `location_key`: Optional but recommended stable authoring key; exported from config packages when present (immediately after `loc_id` in package `locations.csv` and in `Locations.csv` reports)
+**Required Columns** (package / pipeline **`passes.csv`** — one row per timed pass):
+- `pass_id`: Timed pass instance identifier
+- `loc_id`: Human Location number (shared by outbound/return passes)
+- `pass_key`: Opaque Crockford unifier for passes at the same Location (system join; not volunteer-facing)
 - `loc_label`: Human-readable label
 - `loc_type`: Location category; allowed values are **`LOCATION_TYPE_CHOICES`** in `app/utils/constants.py` (SSOT for Course Mapping and Locations UI).
 - `seg_id`: Associated segment ID(s); may be empty for off-course or proxy-only timing rows. After leg recipe changes, re-apply recipes so segment IDs stay aligned with `segments.csv` (Issue #774).
-- `proxy_loc_id`: Optional **integer** `loc_id` of another location (timing source). In config package authoring (#775), operators pick the source from a dropdown; export writes the numeric id at snapshot time. When set with **empty** `seg_id`, the locations report copies **operational** timing (`loc_end`, `duration`) from that `loc_id` for **all** `loc_type` values (`timing_source` becomes `proxy:<id>` in output). Issue #751. Alphanumeric proxy values are not supported in the analysis pipeline.
+- `proxy_pass_id`: Optional **integer** `pass_id` of another pass (timing source). Legacy column `proxy_loc_id` is still accepted on read.
 - `timing_source`: Optional advanced override (e.g. `proxy:n`) when present in input
 
-**Optional authoring columns** (passed through to the Locations report when present):
-- `location_key`: Stable 5-character key shared across paired reverse legs / course snapshots (helps match duplicate `loc_id`s for the same physical place)
+**Optional authoring columns** (passed through when present):
+- `location_key`: Legacy alias of `pass_key`
 
-**Locations report (`Locations.csv`)**: includes `location_key` immediately after `loc_id` when generating from package/input locations (empty string if the input row has no key).
+**Analysis reports**:
+- **`Passes.csv`**: one row per `pass_id` (bottom-up; agencies). Includes `loc_id`, `pass_key`, `pass`, `same_pass_as`.
+- **`Locations.csv`**: one row per human `loc_id` (UI mirror). Combined window = earliest first / latest last; `pass_ids` lists member passes; `pass_key` joins back to Passes.csv.
+
+**Issue #810 — paired reverse legs:** when two pass rows share a `pass_key`, they are passes at the same Location (outbound vs return). Volunteer UI and Locations.csv show one Location. Import timed staffing on **`pass_id`**.
+
+**`day` on package passes:** org/course legs are day-agnostic. When legs are merged into a package course or **Build race exports** runs, each pass’s `day` is stamped from the package manifest `event_day` (default `sun`).
 
 **Issue #751 — `proxy_loc_id` vs `seg_id` (locations report)**:
 - **`proxy_loc_id` set, `seg_id` empty:** skip runner arrival modeling for that row; apply operational window from the proxy location (same idea as former traffic-only behavior, now config-driven for every type).

--- a/frontend/static/js/map/course_mapping.js
+++ b/frontend/static/js/map/course_mapping.js
@@ -142,7 +142,7 @@ document.addEventListener('DOMContentLoaded', function () {
             btnExport.disabled = false;
             btnExport.title = usePackageLevelEditSave()
                 ? 'Export segments, locations, and related files for this package'
-                : 'Write segments.csv, flow.csv, locations.csv, GPX to course folder';
+                : 'Write segments.csv, flow.csv, passes.csv, GPX to course folder';
         }
     }
 
@@ -1588,8 +1588,9 @@ document.addEventListener('DOMContentLoaded', function () {
         if (!row) return;
         row.innerHTML = '';
         [
-            { text: 'ID', title: 'Crew-facing loc_id (stable across re-apply)' },
-            { text: 'Key', title: 'Stable internal location_key' },
+            { text: 'ID', title: 'Pass instance id (pass_id / course id)' },
+            { text: 'Loc', title: 'Human Location id (loc_id)' },
+            { text: 'Key', title: 'Internal pass_key (not for volunteers)' },
             'Type',
             'Label',
             'Zone'
@@ -3885,11 +3886,19 @@ document.addEventListener('DOMContentLoaded', function () {
             });
             idCell.appendChild(idBtn);
             tr.appendChild(idCell);
-            var keyTd = document.createElement('td');
-            keyTd.textContent = (loc.location_key && String(loc.location_key).trim())
-                ? String(loc.location_key).trim()
+            var humanLocTd = document.createElement('td');
+            var humanLoc = loc.loc_id != null && String(loc.loc_id).trim() !== ''
+                ? String(loc.loc_id).trim()
                 : '—';
-            keyTd.title = 'Stable authoring key (internal)';
+            humanLocTd.textContent = humanLoc;
+            humanLocTd.title = 'Human Location id';
+            tr.appendChild(humanLocTd);
+            var keyTd = document.createElement('td');
+            var keyVal = (loc.pass_key && String(loc.pass_key).trim())
+                || (loc.location_key && String(loc.location_key).trim())
+                || '';
+            keyTd.textContent = keyVal || '—';
+            keyTd.title = 'Internal pass_key';
             tr.appendChild(keyTd);
             tr.appendChild(document.createElement('td')).textContent = typeLabel;
             tr.appendChild(document.createElement('td')).textContent = loc.loc_label || '';
@@ -4838,7 +4847,7 @@ document.addEventListener('DOMContentLoaded', function () {
                         var data = await res.json();
                         if (!res.ok) throw new Error(data.detail || res.statusText);
                         var msg = 'Exported to config package: segments.csv';
-                        if (data.location_count != null) msg += ', locations.csv (' + data.location_count + ' rows)';
+                        if (data.location_count != null) msg += ', passes.csv (' + data.location_count + ' rows)';
                         if (data.flow_path) msg += ', flow.csv';
                         if (data.gpx_files && data.gpx_files.length) {
                             msg += ', ' + data.gpx_files.length + ' event GPX file(s)';
@@ -4849,7 +4858,7 @@ document.addEventListener('DOMContentLoaded', function () {
                             msg += ' — still missing: ' + data.readiness.missing.join(', ');
                         }
                         if (data.segments_backup_path) msg += ' (segments.csv backed up)';
-                        if (data.locations_backup_path) msg += ' (locations.csv backed up)';
+                        if (data.locations_backup_path) msg += ' (passes.csv backed up)';
                         alert(msg);
                     } catch (e) {
                         alert('Export failed: ' + (e.message || String(e)));

--- a/frontend/static/js/map/location_grid_editor.js
+++ b/frontend/static/js/map/location_grid_editor.js
@@ -485,12 +485,13 @@
             { key: '_expand', label: '', width: 36 },
             { key: '_select', label: '', width: 40 },
             { key: 'id', label: 'ID', width: 48 },
-            { key: 'location_key', label: 'Key', width: 56 },
+            { key: 'loc_id', label: 'Loc', width: 44 },
+            { key: 'pass_key', label: 'Key', width: 56 },
             { key: 'loc_label', label: 'Label', width: 140 },
             { key: 'loc_type', label: 'Type', width: 88 },
             { key: 'zone', label: 'Zone', width: 72 },
             { key: 'seg_id', label: 'Seg ID', width: 64 },
-            { key: 'proxy_loc_id', label: 'Proxy ID', width: 72 },
+            { key: 'proxy_loc_id', label: 'Proxy', width: 72 },
             { key: 'resources', label: 'Resources', width: 200 }
         ];
         headers.forEach(function (col) {
@@ -568,11 +569,19 @@
             idTd.textContent = String(locationId(loc, rowIndex));
             tr.appendChild(idTd);
 
+            var humanTd = document.createElement('td');
+            humanTd.className = 'location-grid-readonly';
+            humanTd.textContent = (loc.loc_id != null && String(loc.loc_id).trim() !== '')
+                ? String(loc.loc_id).trim()
+                : '—';
+            tr.appendChild(humanTd);
+
             var keyTd = document.createElement('td');
             keyTd.className = 'location-grid-readonly';
-            keyTd.textContent = (loc.location_key && String(loc.location_key).trim())
-                ? String(loc.location_key).trim()
-                : '—';
+            var keyVal = (loc.pass_key && String(loc.pass_key).trim())
+                || (loc.location_key && String(loc.location_key).trim())
+                || '';
+            keyTd.textContent = keyVal || '—';
             tr.appendChild(keyTd);
 
             var labelTd = document.createElement('td');

--- a/frontend/static/js/map/location_pairing.js
+++ b/frontend/static/js/map/location_pairing.js
@@ -1,0 +1,162 @@
+/**
+ * Issue #810: Collapse paired reverse-leg location rows for map + table.
+ * Outbound = earlier first_runner; return = later.
+ */
+(function (global) {
+    'use strict';
+
+    function timeToSeconds(value) {
+        if (value == null || value === '' || value === 'NA') return null;
+        const text = String(value).trim();
+        const parts = text.split(':');
+        if (parts.length < 2) return null;
+        const h = parseInt(parts[0], 10);
+        const m = parseInt(parts[1], 10);
+        const s = parts.length >= 3 ? parseInt(parts[2], 10) : 0;
+        if (Number.isNaN(h) || Number.isNaN(m)) return null;
+        return h * 3600 + m * 60 + (Number.isNaN(s) ? 0 : s);
+    }
+
+    function pickMinTime(values) {
+        let best = null;
+        let bestSec = null;
+        values.forEach((v) => {
+            const sec = timeToSeconds(v);
+            if (sec == null) return;
+            if (bestSec == null || sec < bestSec) {
+                bestSec = sec;
+                best = v;
+            }
+        });
+        return best;
+    }
+
+    function pickMaxTime(values) {
+        let best = null;
+        let bestSec = null;
+        values.forEach((v) => {
+            const sec = timeToSeconds(v);
+            if (sec == null) return;
+            if (bestSec == null || sec > bestSec) {
+                bestSec = sec;
+                best = v;
+            }
+        });
+        return best;
+    }
+
+    function effectiveKey(loc) {
+        const key = loc && (loc.pass_key != null ? loc.pass_key : loc.location_key);
+        const text = key != null ? String(key).trim() : '';
+        if (text && text.toLowerCase() !== 'nan' && text.toLowerCase() !== 'null') return text;
+        return '';
+    }
+
+    function assignPasses(group) {
+        const ordered = [...group].sort((a, b) => {
+            const fa = timeToSeconds(a.first_runner);
+            const fb = timeToSeconds(b.first_runner);
+            const sa = fa == null ? Number.MAX_SAFE_INTEGER : fa;
+            const sb = fb == null ? Number.MAX_SAFE_INTEGER : fb;
+            if (sa !== sb) return sa - sb;
+            const pa = Number(a.pass_id != null ? a.pass_id : a.loc_id);
+            const pb = Number(b.pass_id != null ? b.pass_id : b.loc_id);
+            return pa - pb;
+        });
+        return ordered.map((row, i) => {
+            const copy = { ...row };
+            copy.pass = i === 0 ? 'outbound' : 'return';
+            const peer = i === 0 ? ordered[1] : ordered[0];
+            const peerPass = peer ? (peer.pass_id != null ? peer.pass_id : peer.loc_id) : '';
+            copy.same_pass_as = peerPass;
+            copy.same_location_as = peerPass;
+            return copy;
+        });
+    }
+
+    /**
+     * @param {Array} locations flat API rows
+     * @returns {Array} location-centric rows (paired collapsed)
+     */
+    function collapseLocationsByKey(locations) {
+        if (!Array.isArray(locations)) return [];
+        const byKey = new Map();
+        const singles = [];
+
+        locations.forEach((loc) => {
+            const key = effectiveKey(loc);
+            if (!key) {
+                singles.push({
+                    ...loc,
+                    paired: false,
+                    primary_loc_id: loc.loc_id,
+                    loc_ids: [loc.loc_id],
+                    passes: [{ ...loc, pass: '' }],
+                });
+                return;
+            }
+            if (!byKey.has(key)) byKey.set(key, []);
+            byKey.get(key).push(loc);
+        });
+
+        const groups = [...singles];
+        byKey.forEach((group, key) => {
+            if (group.length === 1) {
+                const loc = group[0];
+                groups.push({
+                    ...loc,
+                    location_key: key,
+                    paired: false,
+                    primary_loc_id: loc.loc_id,
+                    loc_ids: [loc.loc_id],
+                    passes: [{ ...loc, pass: '' }],
+                });
+                return;
+            }
+            const passes = assignPasses(group);
+            const primary = passes[0];
+            // Human loc_id is shared; fall back to primary row's loc_id
+            const humanLocId = primary.loc_id;
+            const merged = {
+                ...primary,
+                pass_key: key,
+                location_key: key,
+                loc_id: humanLocId,
+                primary_loc_id: humanLocId,
+                loc_ids: [humanLocId],
+                pass_ids: passes.map((p) => (p.pass_id != null ? p.pass_id : p.loc_id)),
+                paired: true,
+                passes,
+                first_runner: pickMinTime(passes.map((p) => p.first_runner)),
+                last_runner: pickMaxTime(passes.map((p) => p.last_runner)),
+                loc_start: pickMinTime(passes.map((p) => p.loc_start)),
+                loc_end: pickMaxTime(passes.map((p) => p.loc_end)),
+                peak_start: pickMinTime(passes.map((p) => p.peak_start)),
+                peak_end: pickMaxTime(passes.map((p) => p.peak_end)),
+                flag: passes.some((p) => p.flag === true || p.flag === 'true' || p.flag === 'Y'),
+                onepage: passes.some((p) => String(p.onepage || '').toLowerCase() === 'y')
+                    ? 'y'
+                    : primary.onepage,
+            };
+            // Prefer max resource counts across passes
+            passes.forEach((p) => {
+                Object.keys(p).forEach((k) => {
+                    if (!k.endsWith('_count') && !k.endsWith('_mins')) return;
+                    const n = Number(p[k]) || 0;
+                    const cur = Number(merged[k]) || 0;
+                    if (n > cur) merged[k] = p[k];
+                });
+            });
+            groups.push(merged);
+        });
+
+        groups.sort((a, b) => Number(a.primary_loc_id || a.loc_id) - Number(b.primary_loc_id || b.loc_id));
+        return groups;
+    }
+
+    global.LocationPairing = {
+        collapseLocationsByKey,
+        timeToSeconds,
+        effectiveKey,
+    };
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -17,20 +17,72 @@ const locationTypeColors = {
     'extract': '#9C27B0' // Purple — remote trail extract / stretcher access (Issue #747)
 };
 
+/** Resource *_count fields only — exclude pass_count and other non-org counts. */
+function isOrgResourceCountKey(key) {
+    if (!key || !String(key).endsWith('_count')) return false;
+    const base = String(key).slice(0, -'_count'.length).toLowerCase();
+    return base !== 'pass';
+}
+
+function formatPassLine(props) {
+    const key = (props.pass_key || props.location_key || '').toString().trim();
+    let ids = props.pass_ids;
+    if (Array.isArray(ids)) {
+        ids = ids.filter((v) => v != null && v !== '').join(',');
+    } else if (ids == null || ids === '') {
+        // Fall back to nested passes or single pass_id
+        if (Array.isArray(props.passes) && props.passes.length) {
+            ids = props.passes
+                .map((p) => (p.pass_id != null ? p.pass_id : null))
+                .filter((v) => v != null)
+                .join(',');
+        } else if (props.pass_id != null) {
+            ids = String(props.pass_id);
+        } else {
+            ids = '';
+        }
+    } else {
+        ids = String(ids).trim();
+    }
+    if (!key && !ids) return '';
+    if (key && ids) return `PASS: ${key} | ${ids}`;
+    if (key) return `PASS: ${key}`;
+    return `PASS: ${ids}`;
+}
+
+function formatPassLineHtml(props) {
+    const line = formatPassLine(props);
+    if (!line) return '';
+    return line.replace(/^PASS:\s*/, '<strong>PASS:</strong> ');
+}
+
 /**
  * Convert locations JSON data to GeoJSON format
+ * Issue #810: one feature per Location (collapse shared location_key)
  * @param {Array} locations - Array of location objects from API
  * @returns {Object} GeoJSON FeatureCollection
  */
 function convertToGeoJSON(locations) {
-    const features = locations
+    const collapsed = (window.LocationPairing && window.LocationPairing.collapseLocationsByKey)
+        ? window.LocationPairing.collapseLocationsByKey(locations)
+        : locations;
+
+    const features = collapsed
         .filter(loc => loc.lat != null && loc.lon != null && !isNaN(loc.lat) && !isNaN(loc.lon))
         .map(loc => {
-            // Issue #591: Include all resource count and mins fields dynamically
-            // Issue #598: Include flag fields
             const properties = {
-                loc_id: loc.loc_id,
-                location_key: loc.location_key,
+                loc_id: loc.primary_loc_id != null ? loc.primary_loc_id : loc.loc_id,
+                loc_ids: loc.loc_ids || [loc.loc_id],
+                pass_key: loc.pass_key || loc.location_key || '',
+                location_key: loc.pass_key || loc.location_key || '',
+                pass_ids: loc.pass_ids != null ? loc.pass_ids : (
+                    Array.isArray(loc.passes)
+                        ? loc.passes.map((p) => (p.pass_id != null ? p.pass_id : p.loc_id)).filter((v) => v != null)
+                        : []
+                ),
+                pass_id: loc.pass_id,
+                paired: !!loc.paired,
+                passes: loc.passes || null,
                 loc_label: loc.loc_label || 'Unknown',
                 loc_type: loc.loc_type || 'unknown',
                 loc_start: loc.loc_start,
@@ -41,23 +93,22 @@ function convertToGeoJSON(locations) {
                 zone: loc.zone,
                 timing_source: loc.timing_source,
                 notes: loc.notes,
-                first_runner: loc.first_runner,  // Issue #483: Include first_runner
-                last_runner: loc.last_runner,     // Issue #483: Include last_runner
-                flag: loc.flag,                   // Issue #598: Include flag
-                flagged_seg_id: loc.flagged_seg_id,  // Issue #598: Include flagged_seg_id
-                flag_severity: loc.flag_severity,     // Issue #598: Include flag_severity
-                flag_worst_los: loc.flag_worst_los,   // Issue #598: Include flag_worst_los
-                flag_note: loc.flag_note,             // Issue #598: Include flag_note
-                onepage: loc.onepage                // Issue #745: SSOT for loc sheet links (table)
+                first_runner: loc.first_runner,
+                last_runner: loc.last_runner,
+                flag: loc.flag,
+                flagged_seg_id: loc.flagged_seg_id,
+                flag_severity: loc.flag_severity,
+                flag_worst_los: loc.flag_worst_los,
+                flag_note: loc.flag_note,
+                onepage: loc.onepage
             };
-            
-            // Issue #591: Dynamically add all resource count and mins fields
+
             Object.keys(loc).forEach(key => {
-                if (key.endsWith('_count') || key.endsWith('_mins')) {
+                if (isOrgResourceCountKey(key) || key.endsWith('_mins')) {
                     properties[key] = loc[key];
                 }
             });
-            
+
             return {
                 type: 'Feature',
                 geometry: {
@@ -67,7 +118,7 @@ function convertToGeoJSON(locations) {
                 properties: properties
             };
         });
-    
+
     return {
         type: 'FeatureCollection',
         features: features
@@ -108,8 +159,12 @@ function createLocationTooltip(properties) {
     const props = properties || {};
     const locType = props.loc_type || 'unknown';
     const locLabel = props.loc_label || 'Unknown';
-    const locId = props.loc_id != null ? String(props.loc_id) : null;
-    const heading = locId ? `${locId}-${locLabel}` : locLabel;
+    const locIds = Array.isArray(props.loc_ids) && props.loc_ids.length
+        ? props.loc_ids
+        : (props.loc_id != null ? [props.loc_id] : []);
+    const heading = props.paired && locIds.length > 1
+        ? `${locLabel} (${locIds.join(' / ')})`
+        : (locIds[0] != null ? `${locIds[0]}-${locLabel}` : locLabel);
     const locStart = props.loc_start && props.loc_start !== 'NA' ? props.loc_start : null;
     const locEnd = props.loc_end && props.loc_end !== 'NA' ? props.loc_end : null;
     const locStartFormatted = formatTimeToHHMM(locStart);
@@ -129,6 +184,10 @@ function createLocationTooltip(properties) {
             <strong>${heading}</strong><br>
             <strong>Type:</strong> <span style="color: ${getLocationMarkerColor(locType)}; font-weight: bold;">${locType}</span>
     `;
+
+    if (props.paired && Array.isArray(props.passes) && props.passes.length > 1) {
+        tooltip += `<br><strong>Passes:</strong> Outbound + Return`;
+    }
     
     if (locStartFormatted && locEndFormatted) {
         tooltip += `<br><strong>Operational Window:</strong> ${locStartFormatted} → ${locEndFormatted}`;
@@ -138,10 +197,10 @@ function createLocationTooltip(properties) {
         tooltip += `<br><strong>Duration:</strong> ${duration} min`;
     }
     
-    // Issue #592: Add resource counts to tooltip
+    // Org resource counts only (exclude pass_count)
     const resourceCounts = [];
     Object.keys(props).forEach(key => {
-        if (key.endsWith('_count')) {
+        if (isOrgResourceCountKey(key)) {
             const count = props[key];
             if (count && count > 0) {
                 const resource = key.replace('_count', '').toUpperCase();
@@ -149,6 +208,10 @@ function createLocationTooltip(properties) {
             }
         }
     });
+    const passLine = formatPassLine(props);
+    if (passLine) {
+        tooltip += `<br>${formatPassLineHtml(props)}`;
+    }
     if (resourceCounts.length > 0) {
         tooltip += `<br><strong>Resources:</strong> ${resourceCounts.join(', ')}`;
     }
@@ -176,8 +239,12 @@ function createLocationPopup(properties) {
     const props = properties || {};
     const locType = props.loc_type || 'unknown';
     const locLabel = props.loc_label || 'Unknown';
-    const locId = props.loc_id != null ? String(props.loc_id) : null;
-    const heading = locId ? `${locId}-${locLabel}` : locLabel;
+    const locIds = Array.isArray(props.loc_ids) && props.loc_ids.length
+        ? props.loc_ids
+        : (props.loc_id != null ? [props.loc_id] : []);
+    const heading = props.paired && locIds.length > 1
+        ? `${locLabel}`
+        : (locIds[0] != null ? `${locIds[0]}-${locLabel}` : locLabel);
     const locStart = props.loc_start && props.loc_start !== 'NA' ? props.loc_start : null;
     const locEnd = props.loc_end && props.loc_end !== 'NA' ? props.loc_end : null;
     const locStartFormatted = formatTimeToHHMM(locStart);
@@ -207,7 +274,7 @@ function createLocationPopup(properties) {
     
     const resourceCounts = [];
     Object.keys(props).forEach(key => {
-        if (key.endsWith('_count')) {
+        if (isOrgResourceCountKey(key)) {
             const count = props[key];
             if (count && count > 0) {
                 const resource = key.replace('_count', '').toUpperCase();
@@ -230,12 +297,17 @@ function createLocationPopup(properties) {
         : "—";
 
     let popup = `
-        <div style="font-family: Arial, sans-serif; font-size: 14px; width: 260px;">
+        <div style="font-family: Arial, sans-serif; font-size: 14px; width: 280px;">
             <h3 style="margin: 0 0 0.5rem 0; font-size: 16px; color: #2c3e50;">${heading}</h3>
             <div style="margin-bottom: 0.5rem;">
                 <strong>Type:</strong> <span style="color: ${getLocationMarkerColor(locType)}; font-weight: bold;">${locType}</span>
             </div>
     `;
+
+    const passLine = formatPassLine(props);
+    if (passLine) {
+        popup += `<div style="margin-bottom: 0.5rem;">${formatPassLineHtml(props)}</div>`;
+    }
 
     if (resourceCounts.length > 0) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Resources:</strong> ${resourceCounts.join(', ')}</div>`;
@@ -249,8 +321,20 @@ function createLocationPopup(properties) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Duration:</strong> ${duration} minutes</div>`;
     }
 
-    popup += `<div style="margin-bottom: 0.5rem;"><strong>First/last runner:</strong> ${firstLastRunner}</div>`;
-
+    if (props.paired && Array.isArray(props.passes) && props.passes.length > 1) {
+        popup += `<div style="margin-bottom: 0.5rem;"><strong>Combined first/last:</strong> ${firstLastRunner}</div>`;
+        props.passes.forEach((pass) => {
+            const role = pass.pass === 'return' ? 'Return' : 'Outbound';
+            const pf = (pass.first_runner && pass.first_runner !== 'NA')
+                ? (formatTimeToHHMM(pass.first_runner) || '—') : '—';
+            const pl = (pass.last_runner && pass.last_runner !== 'NA')
+                ? (formatTimeToHHMM(pass.last_runner) || '—') : '—';
+            const window = (pf !== '—' && pl !== '—') ? `${pf} → ${pl}` : '—';
+            popup += `<div style="margin-bottom: 0.35rem; padding-left: 0.25rem;"><strong>${role}</strong> (ID ${pass.loc_id}): ${window}</div>`;
+        });
+    } else {
+        popup += `<div style="margin-bottom: 0.5rem;"><strong>First/last runner:</strong> ${firstLastRunner}</div>`;
+    }
     if (peakStartFormatted && peakEndFormatted) {
         popup += `<div style="margin-bottom: 0.5rem;"><strong>Peak Window:</strong> ${peakStartFormatted} → ${peakEndFormatted}</div>`;
     }
@@ -516,8 +600,16 @@ async function renderLocations(map) {
             }
         });
         
-        // Store marker reference
-        markersByLocId[props.loc_id] = marker;
+        // Store marker reference for every loc_id in the group (Issue #810)
+        const ids = Array.isArray(props.loc_ids) && props.loc_ids.length
+            ? props.loc_ids
+            : [props.loc_id];
+        ids.forEach((id) => {
+            if (id != null) markersByLocId[String(id)] = marker;
+        });
+        if (props.location_key) {
+            markersByLocId[`key:${props.location_key}`] = marker;
+        }
         
         // Add to layer
         marker.addTo(markersLayer);
@@ -718,11 +810,15 @@ function highlightLocationInTable(locId) {
         window.clearLocationTableHighlight();
     }
     
-    // Find and highlight the target row
+    // Find and highlight the target row (Issue #810: ID cell may be "117 / 129")
+    const target = String(locId);
     const rows = document.querySelectorAll('#locations-table tbody tr');
     rows.forEach(row => {
         const firstCell = row.querySelector('td');
-        if (firstCell && firstCell.textContent.trim() == locId) {
+        if (!firstCell) return;
+        const cellText = firstCell.textContent.trim();
+        const ids = cellText.split('/').map(s => s.trim());
+        if (cellText == target || ids.includes(target)) {
             row.classList.add('selected-row');
             row.style.backgroundColor = '#e3f2fd';
             row.style.cursor = 'pointer';

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -30,6 +30,7 @@ function convertToGeoJSON(locations) {
             // Issue #598: Include flag fields
             const properties = {
                 loc_id: loc.loc_id,
+                location_key: loc.location_key,
                 loc_label: loc.loc_label || 'Unknown',
                 loc_type: loc.loc_type || 'unknown',
                 loc_start: loc.loc_start,

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -3620,6 +3620,25 @@
         });
         content.appendChild(opsRow);
 
+        var onepageWrap = document.createElement('div');
+        onepageWrap.className = 'leg-popup-field';
+        var onepageLbl = document.createElement('label');
+        onepageLbl.className = 'location-onepager-inline';
+        var onepageCb = document.createElement('input');
+        onepageCb.type = 'checkbox';
+        onepageCb.checked = String((opts.loc && opts.loc.onepage) || 'n').toLowerCase() === 'y';
+        onepageLbl.appendChild(onepageCb);
+        var onepageText = document.createElement('span');
+        onepageText.textContent = 'Create One-Pager';
+        onepageLbl.appendChild(onepageText);
+        onepageWrap.appendChild(onepageLbl);
+        var onepageHint = document.createElement('p');
+        onepageHint.className = 'leg-popup-hint';
+        onepageHint.style.marginTop = '0.25rem';
+        onepageHint.textContent = 'When set, analysis builds a loc sheet and links this location on the Locations report.';
+        onepageWrap.appendChild(onepageHint);
+        content.appendChild(onepageWrap);
+
         var notesInput = document.createElement('textarea');
         notesInput.rows = 2;
         notesInput.value = (opts.loc && opts.loc.notes) || '';
@@ -3630,6 +3649,7 @@
             var buf = parseInt(bufferInput.value, 10);
             target.buffer = isNaN(buf) ? 10 : Math.max(0, Math.min(999, buf));
             target.notes = notesInput.value.trim();
+            target.onepage = onepageCb.checked ? 'y' : 'n';
             target.resources = {};
             Object.keys(resourceInputs).forEach(function (code) {
                 var n = parseInt(resourceInputs[code].value, 10);
@@ -3697,7 +3717,9 @@
             redrawLegLocationMarkers(getSelectedLeg());
         }
 
-        btnPrimary.onclick = function () {
+        btnPrimary.onclick = function (ev) {
+            if (ev && ev.stopPropagation) ev.stopPropagation();
+            if (ev && ev.preventDefault) ev.preventDefault();
             var locLabel = (input.value && input.value.trim()) || 'Location';
             var locType = sel.value || 'course';
 
@@ -3759,13 +3781,16 @@
                 );
                 applyOpsFields(savedLoc);
                 locations[locIndex] = savedLoc;
+                // Close immediately so Save feels responsive; persist in background.
+                map.closePopup();
                 setLegStatus('Saving location…');
                 saveLegLocations(selectedLegId, locations)
                     .then(function () {
-                        closeAndRedraw();
+                        redrawLegLocationMarkers(getSelectedLeg());
                         setLegStatus('Location updated.');
                     })
                     .catch(function (err) {
+                        redrawLegLocationMarkers(getSelectedLeg());
                         setLegStatus(err.message || String(err), true);
                     });
             }

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -157,6 +157,7 @@
             <thead>
                 <tr>
                     <th class="table-sortable" data-sort="loc_id">ID <span class="table-sortable-indicator"></span></th>
+                    <th class="table-sortable" data-sort="location_key">Key <span class="table-sortable-indicator"></span></th>
                     <th>Location</th>
                     <th class="table-sortable" data-sort="loc_type">Type <span class="table-sortable-indicator"></span></th>
                     <th class="table-sortable" data-sort="zone">Zone <span class="table-sortable-indicator"></span></th>
@@ -168,7 +169,7 @@
             </thead>
             <tbody id="locations-tbody">
                 <tr>
-                    <td colspan="8" class="placeholder">Loading locations data...</td>
+                    <td colspan="9" class="placeholder">Loading locations data...</td>
                 </tr>
             </tbody>
         </table>
@@ -189,6 +190,10 @@
             </tr>
         </thead>
         <tbody>
+            <tr>
+                <td><strong>Key</strong></td>
+                <td>Stable authoring key for the location (<code>location_key</code>). Use it to match the same physical place when multiple <em>ID</em> rows exist (e.g. paired reverse legs).</td>
+            </tr>
             <tr>
                 <td><strong>Location</strong></td>
                 <td>The name or label of the location (e.g., "Regent & McLeod").</td>
@@ -225,7 +230,7 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-05-03T747Z-extract"></script>
+<script src="/static/js/map/locations.js?v=2026-07-28-location-key"></script>
 
 <!-- Table interaction script -->
 <script>
@@ -334,6 +339,7 @@
         const locations = features.map(feature => {
             const location = {
                 loc_id: feature.properties.loc_id,
+                location_key: feature.properties.location_key,
                 loc_label: feature.properties.loc_label,
                 loc_type: feature.properties.loc_type,
                 zone: feature.properties.zone,
@@ -390,6 +396,7 @@
         const locations = features.map(feature => {
             const location = {
                 loc_id: feature.properties.loc_id,
+                location_key: feature.properties.location_key,
                 loc_label: feature.properties.loc_label,
                 loc_type: feature.properties.loc_type,
                 zone: feature.properties.zone,
@@ -894,6 +901,10 @@
                     aVal = a.loc_id != null && a.loc_id !== undefined ? Number(a.loc_id) : Infinity;
                     bVal = b.loc_id != null && b.loc_id !== undefined ? Number(b.loc_id) : Infinity;
                     break;
+                case 'location_key':
+                    aVal = (a.location_key && a.location_key !== "NA") ? String(a.location_key).toLowerCase() : '';
+                    bVal = (b.location_key && b.location_key !== "NA") ? String(b.location_key).toLowerCase() : '';
+                    break;
                 case 'loc_type':
                     aVal = (a.loc_type && a.loc_type !== "NA") ? a.loc_type.toLowerCase() : '';
                     bVal = (b.loc_type && b.loc_type !== "NA") ? b.loc_type.toLowerCase() : '';
@@ -1111,7 +1122,7 @@
         tbody.innerHTML = '';
         
         if (!locations || locations.length === 0) {
-            tbody.innerHTML = '<tr><td colspan="8" class="placeholder">No locations data available</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="9" class="placeholder">No locations data available</td></tr>';
             return;
         }
         
@@ -1137,6 +1148,11 @@
             
             // Get loc_id
             const locId = location.loc_id !== null && location.loc_id !== undefined ? location.loc_id : "—";
+
+            const locKeyRaw = location.location_key;
+            const locKey = (locKeyRaw != null && locKeyRaw !== "" && locKeyRaw !== "NA" && String(locKeyRaw).toLowerCase() !== "null")
+                ? String(locKeyRaw).trim()
+                : "—";
             
             // Format zone
             const zone = location.zone && location.zone !== "NA" && location.zone !== "" ? location.zone : "—";
@@ -1162,10 +1178,10 @@
             const flagValue = location.flag === true || location.flag === "true" || location.flag === "Y" ? "Y" : "N";
             const flagDisplay = flagValue;
             
-            // Updated table structure - includes Type column, Flag column, combined First/Last Runner
-            // Column order: ID, Location, Type, Zone, Flag, Operational Window, First/Last Runner, Peak Window
+            // Column order: ID, Key, Location, Type, Zone, Flag, Operational Window, First/Last Runner, Peak Window
             row.innerHTML = `
                 <td>${locId}</td>
+                <td>${escapeHtml(locKey)}</td>
                 <td>${formatLocationCellHtml(location)}</td>
                 <td>${locType}</td>
                 <td>${zone}</td>
@@ -1212,7 +1228,7 @@
     
     function showLocationsError(message) {
         const tbody = document.getElementById('locations-tbody');
-        tbody.innerHTML = `<tr><td colspan="8" class="placeholder">${message}</td></tr>`;
+        tbody.innerHTML = `<tr><td colspan="9" class="placeholder">${message}</td></tr>`;
     }
     
     // Make updateLocationsTable globally available for locations.js

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -157,7 +157,6 @@
             <thead>
                 <tr>
                     <th class="table-sortable" data-sort="loc_id">ID <span class="table-sortable-indicator"></span></th>
-                    <th class="table-sortable" data-sort="location_key">Key <span class="table-sortable-indicator"></span></th>
                     <th>Location</th>
                     <th class="table-sortable" data-sort="loc_type">Type <span class="table-sortable-indicator"></span></th>
                     <th class="table-sortable" data-sort="zone">Zone <span class="table-sortable-indicator"></span></th>
@@ -169,7 +168,7 @@
             </thead>
             <tbody id="locations-tbody">
                 <tr>
-                    <td colspan="9" class="placeholder">Loading locations data...</td>
+                    <td colspan="8" class="placeholder">Loading locations data...</td>
                 </tr>
             </tbody>
         </table>
@@ -192,7 +191,11 @@
         <tbody>
             <tr>
                 <td><strong>Key</strong></td>
-                <td>Stable authoring key for the location (<code>location_key</code>). Use it to match the same physical place when multiple <em>ID</em> rows exist (e.g. paired reverse legs).</td>
+                <td>Stable authoring key for the location. When two analysis IDs share a key (paired reverse legs), the table and map show <em>one</em> Location with Outbound and Return runner times.</td>
+            </tr>
+            <tr>
+                <td><strong>ID</strong></td>
+                <td>Crew-facing location id(s). Paired reverse legs show both ids (e.g. <code>117 / 129</code>). Third-party CSV imports still use one row per id.</td>
             </tr>
             <tr>
                 <td><strong>Location</strong></td>
@@ -230,7 +233,8 @@
 
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/locations.js?v=2026-07-28-location-key"></script>
+<script src="/static/js/map/location_pairing.js?v=2026-07-28-810"></script>
+<script src="/static/js/map/locations.js?v=2026-07-29-pass-line"></script>
 
 <!-- Table interaction script -->
 <script>
@@ -285,7 +289,10 @@
             })
             .then(data => {
                 if (data.ok && data.locations) {
-                    locationsData = data.locations;
+                    const raw = data.locations;
+                    locationsData = (window.LocationPairing && window.LocationPairing.collapseLocationsByKey)
+                        ? window.LocationPairing.collapseLocationsByKey(raw)
+                        : raw;
                     
                     // Debug: Check first_runner and last_runner in first location
                     if (data.locations.length > 0) {
@@ -299,8 +306,8 @@
                     }
                     
                     // Populate filter dropdowns
-                    populateTypeFilter(data.locations);
-                    populateZoneFilter(data.locations);
+                    populateTypeFilter(locationsData);
+                    populateZoneFilter(locationsData);
                     // Issue #591: Populate resource filter from API response
                     if (data.resources_available) {
                         populateResourceFilter(data.resources_available);
@@ -333,31 +340,32 @@
         // Mark that data has been loaded to prevent duplicate loading
         tableDataLoaded = true;
         
-        // Convert features back to locations format for table rendering
-        // Issue #483: Include first_runner and last_runner
-        // Issue #591: Include resource count and mins fields dynamically
+        // Issue #810: features are already location-collapsed from convertToGeoJSON
         const locations = features.map(feature => {
+            const p = feature.properties || {};
             const location = {
-                loc_id: feature.properties.loc_id,
-                location_key: feature.properties.location_key,
-                loc_label: feature.properties.loc_label,
-                loc_type: feature.properties.loc_type,
-                zone: feature.properties.zone,
-                loc_start: feature.properties.loc_start,
-                loc_end: feature.properties.loc_end,
-                duration: feature.properties.duration,
-                peak_start: feature.properties.peak_start,
-                peak_end: feature.properties.peak_end,
-                timing_source: feature.properties.timing_source,
-                first_runner: feature.properties.first_runner,
-                last_runner: feature.properties.last_runner,
-                onepage: feature.properties.onepage
+                loc_id: p.loc_id,
+                primary_loc_id: p.loc_id,
+                loc_ids: p.loc_ids || [p.loc_id],
+                location_key: p.location_key,
+                paired: !!p.paired,
+                passes: p.passes || null,
+                loc_label: p.loc_label,
+                loc_type: p.loc_type,
+                zone: p.zone,
+                loc_start: p.loc_start,
+                loc_end: p.loc_end,
+                duration: p.duration,
+                peak_start: p.peak_start,
+                peak_end: p.peak_end,
+                timing_source: p.timing_source,
+                first_runner: p.first_runner,
+                last_runner: p.last_runner,
+                onepage: p.onepage
             };
-            // Issue #591: Dynamically add all resource count and mins fields
-            // Issue #598: Include flag fields
-            Object.keys(feature.properties).forEach(key => {
+            Object.keys(p).forEach(key => {
                 if (key.endsWith('_count') || key.endsWith('_mins') || key === 'flag' || key === 'flagged_seg_id' || key === 'flag_severity' || key === 'flag_worst_los' || key === 'flag_note') {
-                    location[key] = feature.properties[key];
+                    location[key] = p[key];
                 }
             });
             return location;
@@ -391,30 +399,31 @@
             return;
         }
         
-        // Convert features to locations format
-        // Issue #591: Include resource count and mins fields dynamically
         const locations = features.map(feature => {
+            const p = feature.properties || {};
             const location = {
-                loc_id: feature.properties.loc_id,
-                location_key: feature.properties.location_key,
-                loc_label: feature.properties.loc_label,
-                loc_type: feature.properties.loc_type,
-                zone: feature.properties.zone,
-                loc_start: feature.properties.loc_start,
-                loc_end: feature.properties.loc_end,
-                duration: feature.properties.duration,
-                peak_start: feature.properties.peak_start,
-                peak_end: feature.properties.peak_end,
-                timing_source: feature.properties.timing_source,
-                first_runner: feature.properties.first_runner,
-                last_runner: feature.properties.last_runner,
-                onepage: feature.properties.onepage
+                loc_id: p.loc_id,
+                primary_loc_id: p.loc_id,
+                loc_ids: p.loc_ids || [p.loc_id],
+                location_key: p.location_key,
+                paired: !!p.paired,
+                passes: p.passes || null,
+                loc_label: p.loc_label,
+                loc_type: p.loc_type,
+                zone: p.zone,
+                loc_start: p.loc_start,
+                loc_end: p.loc_end,
+                duration: p.duration,
+                peak_start: p.peak_start,
+                peak_end: p.peak_end,
+                timing_source: p.timing_source,
+                first_runner: p.first_runner,
+                last_runner: p.last_runner,
+                onepage: p.onepage
             };
-            // Issue #591: Dynamically add all resource count and mins fields
-            // Issue #598: Include flag fields
-            Object.keys(feature.properties).forEach(key => {
+            Object.keys(p).forEach(key => {
                 if (key.endsWith('_count') || key.endsWith('_mins') || key === 'flag' || key === 'flagged_seg_id' || key === 'flag_severity' || key === 'flag_worst_los' || key === 'flag_note') {
-                    location[key] = feature.properties[key];
+                    location[key] = p[key];
                 }
             });
             return location;
@@ -462,7 +471,7 @@
                 }
             }
             
-            // Last Runner filter
+            // Last Runner filter (combined last when paired — Issue #810)
             const lastRunnerHHMM = timeToHHMM(location.last_runner);
             if (lastRunnerMin && (!lastRunnerHHMM || lastRunnerHHMM < lastRunnerMin)) {
                 return false;
@@ -480,14 +489,15 @@
         } else {
             // Default sort by loc_id
             filtered.sort((a, b) => {
-                const idA = a.loc_id || 0;
-                const idB = b.loc_id || 0;
+                const idA = a.primary_loc_id || a.loc_id || 0;
+                const idB = b.primary_loc_id || b.loc_id || 0;
                 return idA - idB;
             });
         }
         
         // Update map markers (without fitting bounds - preserve user zoom)
-        filterMapToLocations(filtered.map(loc => loc.loc_id), false);
+        const visibleIds = filtered.flatMap(loc => loc.loc_ids || [loc.loc_id]);
+        filterMapToLocations(visibleIds, false);
         
         // Render filtered and sorted data
         renderLocationsTable(filtered);
@@ -771,14 +781,15 @@
         } else {
             // Default sort by loc_id
             filtered.sort((a, b) => {
-                const idA = a.loc_id || 0;
-                const idB = b.loc_id || 0;
+                const idA = a.primary_loc_id || a.loc_id || 0;
+                const idB = b.primary_loc_id || b.loc_id || 0;
                 return idA - idB;
             });
         }
         
         // Update map to show only filtered locations (only fit bounds if requested)
-        filterMapToLocations(filtered.map(loc => loc.loc_id), fitBounds);
+        const visibleIds = filtered.flatMap(loc => loc.loc_ids || [loc.loc_id]);
+        filterMapToLocations(visibleIds, fitBounds);
         
         // Render filtered and sorted data
         renderLocationsTable(filtered);
@@ -1103,7 +1114,7 @@
         if (!day) {
             return escaped;
         }
-        const lid = String(location.loc_id);
+        const lid = String(location.primary_loc_id != null ? location.primary_loc_id : location.loc_id);
         const cloudUi = !!window.CLOUD_UI;
         let path;
         if (cloudUi) {
@@ -1146,42 +1157,48 @@
             const peakEndFormatted = formatTimeToHHMM(peakEnd);
             const peakWindow = (peakStartFormatted && peakEndFormatted) ? `${peakStartFormatted} → ${peakEndFormatted}` : "—";
             
-            // Get loc_id
-            const locId = location.loc_id !== null && location.loc_id !== undefined ? location.loc_id : "—";
-
-            const locKeyRaw = location.location_key;
-            const locKey = (locKeyRaw != null && locKeyRaw !== "" && locKeyRaw !== "NA" && String(locKeyRaw).toLowerCase() !== "null")
-                ? String(locKeyRaw).trim()
-                : "—";
+            // Get loc_id (human Location number)
+            const locId = (location.loc_id !== null && location.loc_id !== undefined ? location.loc_id : "—");
             
             // Format zone
             const zone = location.zone && location.zone !== "NA" && location.zone !== "" ? location.zone : "—";
             
-            // Format First/Last Runner (Issue #592: Combined column)
-            // Handle null, undefined, "NA", or empty string
-            const firstRunnerRaw = location.first_runner;
-            const firstRunnerFormatted = (firstRunnerRaw && firstRunnerRaw !== "NA" && firstRunnerRaw !== "null") 
-                ? formatTimeToHHMM(firstRunnerRaw) || "—"
-                : "—";
-            
-            const lastRunnerRaw = location.last_runner;
-            const lastRunnerFormatted = (lastRunnerRaw && lastRunnerRaw !== "NA" && lastRunnerRaw !== "null")
-                ? formatTimeToHHMM(lastRunnerRaw) || "—"
-                : "—";
-            
-            // Combine First/Last Runner into single column (Issue #592)
-            const firstLastRunner = (firstRunnerFormatted !== "—" && lastRunnerFormatted !== "—")
-                ? `${firstRunnerFormatted} → ${lastRunnerFormatted}`
-                : "—";
+            // Format First/Last Runner (Issue #592: Combined column; paired shows Outbound/Return)
+            let firstLastRunner;
+            if (location.paired && Array.isArray(location.passes) && location.passes.length > 1) {
+                const lines = location.passes.map((pass) => {
+                    const role = pass.pass === 'return' ? 'Return' : 'Outbound';
+                    const pf = (pass.first_runner && pass.first_runner !== 'NA' && pass.first_runner !== 'null')
+                        ? (formatTimeToHHMM(pass.first_runner) || '—') : '—';
+                    const pl = (pass.last_runner && pass.last_runner !== 'NA' && pass.last_runner !== 'null')
+                        ? (formatTimeToHHMM(pass.last_runner) || '—') : '—';
+                    const window = (pf !== '—' && pl !== '—') ? `${pf} → ${pl}` : '—';
+                    return `${role}: ${window}`;
+                });
+                firstLastRunner = lines.join('<br>');
+            } else {
+                const firstRunnerRaw = location.first_runner;
+                const firstRunnerFormatted = (firstRunnerRaw && firstRunnerRaw !== "NA" && firstRunnerRaw !== "null") 
+                    ? formatTimeToHHMM(firstRunnerRaw) || "—"
+                    : "—";
+                
+                const lastRunnerRaw = location.last_runner;
+                const lastRunnerFormatted = (lastRunnerRaw && lastRunnerRaw !== "NA" && lastRunnerRaw !== "null")
+                    ? formatTimeToHHMM(lastRunnerRaw) || "—"
+                    : "—";
+                
+                firstLastRunner = (firstRunnerFormatted !== "—" && lastRunnerFormatted !== "—")
+                    ? `${firstRunnerFormatted} → ${lastRunnerFormatted}`
+                    : "—";
+            }
             
             // Issue #598: Format flag value
             const flagValue = location.flag === true || location.flag === "true" || location.flag === "Y" ? "Y" : "N";
             const flagDisplay = flagValue;
             
-            // Column order: ID, Key, Location, Type, Zone, Flag, Operational Window, First/Last Runner, Peak Window
+            // Column order: ID, Location, Type, Zone, Flag, Operational Window, First/Last Runner, Peak Window
             row.innerHTML = `
-                <td>${locId}</td>
-                <td>${escapeHtml(locKey)}</td>
+                <td>${escapeHtml(String(locId))}</td>
                 <td>${formatLocationCellHtml(location)}</td>
                 <td>${locType}</td>
                 <td>${zone}</td>
@@ -1193,7 +1210,7 @@
             
             // Add click handler for table-to-map filtering
             row.addEventListener('click', function() {
-                const locationId = location.loc_id;
+                const locationId = location.primary_loc_id != null ? location.primary_loc_id : location.loc_id;
                 
                 // Check if this row is already selected
                 if (row.classList.contains('selected-row')) {

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -313,7 +313,7 @@
 <script src="/static/js/table_actions.js?v=799e"></script>
 <script src="/static/js/map/location_grid_editor.js?v=773g"></script>
 <script src="/static/js/map/course_mapping.js?v=795b"></script>
-<script src="/static/js/map/segment_recipes.js?v=791p2"></script>
+<script src="/static/js/map/segment_recipes.js?v=810-onepage-close"></script>
 <script src="/static/js/map/saved_courses.js?v=791p2"></script>
 <script src="/static/js/runners_baseline.js?v=756k"></script>
 <script src="/static/js/race_configuration.js?v=791p2"></script>

--- a/frontend/templates/pages/reports.html
+++ b/frontend/templates/pages/reports.html
@@ -6,7 +6,7 @@
 <div class="page-header">
     <h2>Reports</h2>
     <p style="margin: 0.35rem 0 0; color: #666; font-size: 0.9rem; max-width: 40rem;">
-        Generated Density, Flow, Locations, and finish-time wave reports (grouped by day).
+        Generated Density, Flow, Locations, Passes, and finish-time wave reports (grouped by day).
     </p>
     {% if meta %}
     {% endif %}
@@ -87,11 +87,12 @@
         
         // Filter and categorize files
         const relevantReports = reports.filter(r => {
-            // Include Density, Flow, Locations, finish_times, finish-area PDF (Issue #743)
+            // Include Density, Flow, Locations, Passes, finish_times, finish-area PDF (Issue #743)
             const isRelevantReport = (
                 r.name.includes('Density') ||
                 r.name.includes('Flow') ||
                 r.name.includes('Locations') ||
+                r.name.includes('Passes') ||
                 r.name === 'finish_times.csv' ||
                 r.name === 'finish_area_demand.pdf'
             ) && (r.name.endsWith('.md') || r.name.endsWith('.csv') || r.name === 'finish_area_demand.pdf');
@@ -187,8 +188,9 @@
                     if (name === 'Density.md') return 0;
                     if (name === 'Flow.csv') return 1;
                     if (name === 'Locations.csv') return 2;
-                    if (name === 'finish_times.csv') return 3;
-                    if (name === 'finish_area_demand.pdf') return 4;
+                    if (name === 'Passes.csv') return 3;
+                    if (name === 'finish_times.csv') return 4;
+                    if (name === 'finish_area_demand.pdf') return 5;
                     return 50;
                 };
                 dayReports.sort((a, b) => {

--- a/tests/unit/test_config_package_export_segments.py
+++ b/tests/unit/test_config_package_export_segments.py
@@ -108,13 +108,14 @@ def test_export_config_package_segments_writes_and_validates(tmp_path, monkeypat
     assert result["location_count"] == 1
     loc_lines = locations_path.read_text(encoding="utf-8").strip().splitlines()
     header = loc_lines[0]
-    assert header.startswith("loc_id,")
+    assert header.startswith("pass_id,")
+    assert "loc_id" in header
+    assert "pass_key" in header
     assert "notes" in header
     assert "fpf_count" in header
     assert "yssr_count" in header
     assert "loc_direction" not in header
-    assert "Aid 1" in loc_lines[1]
-    assert "North side" in loc_lines[1]
+    assert locations_path.name == "passes.csv"
 
 
 def test_export_backs_up_existing_segments(tmp_path, monkeypatch):

--- a/tests/unit/test_loc_sheets_list.py
+++ b/tests/unit/test_loc_sheets_list.py
@@ -75,6 +75,40 @@ def test_wrong_day_excluded(tmp_path: Path) -> None:
     assert len(out) == 0
 
 
+def test_paired_location_key_one_index_entry(tmp_path: Path) -> None:
+    """Issue #810: shared location_key with onepage on either pass → one index row."""
+    day = "sun"
+    comp = tmp_path / day / "computation"
+    comp.mkdir(parents=True)
+    (comp / "locations_results.json").write_text(
+        json.dumps(
+            {
+                "locations": [
+                    {
+                        "loc_id": 129,
+                        "location_key": "J6NJY",
+                        "loc_label": "University at George",
+                        "day": "sun",
+                        "onepage": "n",
+                    },
+                    {
+                        "loc_id": 117,
+                        "location_key": "J6NJY",
+                        "loc_label": "University at George",
+                        "day": "sun",
+                        "onepage": "y",
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+    out = build_loc_sheet_entries(tmp_path, day)
+    assert len(out) == 1
+    assert out[0]["loc_id"] == 117
+    assert out[0]["loc_ids"] == [117, 129]
+
+
 def test_fallback_html_on_disk(tmp_path: Path) -> None:
     day = "sun"
     comp = tmp_path / day / "computation"

--- a/tests/unit/test_location_identity.py
+++ b/tests/unit/test_location_identity.py
@@ -1,0 +1,36 @@
+"""Tests for 2027 pass / location identity stamping."""
+
+from app.core.locations.identity import (
+    effective_pass_key,
+    get_loc_id,
+    get_pass_id,
+    stamp_pass_identity,
+)
+
+
+def test_stamp_pass_identity_assigns_shared_loc_id():
+    locs = [
+        {"id": 32, "location_key": "7EFZ9", "loc_label": "Fulton out"},
+        {"id": 3, "location_key": "7EFZ9", "loc_label": "Fulton return"},
+        {"id": 94, "location_key": "73634", "loc_label": "WSB"},
+    ]
+    stamp_pass_identity(locs)
+    assert get_pass_id(locs[0]) == 32
+    assert get_pass_id(locs[1]) == 3
+    assert locs[0]["pass_key"] == locs[1]["pass_key"] == "7EFZ9"
+    assert get_loc_id(locs[0]) == get_loc_id(locs[1])
+    assert get_loc_id(locs[0]) != get_pass_id(locs[0])
+    assert get_loc_id(locs[2]) != get_loc_id(locs[0])
+    assert effective_pass_key(locs[2]) == "73634"
+
+
+def test_stamp_pass_identity_preserves_existing_shared_loc_id():
+    locs = [
+        {"id": 10, "pass_key": "ABCDE", "loc_id": 7, "loc_label": "A"},
+        {"id": 20, "pass_key": "ABCDE", "loc_id": 7, "loc_label": "B"},
+    ]
+    stamp_pass_identity(locs)
+    assert get_loc_id(locs[0]) == 7
+    assert get_loc_id(locs[1]) == 7
+    assert get_pass_id(locs[0]) == 10
+    assert get_pass_id(locs[1]) == 20

--- a/tests/unit/test_location_keys.py
+++ b/tests/unit/test_location_keys.py
@@ -21,6 +21,7 @@ def test_ensure_location_key_preserves_existing():
     loc = {"location_key": "ABCDE", "loc_label": "A"}
     assert ensure_location_key(loc, used) == "ABCDE"
     assert loc["location_key"] == "ABCDE"
+    assert "ABCDE" in used
 
 
 def test_ensure_location_key_allocates_when_missing():
@@ -30,3 +31,22 @@ def test_ensure_location_key_allocates_when_missing():
     assert is_valid_location_key(key)
     assert key != "ABCDE"
     assert loc["location_key"] == key
+    assert key in used
+
+
+def test_ensure_location_key_allows_shared_key_for_paired_legs():
+    """Issue #810: paired reverse legs may reuse the same location_key."""
+    used = set()
+    a = {"location_key": "J6NJY", "loc_label": "George out"}
+    b = {"location_key": "J6NJY", "loc_label": "George return"}
+    assert ensure_location_key(a, used) == "J6NJY"
+    assert ensure_location_key(b, used) == "J6NJY"
+    assert a["location_key"] == b["location_key"] == "J6NJY"
+    assert used == {"J6NJY"}
+
+
+def test_ensure_location_key_preserves_when_already_in_used():
+    used = {"J6NJY"}
+    loc = {"location_key": "J6NJY", "loc_label": "Return pass"}
+    assert ensure_location_key(loc, used) == "J6NJY"
+    assert loc["location_key"] == "J6NJY"

--- a/tests/unit/test_location_pairing.py
+++ b/tests/unit/test_location_pairing.py
@@ -1,0 +1,95 @@
+"""Issue #810: paired reverse-leg location helpers."""
+
+from app.core.locations.pairing import (
+    annotate_location_passes,
+    effective_location_key,
+    group_rows_by_location_key,
+    time_to_seconds,
+)
+
+
+def test_annotate_assigns_outbound_return_by_first_runner():
+    rows = [
+        {
+            "loc_id": 129,
+            "location_key": "J6NJY",
+            "first_runner": "08:12:57",
+            "last_runner": "09:51:00",
+        },
+        {
+            "loc_id": 117,
+            "location_key": "J6NJY",
+            "first_runner": "08:02:33",
+            "last_runner": "09:09:37",
+        },
+    ]
+    annotate_location_passes(rows)
+    by_id = {r["loc_id"]: r for r in rows}
+    assert by_id[117]["pass"] == "outbound"
+    assert by_id[117]["same_location_as"] == 129
+    assert by_id[129]["pass"] == "return"
+    assert by_id[129]["same_location_as"] == 117
+
+
+def test_annotate_leaves_unpaired_empty():
+    rows = [
+        {"loc_id": 1, "location_key": "AAAAA", "first_runner": "08:00:00"},
+        {"loc_id": 2, "location_key": "", "first_runner": "09:00:00"},
+    ]
+    annotate_location_passes(rows)
+    assert rows[0]["pass"] == ""
+    assert rows[0]["same_location_as"] == ""
+    assert rows[1]["pass"] == ""
+
+
+def test_group_rows_combines_paired_window():
+    rows = [
+        {
+            "loc_id": 117,
+            "location_key": "J6NJY",
+            "loc_label": "University at George",
+            "first_runner": "08:02:33",
+            "last_runner": "09:09:37",
+            "loc_start": "06:15:00",
+            "loc_end": "09:20:00",
+            "onepage": "y",
+        },
+        {
+            "loc_id": 129,
+            "location_key": "J6NJY",
+            "loc_label": "University at George",
+            "first_runner": "08:12:57",
+            "last_runner": "09:51:00",
+            "loc_start": "06:15:00",
+            "loc_end": "10:05:00",
+            "onepage": "n",
+        },
+        {
+            "loc_id": 50,
+            "location_key": "SOLO1",
+            "loc_label": "Solo",
+            "first_runner": "08:00:00",
+            "last_runner": "09:00:00",
+            "loc_start": "06:15:00",
+            "loc_end": "09:10:00",
+        },
+    ]
+    groups = group_rows_by_location_key(rows)
+    paired = next(g for g in groups if g.get("pass_key") == "J6NJY" or g["location_key"] == "J6NJY")
+    assert paired["paired"] is True
+    assert paired["pass_ids"] == [117, 129]
+    assert paired["loc_ids"] == [paired["loc_id"]]
+    assert paired["first_runner"] == "08:02:33"
+    assert paired["last_runner"] == "09:51:00"
+    assert paired["loc_end"] == "10:05:00"
+    assert paired["onepage"] == "y"
+    assert [p["pass"] for p in paired["passes"]] == ["outbound", "return"]
+
+    solo = next(g for g in groups if g.get("pass_key") == "SOLO1" or g["location_key"] == "SOLO1")
+    assert solo["paired"] is False
+    assert solo["loc_ids"] == [50]
+
+
+def test_effective_location_key_leg_fallback():
+    assert effective_location_key({"leg_loc_key": "ABCDE"}) == "ABCDE"
+    assert time_to_seconds("08:02:33") == 8 * 3600 + 2 * 60 + 33

--- a/tests/unit/test_location_report_location_key.py
+++ b/tests/unit/test_location_report_location_key.py
@@ -1,4 +1,4 @@
-"""Locations report includes stable location_key in Locations.csv."""
+"""Locations/Passes reports include pass_key and human loc_id."""
 
 from __future__ import annotations
 
@@ -7,48 +7,49 @@ from pathlib import Path
 import pandas as pd
 
 import app.location_report as location_report
+from app.io.loader import normalize_passes_input_dataframe
 
 
-def test_generate_location_report_includes_location_key(tmp_path, monkeypatch):
-    locations = pd.DataFrame(
-        [
-            {
-                "loc_id": 151,
-                "location_key": "D3UF4",
-                "loc_label": "Trail at George",
-                "loc_type": "course",
-                "lat": 45.95,
-                "lon": -66.63,
-                "seg_id": "S11",
-                "full": "y",
-                "half": "n",
-                "10k": "n",
-                "buffer": 10,
-                "interval": 5,
-                "zone": "",
-                "notes": "",
-            },
-            {
-                "loc_id": 148,
-                "leg_loc_key": "D3UF4",  # fallback when location_key absent
-                "loc_label": "Trail at George",
-                "loc_type": "course",
-                "lat": 45.95,
-                "lon": -66.63,
-                "seg_id": "S9",
-                "full": "y",
-                "half": "y",
-                "10k": "y",
-                "buffer": 10,
-                "interval": 5,
-                "zone": "",
-                "notes": "",
-            },
-        ]
+def test_generate_location_report_writes_passes_and_locations(tmp_path, monkeypatch):
+    locations = normalize_passes_input_dataframe(
+        pd.DataFrame(
+            [
+                {
+                    "loc_id": 151,
+                    "location_key": "D3UF4",
+                    "loc_label": "Trail at George",
+                    "loc_type": "course",
+                    "lat": 45.95,
+                    "lon": -66.63,
+                    "seg_id": "S11",
+                    "full": "y",
+                    "half": "n",
+                    "10k": "n",
+                    "buffer": 10,
+                    "interval": 5,
+                    "zone": "",
+                    "notes": "",
+                },
+                {
+                    "loc_id": 148,
+                    "leg_loc_key": "D3UF4",
+                    "loc_label": "Trail at George",
+                    "loc_type": "course",
+                    "lat": 45.95,
+                    "lon": -66.63,
+                    "seg_id": "S9",
+                    "full": "y",
+                    "half": "y",
+                    "10k": "y",
+                    "buffer": 10,
+                    "interval": 5,
+                    "zone": "",
+                    "notes": "",
+                },
+            ]
+        )
     )
-    runners = pd.DataFrame(
-        columns=["runner_id", "event", "pace", "start_offset"]
-    )
+    runners = pd.DataFrame(columns=["runner_id", "event", "pace", "start_offset"])
     segments = pd.DataFrame(
         [
             {
@@ -88,11 +89,25 @@ def test_generate_location_report_includes_location_key(tmp_path, monkeypatch):
         gpx_paths={"full": "full.gpx"},
     )
     assert result.get("ok") is True
-    report_path = Path(result["file_path"])
-    assert report_path.exists()
-    df = pd.read_csv(report_path)
-    assert "location_key" in df.columns
-    assert list(df.columns[:4]) == ["loc_id", "location_key", "loc_label", "day"]
-    by_id = df.set_index("loc_id")["location_key"].to_dict()
-    assert by_id[151] == "D3UF4"
-    assert by_id[148] == "D3UF4"
+
+    passes_path = Path(result["passes_path"])
+    locs_path = Path(result["file_path"])
+    assert passes_path.exists()
+    assert locs_path.exists()
+
+    passes = pd.read_csv(passes_path)
+    assert list(passes.columns[:5]) == [
+        "pass_id",
+        "loc_id",
+        "pass_key",
+        "pass",
+        "same_pass_as",
+    ]
+    assert set(passes["pass_key"].astype(str)) == {"D3UF4"}
+    assert passes["loc_id"].nunique() == 1
+    assert set(passes["pass"]) == {"outbound", "return"}
+
+    locs = pd.read_csv(locs_path)
+    assert "pass_key" in locs.columns
+    assert len(locs) == 1
+    assert int(locs.iloc[0]["pass_count"]) == 2

--- a/tests/unit/test_location_report_location_key.py
+++ b/tests/unit/test_location_report_location_key.py
@@ -1,0 +1,98 @@
+"""Locations report includes stable location_key in Locations.csv."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+import app.location_report as location_report
+
+
+def test_generate_location_report_includes_location_key(tmp_path, monkeypatch):
+    locations = pd.DataFrame(
+        [
+            {
+                "loc_id": 151,
+                "location_key": "D3UF4",
+                "loc_label": "Trail at George",
+                "loc_type": "course",
+                "lat": 45.95,
+                "lon": -66.63,
+                "seg_id": "S11",
+                "full": "y",
+                "half": "n",
+                "10k": "n",
+                "buffer": 10,
+                "interval": 5,
+                "zone": "",
+                "notes": "",
+            },
+            {
+                "loc_id": 148,
+                "leg_loc_key": "D3UF4",  # fallback when location_key absent
+                "loc_label": "Trail at George",
+                "loc_type": "course",
+                "lat": 45.95,
+                "lon": -66.63,
+                "seg_id": "S9",
+                "full": "y",
+                "half": "y",
+                "10k": "y",
+                "buffer": 10,
+                "interval": 5,
+                "zone": "",
+                "notes": "",
+            },
+        ]
+    )
+    runners = pd.DataFrame(
+        columns=["runner_id", "event", "pace", "start_offset"]
+    )
+    segments = pd.DataFrame(
+        [
+            {
+                "seg_id": "S11",
+                "seg_label": "rev",
+                "full": "y",
+                "half": "n",
+                "10k": "n",
+                "full_from_km": 0.0,
+                "full_to_km": 0.3,
+                "direction": "uni",
+                "width_m": 4.0,
+            }
+        ]
+    )
+
+    monkeypatch.setattr(location_report, "load_locations", lambda p: locations.copy())
+    monkeypatch.setattr(location_report, "load_runners", lambda p: runners.copy())
+    monkeypatch.setattr(location_report, "load_segments", lambda p: segments.copy())
+    monkeypatch.setattr(location_report, "load_all_courses", lambda gpx: {})
+    monkeypatch.setattr(
+        location_report,
+        "calculate_arrival_times_for_location",
+        lambda *a, **k: [],
+    )
+    monkeypatch.setattr(location_report, "load_flagged_segments", lambda **k: {})
+
+    out_dir = tmp_path / "reports"
+    out_dir.mkdir()
+    result = location_report.generate_location_report(
+        locations_csv=str(tmp_path / "locations.csv"),
+        runners_csv=str(tmp_path / "runners.csv"),
+        segments_csv=str(tmp_path / "segments.csv"),
+        start_times={"full": 420, "half": 440, "10k": 460},
+        output_dir=str(out_dir),
+        day="sun",
+        gpx_paths={"full": "full.gpx"},
+    )
+    assert result.get("ok") is True
+    report_path = Path(result["file_path"])
+    assert report_path.exists()
+    df = pd.read_csv(report_path)
+    assert "location_key" in df.columns
+    assert list(df.columns[:4]) == ["loc_id", "location_key", "loc_label", "day"]
+    by_id = df.set_index("loc_id")["location_key"].to_dict()
+    assert by_id[151] == "D3UF4"
+    assert by_id[148] == "D3UF4"

--- a/tests/unit/test_locations_schema.py
+++ b/tests/unit/test_locations_schema.py
@@ -50,6 +50,7 @@ def test_build_locations_csv_full_schema():
         "locations": [
             {
                 "id": 1,
+                "location_key": "ABCDE",
                 "loc_label": "Post A",
                 "loc_type": "course",
                 "lat": 45.95,
@@ -66,10 +67,28 @@ def test_build_locations_csv_full_schema():
     reader = csv.DictReader(io.StringIO(csv_content))
     row = next(reader)
     assert row["loc_id"] == "1"
+    assert row["location_key"] == "ABCDE"
     assert row["notes"] == "Watch crossing"
     assert row["yssr_count"] == "2"
     assert row["fpf_count"] == "0"
     assert row["full"] == "y"
+
+
+def test_build_locations_csv_leg_loc_key_fallback():
+    course = {
+        "locations": [
+            {
+                "id": 2,
+                "leg_loc_key": "XYZZY",
+                "loc_label": "Leg pin",
+                "loc_type": "course",
+            }
+        ]
+    }
+    csv_content = build_locations_csv(course, resource_codes=["fpf"])
+    reader = csv.DictReader(io.StringIO(csv_content))
+    row = next(reader)
+    assert row["location_key"] == "XYZZY"
 
 
 def test_suggest_location_events_from_segments():

--- a/tests/unit/test_locations_schema.py
+++ b/tests/unit/test_locations_schema.py
@@ -66,8 +66,9 @@ def test_build_locations_csv_full_schema():
     csv_content = build_locations_csv(course, resource_codes=["fpf", "yssr", "awp", "vol"])
     reader = csv.DictReader(io.StringIO(csv_content))
     row = next(reader)
-    assert row["loc_id"] == "1"
-    assert row["location_key"] == "ABCDE"
+    assert row["pass_id"] == "1"
+    assert row["pass_key"] == "ABCDE"
+    assert row["loc_id"]  # human loc_id stamped
     assert row["notes"] == "Watch crossing"
     assert row["yssr_count"] == "2"
     assert row["fpf_count"] == "0"
@@ -88,7 +89,7 @@ def test_build_locations_csv_leg_loc_key_fallback():
     csv_content = build_locations_csv(course, resource_codes=["fpf"])
     reader = csv.DictReader(io.StringIO(csv_content))
     row = next(reader)
-    assert row["location_key"] == "XYZZY"
+    assert row["pass_key"] == "XYZZY"
 
 
 def test_suggest_location_events_from_segments():

--- a/tests/unit/test_package_legs.py
+++ b/tests/unit/test_package_legs.py
@@ -315,6 +315,28 @@ def test_merge_leg_locations_sets_seg_id_from_leg(tmp_path, monkeypatch):
     assert leg_locs[0]["leg_loc_key"] == "01:0"
     assert leg_locs[0]["full"] == "y"
     assert leg_locs[0]["half"] == "n"
+    assert leg_locs[0]["day"] == "sun"
+
+
+def test_stamp_locations_with_package_day_overwrites_blank_and_nan():
+    from app.core.config_package.legs import stamp_locations_with_package_day
+
+    locations = [
+        {"loc_label": "A", "day": ""},
+        {"loc_label": "B", "day": "nan"},
+        {"loc_label": "C", "day": "sat"},
+    ]
+    updated = stamp_locations_with_package_day(locations, "sun")
+    assert updated == 3
+    assert all(loc["day"] == "sun" for loc in locations)
+
+    fill_only = [{"loc_label": "D", "day": "sat"}, {"loc_label": "E", "day": ""}]
+    updated = stamp_locations_with_package_day(
+        fill_only, "sun", overwrite=False
+    )
+    assert updated == 1
+    assert fill_only[0]["day"] == "sat"
+    assert fill_only[1]["day"] == "sun"
 
 
 def test_merge_leg_locations_resolves_proxy_leg_loc_key(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- **#810:** Collapse paired reverse-leg Locations in map, Course Resource Timing table, and loc sheets (Outbound + Return); keep timed rows for agencies.
- **#811:** 2027 identity — `loc_id` = human Location, `pass_id` = timed instance, `pass_key` = opaque unifier; package `passes.csv`; analysis `Passes.csv` + consolidated `Locations.csv`.
- Stamp package `event_day` onto passes at merge/export; one-pagers at `/{loc_id}.html`; Reports page download for `Passes.csv`; popup shows `PASS: {pass_key} | {pass_ids}` (not under Resources).

## Test plan
- [ ] Rebuild race exports on FM2027 package → `passes.csv` has `pass_id`, `loc_id`, `pass_key`, `day`
- [ ] Run analysis → `Passes.csv` (151) + `Locations.csv` (113); no blank/`nan` day
- [ ] Locations UI: one pin/row per Location; Outbound/Return when paired; no PASS under Resources
- [ ] Loc sheets: one HTML per human `loc_id` with both passes when paired
- [ ] Reports page: download `Locations.csv` and `Passes.csv`
- [ ] Unit: `test_location_identity`, `test_location_pairing`, related package/export tests

Closes #810
Closes #811


Made with [Cursor](https://cursor.com)