### PR TITLE
Dynamic event discovery for GeoJSON, GPX, and locations (#701)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -163,6 +163,11 @@
 ### UI Changes
 - **Loc Sheets removed from navigation**: one-pagers are linked from the Locations UI (route kept)
 
+### Issue #701 — dynamic event discovery
+- Analysis GeoJSON / GPX / location helpers discover event flags and spans from `analysis.json` ∩ `COURSE_EVENT_IDS` (no duplicated elite/open/10k/half/full loops)
+- Elite/open included in `segments_list` builders and GeoJSON event labels alongside full/half/10k
+- Shared helpers in `app/core/event_discovery.py`
+
 ### Issue #786 — segment km vs stitched GPX
 - Per-event `from_km`/`to_km` are measured along the stitched recipe polyline (same geometry as event GPX), not sum-of-rounded per-leg `length_km`
 - Exported / enriched event kms use **3 decimals** (1 m)

--- a/app/api/map.py
+++ b/app/api/map.py
@@ -236,7 +236,9 @@ async def get_map_segments():
             gpx_paths[event_name.lower()] = str(analysis_context.gpx_path(event_name))
         courses = load_all_courses(gpx_paths)
         
-        # Convert to format for GPX processor
+        # Convert to format for GPX processor (#701: all analysis event flags/spans)
+        from app.core.event_discovery import build_segment_event_payload
+
         segments_list = []
         for _, seg in segments_df.iterrows():
             seg_id = seg.get("seg_id")
@@ -245,19 +247,12 @@ async def get_map_segments():
                 raise HTTPException(status_code=500, detail="Segments metadata missing seg_id")
             if not seg_label:
                 raise HTTPException(status_code=500, detail=f"Segment {seg_id} missing seg_label")
-            segments_list.append({
+            entry = {
                 "seg_id": seg_id,
                 "segment_label": seg_label,
-                "10k": seg.get('10k', seg.get('10K', 'n')),
-                "half": seg.get('half', 'n'),
-                "full": seg.get('full', 'n'),
-                "10k_from_km": seg.get('10k_from_km') or seg.get('10K_from_km'),
-                "10k_to_km": seg.get('10k_to_km') or seg.get('10K_to_km'),
-                "half_from_km": seg.get('half_from_km'),
-                "half_to_km": seg.get('half_to_km'),
-                "full_from_km": seg.get('full_from_km'),
-                "full_to_km": seg.get('full_to_km')
-            })
+            }
+            entry.update(build_segment_event_payload(seg, gpx_paths.keys()))
+            segments_list.append(entry)
         
         # Generate centerlines
         segments_with_coords = generate_segment_coordinates(courses, segments_list)

--- a/app/core/artifacts/frontend.py
+++ b/app/core/artifacts/frontend.py
@@ -618,24 +618,10 @@ def _create_segment_feature(seg_id, segment_dims, schema_keys):
         raise ValueError(f"Segment {seg_id} missing direction in segments metadata.")
     schema_key = _resolve_schema_key(seg_id, schema_keys, dims)
     
-    # Issue #655: Calculate length_km from event-specific fields
-    length_km = None
-    for col in ["elite_length", "open_length", "10k_length", "half_length", "full_length"]:
-        if col in dims and dims[col] is not None and pd.notna(dims[col]) and dims[col] > 0:
-            length_km = float(dims[col])
-            break
-    
-    # Fallback: Calculate from event-specific from_km/to_km
-    if length_km is None or length_km == 0.0:
-        for event in ["elite", "open", "10k", "half", "full"]:
-            event_from = dims.get(f"{event}_from_km")
-            event_to = dims.get(f"{event}_to_km")
-            if event_from is not None and event_to is not None and pd.notna(event_from) and pd.notna(event_to):
-                length_km = float(event_to) - float(event_from)
-                break
-    
-    if length_km is None or length_km == 0.0:
-        length_km = 0.0
+    # Issue #655 / #701: length from dynamic event length or span columns
+    from app.core.event_discovery import display_events_from_flags, length_km_from_event_fields
+
+    length_km = length_km_from_event_fields(dims)
     
     return {
         "type": "Feature",
@@ -649,7 +635,7 @@ def _create_segment_feature(seg_id, segment_dims, schema_keys):
             "length_km": length_km,
             "width_m": float(width_val),
             "direction": direction,
-            "events": [event for event in ["Full", "Half", "10K"] if dims.get(event.lower() if event != "10K" else "10K", "") == "y"],
+            "events": display_events_from_flags(dims),
             "schema": schema_key,
             "description": dims.get("description", "No description available")
         }
@@ -690,24 +676,10 @@ def _build_segment_feature_properties(seg_id, segment_dims, schema_keys):
         raise ValueError(f"Segment {seg_id} missing direction in segments metadata.")
     schema_key = _resolve_schema_key(seg_id, schema_keys, dims)
     
-    # Issue #655: Calculate length_km from event-specific fields
-    length_km = None
-    for col in ["elite_length", "open_length", "10k_length", "half_length", "full_length"]:
-        if col in dims and dims[col] is not None and pd.notna(dims[col]) and dims[col] > 0:
-            length_km = float(dims[col])
-            break
-    
-    # Fallback: Calculate from event-specific from_km/to_km
-    if length_km is None or length_km == 0.0:
-        for event in ["elite", "open", "10k", "half", "full"]:
-            event_from = dims.get(f"{event}_from_km")
-            event_to = dims.get(f"{event}_to_km")
-            if event_from is not None and event_to is not None and pd.notna(event_from) and pd.notna(event_to):
-                length_km = float(event_to) - float(event_from)
-                break
-    
-    if length_km is None or length_km == 0.0:
-        length_km = 0.0
+    # Issue #655 / #701: length from dynamic event length or span columns
+    from app.core.event_discovery import display_events_from_flags, length_km_from_event_fields
+
+    length_km = length_km_from_event_fields(dims)
     
     return {
         "seg_id": seg_id,
@@ -715,8 +687,7 @@ def _build_segment_feature_properties(seg_id, segment_dims, schema_keys):
         "length_km": length_km,
         "width_m": float(width_val),
         "direction": direction,
-        "events": [event for event in ["Full", "Half", "10K"] 
-                   if dims.get(event.lower() if event != "10K" else "10K", "") == "y"],
+        "events": display_events_from_flags(dims),
         "schema": schema_key,
         "description": dims.get("description", "No description available")
     }
@@ -822,6 +793,8 @@ def generate_segments_geojson(reports_dir: Path, analysis_context: Optional[Any]
     
     # Load segments data to get segment definitions
     try:
+        from app.core.event_discovery import active_events, build_segment_event_payload
+
         segments_df = analysis_context.get_segments_df()
         segments_list = []
         for _, seg in segments_df.iterrows():
@@ -832,45 +805,21 @@ def generate_segments_geojson(reports_dir: Path, analysis_context: Optional[Any]
             if not seg_label:
                 raise ValueError(f"Segment {seg_id} missing seg_label for generate_segments_geojson.")
             
-            # Issue #655: Filter segments to only include those that belong to events in the analysis
-            # Check if segment belongs to any available event (elite, open, 10k, half, full)
-            segment_events = []
-            if seg.get("elite", "").lower() == "y" and "elite" in available_event_names:
-                segment_events.append("elite")
-            if seg.get("open", "").lower() == "y" and "open" in available_event_names:
-                segment_events.append("open")
-            if (seg.get("10k", "") or seg.get("10K", "")).lower() == "y" and "10k" in available_event_names:
-                segment_events.append("10k")
-            if seg.get("half", "").lower() == "y" and "half" in available_event_names:
-                segment_events.append("half")
-            if seg.get("full", "").lower() == "y" and "full" in available_event_names:
-                segment_events.append("full")
+            # Issue #655 / #701: include segments for any analysis event with flag y
+            segment_events = active_events(seg, available_event_names)
             
             # Skip segments that don't belong to any available event
             if not segment_events:
                 continue  # Skip segments not in current analysis
             
-            segments_list.append({
+            entry = {
                 "seg_id": seg_id,
                 "segment_label": seg_label,
-                "elite": seg.get("elite", "n"),  # Issue #655: Add elite and open columns for Saturday events
-                "open": seg.get("open", "n"),
-                "10k": seg.get("10k") if seg.get("10k") is not None else seg.get("10K", "n"),
-                "half": seg.get("half", "n"),
-                "full": seg.get("full", "n"),
-                "elite_from_km": seg.get("elite_from_km"),  # Issue #655: Add elite and open from_km/to_km fields
-                "elite_to_km": seg.get("elite_to_km"),
-                "open_from_km": seg.get("open_from_km"),
-                "open_to_km": seg.get("open_to_km"),
-                "10k_from_km": seg.get("10k_from_km") if seg.get("10k_from_km") is not None else seg.get("10K_from_km"),
-                "10k_to_km": seg.get("10k_to_km") if seg.get("10k_to_km") is not None else seg.get("10K_to_km"),
-                "half_from_km": seg.get("half_from_km"),
-                "half_to_km": seg.get("half_to_km"),
-                "full_from_km": seg.get("full_from_km"),
-                "full_to_km": seg.get("full_to_km"),
                 "direction": seg.get("direction"),
                 "width_m": seg.get("width_m"),
-            })
+            }
+            entry.update(build_segment_event_payload(seg, available_event_names))
+            segments_list.append(entry)
             # Issue #655: Validate that direction is present - if missing, this is a data issue
             if not segments_list[-1].get("direction"):
                 raise ValueError(
@@ -939,40 +888,20 @@ def generate_segments_geojson(reports_dir: Path, analysis_context: Optional[Any]
             # Update properties with dimensions
             props["label"] = seg_label
             
-            # Issue #655: Calculate length_km from event-specific fields or from_km/to_km
-            # Try event-specific length columns first (elite_length, open_length, etc.)
-            length_km = None
-            for col in ["elite_length", "open_length", "10k_length", "half_length", "full_length"]:
-                if col in dims and dims[col] is not None and pd.notna(dims[col]) and dims[col] > 0:
-                    length_km = float(dims[col])
-                    break
-            
-            # Fallback: Calculate from from_km/to_km if length column not found or is 0
-            if length_km is None or length_km == 0.0:
-                # Use from_km/to_km from the feature properties (already set by generate_segment_coordinates)
+            # Issue #655 / #701: Calculate length_km from dynamic event fields
+            from app.core.event_discovery import display_events_from_flags, length_km_from_event_fields
+
+            length_km = length_km_from_event_fields(dims)
+            if length_km == 0.0:
                 from_km = props.get("from_km")
                 to_km = props.get("to_km")
                 if from_km is not None and to_km is not None and pd.notna(from_km) and pd.notna(to_km):
                     length_km = float(to_km) - float(from_km)
-                else:
-                    # Last resort: Try event-specific from_km/to_km from dims
-                    feature_events = props.get("events", [])
-                    if feature_events:
-                        event = feature_events[0].lower()  # Use first event
-                        event_from = dims.get(f"{event}_from_km")
-                        event_to = dims.get(f"{event}_to_km")
-                        if event_from is not None and event_to is not None and pd.notna(event_from) and pd.notna(event_to):
-                            length_km = float(event_to) - float(event_from)
             
-            # Default to 0.0 if still no length found
-            if length_km is None or length_km == 0.0:
-                length_km = 0.0
-            
-            props["length_km"] = length_km
+            props["length_km"] = length_km if length_km else 0.0
             props["width_m"] = float(width_val)
             props["direction"] = direction
-            props["events"] = [event for event in ["Full", "Half", "10K"] 
-                              if dims.get(event.lower() if event != "10K" else "10K", "") == "y"]
+            props["events"] = display_events_from_flags(dims, available_event_names)
             props["schema"] = schema_key
             desc_val = dims.get("description", "")
             if desc_val is None or (isinstance(desc_val, float) and pd.isna(desc_val)):

--- a/app/core/density/compute.py
+++ b/app/core/density/compute.py
@@ -222,26 +222,14 @@ def load_density_cfg(path: str) -> Dict[str, dict]:
     """
     from app.io.loader import load_segments
     df = load_segments(path)
-    
-    def y(row, col): 
-        return str(row.get(col, "")).strip().lower() == "y"
-    
+
     cfg = {}
     for _, r in df.iterrows():
-        # Phase 4 (Issue #498): Support all event types dynamically
-        # Issue #548 Bug 1: Use lowercase event names consistently to match CSV columns
-        # Check for event flags (full, half, 10k, elite, open) - case-insensitive
-        events = []
-        event_columns = ["full", "half", "10k", "elite", "open"]
-        for event_col in event_columns:
-            # Case-insensitive column matching
-            for col in r.index:
-                if col.lower() == event_col.lower() and y(r, col):
-                    # Issue #548 Bug 1: Keep lowercase for internal consistency
-                    events.append(event_col.lower())
-                    break
-        
-        events = tuple(events)
+        # Phase 4 (Issue #498) / #701: discover active event flags dynamically
+        from app.core.event_discovery import active_events
+        from app.utils.constants import COURSE_EVENT_IDS
+
+        events = tuple(active_events(r, COURSE_EVENT_IDS))
         
         # Standardized on "10k_from_km"/"10k_to_km" keys (Issue #508)
         # Handles both "10K_from_km" (v1) and "10k_from_km" (v2) CSV column formats

--- a/app/core/event_discovery.py
+++ b/app/core/event_discovery.py
@@ -1,0 +1,156 @@
+"""
+Dynamic event flag / span discovery for analysis artifacts (#701).
+
+Analysis-facing code should iterate events from analysis.json (or a provided
+subset of COURSE_EVENT_IDS), not duplicated elite/open/10k/half/full literals.
+Config-facing code continues to use COURSE_EVENT_IDS as the product vocabulary.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+import pandas as pd
+
+from app.utils.constants import COURSE_EVENT_IDS
+
+# Stable GPX / length tie-break among product events (Saturday first, then Sunday).
+GPX_EVENT_PRIORITY: List[str] = ["elite", "open", "10k", "half", "full"]
+
+
+def normalize_event_name(name: str) -> str:
+    return str(name or "").strip().lower()
+
+
+def event_display_label(event: str) -> str:
+    """UI/GeoJSON label: 10k → 10K, full → Full."""
+    e = normalize_event_name(event)
+    if e == "10k":
+        return "10K"
+    return e.capitalize() if e else ""
+
+
+def _row_get_ci(row: Mapping[str, Any], key: str) -> Any:
+    """Get a value from a mapping/Series with exact then case-insensitive key match."""
+    if key in row:
+        return row[key]
+    key_l = key.lower()
+    # pandas Series: prefer .index
+    keys = list(getattr(row, "index", row.keys()))
+    for k in keys:
+        if str(k).lower() == key_l:
+            return row[k]
+    return None
+
+
+def resolve_event_flag(row: Mapping[str, Any], event: str) -> str:
+    """Return normalized flag string for an event column ('' if absent)."""
+    event = normalize_event_name(event)
+    val = _row_get_ci(row, event)
+    if val is None and event == "10k":
+        val = _row_get_ci(row, "10K")
+    if val is None or (isinstance(val, float) and pd.isna(val)):
+        return ""
+    return str(val).strip().lower()
+
+
+def is_event_active(row: Mapping[str, Any], event: str) -> bool:
+    return resolve_event_flag(row, event) == "y"
+
+
+def active_events(
+    row: Mapping[str, Any],
+    event_names: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Event ids from ``event_names`` (default COURSE_EVENT_IDS) with flag ``y``."""
+    names = [normalize_event_name(e) for e in (event_names or COURSE_EVENT_IDS) if e]
+    return [e for e in names if is_event_active(row, e)]
+
+
+def get_event_span(row: Mapping[str, Any], event: str) -> Tuple[Any, Any]:
+    """Return (from_km, to_km) for an event, including legacy 10K_* columns."""
+    event = normalize_event_name(event)
+    from_km = _row_get_ci(row, f"{event}_from_km")
+    to_km = _row_get_ci(row, f"{event}_to_km")
+    if event == "10k":
+        if from_km is None:
+            from_km = _row_get_ci(row, "10K_from_km")
+        if to_km is None:
+            to_km = _row_get_ci(row, "10K_to_km")
+    return from_km, to_km
+
+
+def build_segment_event_payload(
+    row: Mapping[str, Any],
+    event_names: Optional[Sequence[str]] = None,
+) -> Dict[str, Any]:
+    """
+    Flags + span fields for ``generate_segment_coordinates``.
+
+    Copies every listed event's flag and ``{event}_from_km`` / ``{event}_to_km``.
+    """
+    names = [normalize_event_name(e) for e in (event_names or COURSE_EVENT_IDS) if e]
+    out: Dict[str, Any] = {}
+    for event in names:
+        flag = resolve_event_flag(row, event)
+        out[event] = flag if flag in ("y", "n") else (flag or "n")
+        from_km, to_km = get_event_span(row, event)
+        out[f"{event}_from_km"] = from_km
+        out[f"{event}_to_km"] = to_km
+    return out
+
+
+def pick_gpx_event(
+    segment: Mapping[str, Any],
+    available_events: Iterable[str],
+    *,
+    priority: Optional[Sequence[str]] = None,
+) -> Optional[str]:
+    """
+    Choose which event's GPX/spans to use for a segment.
+
+    Walks ``priority`` (default GPX_EVENT_PRIORITY), then any other available
+    events, picking the first with flag ``y``.
+    """
+    available = {normalize_event_name(e) for e in available_events if e}
+    order = [normalize_event_name(e) for e in (priority or GPX_EVENT_PRIORITY)]
+    for event in available:
+        if event not in order:
+            order.append(event)
+    for event in order:
+        if event in available and is_event_active(segment, event):
+            return event
+    return None
+
+
+def length_km_from_event_fields(
+    dims: Mapping[str, Any],
+    event_names: Optional[Sequence[str]] = None,
+) -> float:
+    """Best-effort segment length from ``{event}_length`` or span columns."""
+    names = [normalize_event_name(e) for e in (event_names or GPX_EVENT_PRIORITY) if e]
+    for event in names:
+        col = f"{event}_length"
+        val = _row_get_ci(dims, col)
+        if val is not None and pd.notna(val) and float(val) > 0:
+            return float(val)
+    for event in names:
+        from_km, to_km = get_event_span(dims, event)
+        if (
+            from_km is not None
+            and to_km is not None
+            and pd.notna(from_km)
+            and pd.notna(to_km)
+        ):
+            length = float(to_km) - float(from_km)
+            if length > 0:
+                return length
+    return 0.0
+
+
+def display_events_from_flags(
+    row: Mapping[str, Any],
+    event_names: Optional[Sequence[str]] = None,
+) -> List[str]:
+    """Active event display labels (Full, Half, 10K, Elite, Open, …)."""
+    return [event_display_label(e) for e in active_events(row, event_names)]

--- a/app/core/gpx/processor.py
+++ b/app/core/gpx/processor.py
@@ -280,19 +280,14 @@ def generate_segment_coordinates(
         if not label:
             raise ValueError(f"Segment {seg_id} missing required segment_label for GPX coordinate generation.")
         
-        # Determine which event to use based on which events use this segment
-        # Priority: elite, open, 10k, half, full (covering sat/sun events)
-        # Issue #655: Only check for events that exist in the courses dict to avoid
-        # failures when segments reference events not in the current analysis
-        # Note: column names are lowercase in CSV
-        gpx_event = None
-        available_events = set(courses.keys())  # Only check events we have GPX data for
-        for event in ["elite", "open", "10k", "half", "full"]:
-            if event in available_events and segment.get(event, "").lower() == "y":
-                gpx_event = event
-                break
+        # Choose GPX/spans from analysis events present on this segment (#701).
+        # Issue #655: Only consider events that exist in the courses dict.
+        from app.core.event_discovery import pick_gpx_event
+
+        gpx_event = pick_gpx_event(segment, courses.keys())
         
         if gpx_event is None:
+            available_events = set(courses.keys())
             raise ValueError(
                 f"Segment {seg_id} does not match any available event with GPX data. "
                 f"Available events: {sorted(available_events)}. "

--- a/app/density_report.py
+++ b/app/density_report.py
@@ -2221,7 +2221,9 @@ def _add_geometries_to_bin_features(
             gpx_paths[event_name.lower()] = str(analysis_context.gpx_path(event_name))
         courses = load_all_courses(gpx_paths)
         
-        # Convert segments to dict format for GPX processor
+        # Convert segments to dict format for GPX processor (#701: all analysis events)
+        from app.core.event_discovery import build_segment_event_payload
+
         segments_list = []
         for _, segment in segments_df.iterrows():
             seg_id = segment.get("seg_id")
@@ -2230,24 +2232,14 @@ def _add_geometries_to_bin_features(
                 raise ValueError("segments.csv missing seg_id for bin geometry generation.")
             if not seg_label:
                 raise ValueError(f"Segment {seg_id} missing seg_label for bin geometry generation.")
-            segments_list.append({
+            entry = {
                 "seg_id": seg_id,
                 "segment_label": seg_label,
-                # Issue #548 Bug 1: Use lowercase '10k' to match CSV column format
-                "10k": segment.get('10k', segment.get('10K', 'n')),
-                "half": segment.get('half', 'n'),
-                "full": segment.get('full', 'n'),
-                # Issue #655: Fix 10k_from_km/to_km extraction bug - handle 0 values correctly
-                # Use 'is not None' check instead of 'or' to properly handle 0.0 values
-                "10k_from_km": segment.get('10k_from_km') if segment.get('10k_from_km') is not None else segment.get('10K_from_km'),
-                "10k_to_km": segment.get('10k_to_km') if segment.get('10k_to_km') is not None else segment.get('10K_to_km'),
-                "half_from_km": segment.get('half_from_km'),
-                "half_to_km": segment.get('half_to_km'),
-                "full_from_km": segment.get('full_from_km'),
-                "full_to_km": segment.get('full_to_km'),
                 "direction": segment.get("direction"),
                 "width_m": segment.get("width_m"),
-            })
+            }
+            entry.update(build_segment_event_payload(segment, gpx_paths.keys()))
+            segments_list.append(entry)
         
         # Generate segment centerlines from GPX
         segments_with_coords = generate_segment_coordinates(courses, segments_list)

--- a/app/geo_utils.py
+++ b/app/geo_utils.py
@@ -275,6 +275,8 @@ def generate_bins_geojson(segments_data: Dict[str, SegmentBinData], analysis_con
 
         # Load segments data to get segment definitions
         segments_df = analysis_context.get_segments_df()
+        from app.core.event_discovery import build_segment_event_payload
+
         segments_list = []
         for _, seg in segments_df.iterrows():
             seg_id = seg.get("seg_id")
@@ -283,21 +285,14 @@ def generate_bins_geojson(segments_data: Dict[str, SegmentBinData], analysis_con
                 raise ValueError("segments.csv missing seg_id for generate_bins_geojson.")
             if not seg_label:
                 raise ValueError(f"Segment {seg_id} missing seg_label for generate_bins_geojson.")
-            segments_list.append({
+            entry = {
                 "seg_id": seg_id,
                 "segment_label": seg_label,
-                "10k": seg.get("10k", seg.get("10K", "n")),
-                "half": seg.get("half", "n"),
-                "full": seg.get("full", "n"),
-                "10k_from_km": seg.get("10k_from_km") or seg.get("10K_from_km"),
-                "10k_to_km": seg.get("10k_to_km") or seg.get("10K_to_km"),
-                "half_from_km": seg.get("half_from_km"),
-                "half_to_km": seg.get("half_to_km"),
-                "full_from_km": seg.get("full_from_km"),
-                "full_to_km": seg.get("full_to_km"),
                 "direction": seg.get("direction"),
                 "width_m": seg.get("width_m"),
-            })
+            }
+            entry.update(build_segment_event_payload(seg, gpx_paths.keys()))
+            segments_list.append(entry)
 
         # Generate real coordinates for all segments
         segments_with_coords = generate_segment_coordinates(courses, segments_list)

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -473,16 +473,18 @@ def calculate_arrival_times_for_location(
     """
     arrival_times = []
     
-    # Get eligible events (where flag is 'y')
-    # Use lowercase event names (v2 standard)
-    # Issue #531: include elite/open for Saturday 5K events
-    eligible_events = []
-    for event in ["full", "half", "10k", "elite", "open"]:
-        if str(location.get(event, "")).lower() == "y":
-            eligible_events.append(event.lower())
-    
+    # Eligible events: product vocabulary ∩ (courses present or all COURSE_EVENT_IDS),
+    # discovered dynamically from location flags (#701 / #531 elite+open).
+    from app.core.event_discovery import active_events
+    from app.utils.constants import COURSE_EVENT_IDS
+
+    candidate_events = list(dict.fromkeys([*COURSE_EVENT_IDS, *courses.keys()]))
+    eligible_events = active_events(location, candidate_events)
+
     if not eligible_events:
-        logger.warning(f"Location {location.get('loc_id')}: No eligible events (full={location.get('full')}, half={location.get('half')}, 10k={location.get('10k')})")
+        logger.warning(
+            f"Location {location.get('loc_id')}: No eligible events among {candidate_events}"
+        )
         return arrival_times
     
     logger.debug(f"Location {location.get('loc_id')}: Processing {len(eligible_events)} eligible events: {eligible_events}")

--- a/app/one_pager.py
+++ b/app/one_pager.py
@@ -767,12 +767,9 @@ def _format_bullets_html(text: str) -> str:
 
 
 def _extract_events(location: Dict[str, Any]) -> List[str]:
-    events = []
-    for name in ["full", "half", "10k", "elite", "open"]:
-        value = str(location.get(name, "")).strip().lower()
-        if value == "y":
-            events.append(name)
-    return events
+    from app.core.event_discovery import active_events
+
+    return active_events(location)
 
 
 def _is_proxy_location(location: Dict[str, Any]) -> bool:

--- a/tests/unit/test_event_discovery.py
+++ b/tests/unit/test_event_discovery.py
@@ -1,0 +1,86 @@
+"""Tests for dynamic event discovery helpers (#701)."""
+
+import pandas as pd
+import pytest
+
+from app.core.event_discovery import (
+    active_events,
+    build_segment_event_payload,
+    display_events_from_flags,
+    length_km_from_event_fields,
+    pick_gpx_event,
+)
+from app.core.gpx.processor import generate_segment_coordinates
+from app.core.gpx.processor import GPXCourse, GPXPoint
+
+
+def test_active_events_subset_and_elite_open():
+    row = {
+        "elite": "y",
+        "open": "Y",
+        "full": "n",
+        "half": "",
+        "10k": "n",
+    }
+    assert active_events(row, ["elite", "open", "full"]) == ["elite", "open"]
+    assert display_events_from_flags(row) == ["Elite", "Open"]
+
+
+def test_build_segment_event_payload_includes_spans():
+    row = pd.Series(
+        {
+            "elite": "y",
+            "open": "n",
+            "elite_from_km": 0.0,
+            "elite_to_km": 1.2,
+            "open_from_km": 0.0,
+            "open_to_km": 0.0,
+        }
+    )
+    payload = build_segment_event_payload(row, ["elite", "open"])
+    assert payload["elite"] == "y"
+    assert payload["elite_from_km"] == 0.0
+    assert payload["elite_to_km"] == 1.2
+    assert payload["open"] == "n"
+
+
+def test_pick_gpx_event_prefers_priority_among_available():
+    segment = {"elite": "n", "open": "y", "10k": "y", "half": "n", "full": "n"}
+    assert pick_gpx_event(segment, ["10k", "open", "full"]) == "open"
+    assert pick_gpx_event(segment, ["10k"]) == "10k"
+    assert pick_gpx_event(segment, ["full"]) is None
+
+
+def test_length_km_from_event_fields():
+    dims = {"elite_length": 0, "open_from_km": 1.0, "open_to_km": 2.5, "open": "y"}
+    assert length_km_from_event_fields(dims, ["elite", "open"]) == pytest.approx(1.5)
+
+
+def test_generate_segment_coordinates_elite_only_subset():
+    """Elite+open analysis subset: segment flagged elite must resolve without full/half/10k."""
+    points = [
+        GPXPoint(lat=45.96, lon=-66.64, distance_km=0.0),
+        GPXPoint(lat=45.961, lon=-66.639, distance_km=0.15),
+        GPXPoint(lat=45.962, lon=-66.638, distance_km=0.30),
+    ]
+    course = GPXCourse(name="elite", points=points, total_distance_km=0.3)
+    courses = {"elite": course}
+    to_km = min(0.25, course.cum_km[-1] if course.cum_km else 0.25)
+    segments = [
+        {
+            "seg_id": "S1",
+            "segment_label": "Start",
+            "elite": "y",
+            "elite_from_km": 0.0,
+            "elite_to_km": to_km,
+            "full": "n",
+            "half": "n",
+            "10k": "n",
+            "direction": "uni",
+            "width_m": 3.0,
+        }
+    ]
+    out = generate_segment_coordinates(courses, segments)
+    assert len(out) == 1
+    assert out[0]["seg_id"] == "S1"
+    assert len(out[0]["line_coords"]) >= 2


### PR DESCRIPTION
## Summary
- Add `app/core/event_discovery.py` for flag/span/GPX-event helpers within `COURSE_EVENT_IDS`
- Wire GeoJSON, GPX segment coords, location eligibility, `segments_list` builders, density compute, and one-pager off those helpers (no duplicated five-name loops)
- Unit tests for subset / elite-only discovery; CHANGELOG updated
- E2E: `ek6eu8XUDy5pRUembPYTQr` vs prior same-package run — Flow/GeoJSON/metrics match; no midpoint fallbacks; discovery helpers live in Docker

## Test plan
- [x] `tests/unit/test_event_discovery.py`
- [x] E2E analysis on package `bGNTx9388Ah9LpXarPuLak`
- [ ] Spot-check elite/open GeoJSON props on a Saturday-style subset if available


Made with [Cursor](https://cursor.com)