### PR TITLE
Reconcile stitched event kms for location projection (#786)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,8 +163,10 @@
 ### UI Changes
 - **Loc Sheets removed from navigation**: one-pagers are linked from the Locations UI (route kept)
 
-### Known Issues
-- **#786**: segment km bookkeeping drifts from stitched course geometry (~100 m mid-course), which can still fail centerline projection for pins at turn points
+### Issue #786 — segment km vs stitched GPX
+- Per-event `from_km`/`to_km` are measured along the stitched recipe polyline (same geometry as event GPX), not sum-of-rounded per-leg `length_km`
+- Exported / enriched event kms use **3 decimals** (1 m)
+- Removes mid-course bookkeeping drift that broke turn-point location projection
 
 ## [v2.0.6] - 2026-01-12
 

--- a/app/core/course/export.py
+++ b/app/core/course/export.py
@@ -15,6 +15,8 @@ from app.utils.constants import COURSE_EVENT_IDS
 
 # GPX 1.1 namespace
 GPX_NS = "http://www.topografix.com/GPX/1/1"
+# Match segment_library EVENT_KM_DECIMALS (1 m along-course).
+KM_DECIMALS = 3
 
 
 def _event_id(e: Any) -> str:
@@ -41,11 +43,11 @@ def _segment_display_id(segment_index: int) -> str:
 
 
 def _format_km_pipeline(value: float) -> str:
-    """Format km like 2026_final segments.csv (0, 0.9 — not always two decimals)."""
-    v = round(float(value), 2)
+    """Format km for pipeline segments.csv (trim trailing zeros; up to 3 decimals)."""
+    v = round(float(value), KM_DECIMALS)
     if v == int(v):
         return str(int(v))
-    text = format(v, ".2f")
+    text = format(v, f".{KM_DECIMALS}f")
     return text.rstrip("0").rstrip(".")
 
 
@@ -110,8 +112,8 @@ def _segment_events_set(seg: Dict[str, Any], event_ids: List[str]) -> set:
 
 
 def _format_km(value: float) -> str:
-    """Format a distance value to exactly 2 decimal places for CSV output."""
-    return format(round(float(value), 2), ".2f")
+    """Format a distance value to fixed decimals for CSV output (1 m resolution)."""
+    return format(round(float(value), KM_DECIMALS), f".{KM_DECIMALS}f")
 
 
 def _stored_event_kms(
@@ -145,7 +147,7 @@ def _event_cumulative_distances(segments: List[Dict], event_ids: List[str]) -> L
     Recipe-built segments keep their stored per-event kms (recipe traversal order);
     other segments accumulate in list order.
     Returns list of dicts: result[i][eid] = (from_km, to_km) for segment i and event eid.
-    Accumulated values are rounded to 2 decimal places to avoid float drift.
+    Accumulated values are rounded to KM_DECIMALS to avoid float drift.
     """
     n = len(segments)
     result = [{} for _ in range(n)]
@@ -164,9 +166,9 @@ def _event_cumulative_distances(segments: List[Dict], event_ids: List[str]) -> L
                 continue
             from_km = float(seg.get("from_km") or 0)
             to_km = float(seg.get("to_km") or 0)
-            seg_len = round(to_km - from_km, 2)
-            from_accum = round(accumulated, 2)
-            to_accum = round(accumulated + seg_len, 2)
+            seg_len = round(to_km - from_km, KM_DECIMALS)
+            from_accum = round(accumulated, KM_DECIMALS)
+            to_accum = round(accumulated + seg_len, KM_DECIMALS)
             result[i][eid] = (from_accum, to_accum)
             accumulated = to_accum
     return result
@@ -186,8 +188,8 @@ def enrich_segments_event_distances(segments: List[Dict], event_ids: List[str] =
     for i, seg in enumerate(segments):
         for ei, eid in enumerate(event_ids_lower):
             from_km, to_km = distances[i].get(eid, (0.0, 0.0))
-            seg[f"{eid}_from_km"] = round(float(from_km), 2)
-            seg[f"{eid}_to_km"] = round(float(to_km), 2)
+            seg[f"{eid}_from_km"] = round(float(from_km), KM_DECIMALS)
+            seg[f"{eid}_to_km"] = round(float(to_km), KM_DECIMALS)
 
 
 def build_segments_csv(course: Dict[str, Any], fmt: str = "pipeline") -> str:
@@ -266,7 +268,7 @@ def build_segments_csv(course: Dict[str, Any], fmt: str = "pipeline") -> str:
             else:
                 ev_from, ev_to = event_distances[i].get(eid_lower, (0.0, 0.0))
                 event_km.extend([km_fmt(ev_from), km_fmt(ev_to)])
-        seg_len = round(to_km - from_km, 2)
+        seg_len = round(to_km - from_km, KM_DECIMALS)
         zero_km = km_fmt(0.0) if use_pipeline else _format_km(0.0)
         lengths = [km_fmt(seg_len) if eid.lower() in seg_events else zero_km for eid in event_ids]
         description = seg.get("description", "")

--- a/app/core/course/segment_library.py
+++ b/app/core/course/segment_library.py
@@ -26,6 +26,8 @@ from app.utils.constants import COURSE_EVENT_IDS
 GPX_NS = "http://www.topografix.com/GPX/1/1"
 EARTH_R = 6371000.0
 STITCH_TOLERANCE_M = 80.0
+# Along-course km on stitched event polylines (1 m); matches export formatting.
+EVENT_KM_DECIMALS = 3
 
 
 def normalize_library_manifest(data: Dict[str, Any]) -> Dict[str, Any]:
@@ -70,6 +72,18 @@ def _haversine_m(lon1: float, lat1: float, lon2: float, lat2: float) -> float:
         * math.sin(d_lon / 2) ** 2
     )
     return EARTH_R * 2 * math.atan2(math.sqrt(a), math.sqrt(1 - a))
+
+
+def _polyline_length_km(coords: Sequence[Sequence[float]]) -> float:
+    """Haversine length of [[lon, lat], ...] in kilometres."""
+    if len(coords) < 2:
+        return 0.0
+    total_m = 0.0
+    for i in range(1, len(coords)):
+        lon1, lat1 = float(coords[i - 1][0]), float(coords[i - 1][1])
+        lon2, lat2 = float(coords[i][0]), float(coords[i][1])
+        total_m += _haversine_m(lon1, lat1, lon2, lat2)
+    return total_m / 1000.0
 
 
 def load_manifest(path: Path) -> Dict[str, Any]:
@@ -285,24 +299,43 @@ def _build_event_occurrence_km(
     legs_by_id: Dict[str, Dict[str, Any]],
     event_ids: Sequence[str],
 ) -> Dict[str, Dict[LegOccurrence, Tuple[float, float]]]:
-    """Per-event km window for each (leg_id, 1-based occurrence) in that recipe."""
+    """
+    Per-event km window for each (leg_id, 1-based occurrence) in that recipe.
+
+    Distances are measured along the same stitched polyline used for event GPX
+    (``concat_recipe_coordinates``), not by summing per-leg ``length_km`` rounded
+    independently. That keeps ``from_km``/``to_km`` aligned with
+    ``slice_polyline_by_km`` in location reports (#786).
+    """
     result: Dict[str, Dict[LegOccurrence, Tuple[float, float]]] = {}
+    decimals = EVENT_KM_DECIMALS
     for eid in event_ids:
         key = eid if eid in recipes else eid.lower()
         seq = recipes.get(key) or []
         occ_counts: Dict[str, int] = {}
         cum = 0.0
+        prev_end: Optional[List[float]] = None
         event_map: Dict[LegOccurrence, Tuple[float, float]] = {}
         for raw_id in seq:
             cid = str(raw_id).strip()
             ch = legs_by_id.get(cid)
             if not ch:
                 continue
-            length = float(ch["length_km"])
+            part = ch.get("coordinates") or []
+            if len(part) < 2:
+                continue
             occ_counts[cid] = occ_counts.get(cid, 0) + 1
             occ = occ_counts[cid]
-            cum += length
-            event_map[(cid, occ)] = (round(cum - length, 2), round(cum, 2))
+            if prev_end is None:
+                contrib_km = _polyline_length_km(part)
+            else:
+                # Drop the join vertex, matching concat_recipe_coordinates.
+                contrib_km = _polyline_length_km([prev_end] + list(part[1:]))
+            from_km = round(cum, decimals)
+            cum += contrib_km
+            to_km = round(cum, decimals)
+            event_map[(cid, occ)] = (from_km, to_km)
+            prev_end = [float(part[-1][0]), float(part[-1][1])]
         result[eid.lower()] = event_map
     return result
 
@@ -458,10 +491,13 @@ def export_library_to_course(
     recipe_lengths: Dict[str, float] = {}
     for eid in event_ids:
         key = eid if eid in recipes else eid.lower()
-        seq = recipes.get(key) or []
+        seq = [str(c).strip() for c in (recipes.get(key) or []) if str(c).strip() in legs_by_id]
+        if not seq:
+            recipe_lengths[eid] = 0.0
+            continue
         recipe_lengths[eid] = round(
-            sum(float(legs_by_id[c]["length_km"]) for c in seq if c in legs_by_id),
-            2,
+            _polyline_length_km(concat_recipe_coordinates(seq, legs_by_id)),
+            EVENT_KM_DECIMALS,
         )
 
     return {

--- a/docs/dev-guides/segment-library-2027.md
+++ b/docs/dev-guides/segment-library-2027.md
@@ -2,7 +2,7 @@
 
 **Status:** Implemented (org-primary since #780/#783; corridor pairing since #785)
 **Last updated:** 2026-06
-**Epics/issues:** #755 (library), #780 (org-primary), #785 (corridor pairing), #786 (km drift — open)
+**Epics/issues:** #755 (library), #780 (org-primary), #785 (corridor pairing), #786 (km drift — fixed: post-stitch traced kms)
 **User guide:** [Race Configuration](../user-guide/race-configuration.md)
 
 ---
@@ -78,7 +78,7 @@ Two copies of leg data exist: the leg manifest (authoring) and the package `cour
 - **Leg-owned:** `lat`, `lon`, `placement` (`_LEG_OWNED_PLACEMENT_FIELDS`) — pin moves on the Legs tab always win; stale course copies never override them.
 - **Course-owned (preserved):** crew-facing `id` (`loc_id`), resources, zone, notes, buffer, interval, contact, proxy settings, etc. (`_LEG_LOC_PRESERVE_FIELDS` minus placement). Identity is matched by `location_key` / `leg_loc_key`.
 
-**Server-owned recipe kms:** `_preserve_recipe_segment_kms()` (`storage.py::save_config_course`) prevents stale client saves from overwriting recipe-applied per-event `from_km`/`to_km` and the `segment_library_applied` flag.
+**Server-owned recipe kms:** `_preserve_recipe_segment_kms()` (`storage.py::save_config_course`) prevents stale client saves from overwriting recipe-applied per-event `from_km`/`to_km` and the `segment_library_applied` flag. Those kms are measured along the stitched event polyline (`_build_event_occurrence_km` / `concat_recipe_coordinates`), rounded to 3 decimals (1 m), so they match GPX slicing in location reports (#786).
 
 **UI note:** the Legs and Course tabs share one Leaflet map. Course-level location pins are removed while the Legs tab is active (`removeLocationPins` in `course_mapping.js`, called from `onLegsTabShown`) to avoid duplicate-pin confusion.
 
@@ -93,7 +93,7 @@ Two copies of leg data exist: the leg manifest (authoring) and the package `cour
 | `LOCATION_SNAP_THRESHOLD_M` | 50 | Max pin → segment-centerline distance for projection and for `find_nearest_segment` discovery |
 | `LOCATION_SEGMENT_CLAMP_M` | 50 | Boundary pins projecting metres past a segment end are clamped into bounds instead of falling back to midpoint |
 
-Known limitation: recipe-bookkept kms vs stitched-GPX traced distance drift up to ~110 m mid-course, which can still fail projection for pins at turn points — see **#786** for the planned reconciliation (record traced kms at export).
+Per-event `from_km`/`to_km` are reconciled to the stitched course at apply/export (#786), so snap/clamp can stay tight at 50 m for boundary pins.
 
 ---
 

--- a/docs/reference/quick-reference.md
+++ b/docs/reference/quick-reference.md
@@ -230,7 +230,7 @@ The following constants have been **removed** - values now come from API request
 
 **Location projection (`app/utils/constants.py`):**
 - `LOCATION_SNAP_THRESHOLD_M` (50 m): max pin → segment-centerline distance for projection and nearest-segment discovery
-- `LOCATION_SEGMENT_CLAMP_M` (50 m): boundary pins projecting metres past a segment end are clamped into bounds instead of falling back to segment-midpoint timing (see issue #786 for the km-drift limitation)
+- `LOCATION_SEGMENT_CLAMP_M` (50 m): boundary pins projecting metres past a segment end are clamped into bounds instead of falling back to segment-midpoint timing
 
 **Density:**
 - LOS thresholds: See `config/density_rulebook.yml`

--- a/docs/user-guide/race-configuration.md
+++ b/docs/user-guide/race-configuration.md
@@ -267,4 +267,4 @@ No — keep each directional leg `overtake`/`uni` (or as its same-direction inte
 Both legs must appear in at least one recipe of events being analyzed, and the events' passes must overlap in time.
 
 **"A location at a turnaround gets odd first/last runner times."**
-Turn-point pins sit at segment boundaries and can be affected by small distance bookkeeping differences (see issue #786). Keep the pin physically accurate; do not nudge it to compensate.
+Turn-point pins sit at segment boundaries. Recipe event kms are reconciled to the stitched course GPX at apply/export (#786); keep the pin physically accurate and re-apply recipes if segments were built before that fix.

--- a/tests/unit/test_leg_library_resolver.py
+++ b/tests/unit/test_leg_library_resolver.py
@@ -33,6 +33,17 @@ _GPX = """<?xml version="1.0"?>
 </gpx>"""
 
 
+def _gpx_leg(lon0: float, lon1: float, *, lat: float = 45.96) -> str:
+    """Two-point GPX with distinct endpoints so stitch contributions are non-zero."""
+    return f"""<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><name>leg</name><trkseg>
+    <trkpt lat="{lat}" lon="{lon0}"/>
+    <trkpt lat="{lat}" lon="{lon1}"/>
+  </trkseg></trk>
+</gpx>"""
+
+
 def _seed_org_leg(tmp_path, *, legs=None):
     org_dir = tmp_path / "org" / "legs"
     org_dir.mkdir(parents=True)
@@ -236,17 +247,17 @@ def test_apply_preserves_half_recipe_km_order(tmp_path, monkeypatch):
     _patch_roots(tmp_path, monkeypatch)
     org_dir = tmp_path / "org" / "legs"
     org_dir.mkdir(parents=True)
-    gpx = _GPX
+    # Distinct geometries so post-stitch km windows advance (#786).
     legs_spec = [
-        ("12", "start.gpx", 2.71),
-        ("06", "mid.gpx", 2.32),
-        ("13", "connector.gpx", 0.03),
-        ("09", "long.gpx", 5.77),
-        ("14", "finish.gpx", 0.2),
+        ("12", "start.gpx", -66.64, -66.63),
+        ("06", "mid.gpx", -66.63, -66.62),
+        ("13", "connector.gpx", -66.62, -66.619),
+        ("09", "long.gpx", -66.619, -66.55),
+        ("14", "finish.gpx", -66.55, -66.548),
     ]
     manifest_legs_list = []
-    for leg_id, fname, _km in legs_spec:
-        (org_dir / fname).write_text(gpx, encoding="utf-8")
+    for leg_id, fname, lon0, lon1 in legs_spec:
+        (org_dir / fname).write_text(_gpx_leg(lon0, lon1), encoding="utf-8")
         manifest_legs_list.append(
             {"id": leg_id, "file": fname, "seg_label": f"Leg {leg_id}"}
         )

--- a/tests/unit/test_segment_library.py
+++ b/tests/unit/test_segment_library.py
@@ -5,8 +5,11 @@ from pathlib import Path
 import pytest
 
 from app.core.course.segment_library import (
+    EVENT_KM_DECIMALS,
+    _polyline_length_km,
     build_course_segments_from_library,
     build_flow_csv_from_segments,
+    concat_recipe_coordinates,
     export_library_to_course,
     load_leg_library,
     load_manifest,
@@ -123,8 +126,10 @@ def test_build_course_segments_leg_reuse(manifest, legs_by_id):
     assert set(leg05[0]["events"]) == {"full", "half", "10k"}
     assert leg05[1]["events"] == ["full"]
     assert leg05[0]["full_to_km"] < leg05[1]["full_from_km"]
-    length = float(leg05[0]["length_km"])
-    assert leg05[0]["half_to_km"] == pytest.approx(leg05[0]["half_from_km"] + length, abs=0.05)
+    half_len = float(leg05[0]["half_to_km"]) - float(leg05[0]["half_from_km"])
+    assert half_len == pytest.approx(
+        _polyline_length_km(legs["05"]["coordinates"]), abs=0.02
+    )
     assert leg05[1]["half_from_km"] == 0.0
     assert leg05[1]["half_to_km"] == 0.0
 
@@ -153,7 +158,63 @@ def test_build_course_segments_follows_recipe_order_not_manifest_order(manifest,
     assert full_leg_order == ["01", "02", "03", "16", "04"]
     leg16 = next(s for s in segments if s["leg_id"] == "16")
     assert leg16["seg_id"] == "S4"
-    assert leg16["full_from_km"] == pytest.approx(9.87, abs=0.05)
-    assert leg16["full_to_km"] == pytest.approx(15.44, abs=0.05)
+    # Event kms follow stitched polyline, not overridden length_km bookkeeping.
+    traced = concat_recipe_coordinates(["01", "02", "03"], legs)
+    expect_from = round(_polyline_length_km(traced), EVENT_KM_DECIMALS)
+    traced_to_16 = concat_recipe_coordinates(["01", "02", "03", "16"], legs)
+    expect_to = round(_polyline_length_km(traced_to_16), EVENT_KM_DECIMALS)
+    assert leg16["full_from_km"] == pytest.approx(expect_from, abs=1e-6)
+    assert leg16["full_to_km"] == pytest.approx(expect_to, abs=1e-6)
     leg04 = next(s for s in segments if s["leg_id"] == "04")
-    assert leg04["full_from_km"] == pytest.approx(15.44, abs=0.05)
+    assert leg04["full_from_km"] == pytest.approx(expect_to, abs=1e-6)
+
+
+def test_event_kms_follow_stitched_polyline_not_sum_of_rounded_lengths():
+    """#786: boundary kms match Authority B even when rounded length_km sums drift."""
+    leg_a = {
+        "id": "A",
+        "coordinates": [
+            [-75.70, 45.40],
+            [-75.69, 45.40],
+            [-75.68, 45.40],
+        ],
+    }
+    leg_b = {
+        "id": "B",
+        "coordinates": [
+            [-75.68, 45.40],
+            [-75.67, 45.40],
+            [-75.66, 45.40],
+        ],
+    }
+    true_a = _polyline_length_km(leg_a["coordinates"])
+    true_b = _polyline_length_km(leg_b["coordinates"])
+    # Force bookkeeping drift: claim lengths that disagree with geometry.
+    leg_a["length_km"] = round(true_a, 2) + 0.05
+    leg_b["length_km"] = round(true_b, 2) + 0.05
+    bookkept_end = round(leg_a["length_km"] + leg_b["length_km"], 2)
+    traced_end = round(
+        _polyline_length_km(
+            concat_recipe_coordinates(["A", "B"], {"A": leg_a, "B": leg_b})
+        ),
+        EVENT_KM_DECIMALS,
+    )
+    assert abs(bookkept_end - traced_end) >= 0.05
+
+    manifest = {
+        "legs": [{"id": "A"}, {"id": "B"}],
+        "recipes": {"full": ["A", "B"], "half": [], "10k": []},
+    }
+    segments = build_course_segments_from_library(
+        manifest, {"A": leg_a, "B": leg_b}, event_ids=["full"]
+    )
+    assert len(segments) == 2
+    assert segments[0]["full_from_km"] == 0.0
+    assert segments[0]["full_to_km"] == pytest.approx(
+        round(true_a, EVENT_KM_DECIMALS), abs=1e-6
+    )
+    assert segments[1]["full_from_km"] == pytest.approx(
+        segments[0]["full_to_km"], abs=1e-6
+    )
+    assert segments[1]["full_to_km"] == pytest.approx(traced_end, abs=1e-6)
+    assert segments[1]["full_to_km"] != bookkept_end


### PR DESCRIPTION
## Summary
- Measure per-event `from_km`/`to_km` along the stitched recipe polyline (same geometry as event GPX), ending Authority A vs B mid-course drift (#786)
- Export/enrich event kms at 3 decimals (1 m); keep recipe-km preservation on the reconciled values
- Unit coverage for traced vs sum-of-rounded-length boundaries; docs/CHANGELOG updated
- E2E: analysis `FMv55BtbmjxgAuctejzedo` — no midpoint/clamp fallbacks; Half Turn pins project to reconciled boundary

## Test plan
- [x] Unit: `test_segment_library`, `test_leg_library_resolver`, related export tests
- [x] E2E analysis on package with re-applied recipes (`bGNTx9388Ah9LpXarPuLak`)
- [ ] Spot-check Locations UI turnaround times after merge


Made with [Cursor](https://cursor.com)