### PR TITLE
UX: Reports select download, Density heatmap size, Build mode clarity (#815)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #815 — UX polish (Reports / Density / Build)
+- **Reports**: per-section file select + Download (day reports + data files); size/modified shown for the selected file only
+- **Density**: heatmap display ~30% smaller on laptop (`max-width: 70%`); full width under 768px
+- **Build vs Analysis**: hide Active run context strip on Build routes; rename analysis chrome link to **Open source package** (avoids clash with Build → Packages)
+
 ### 2027 location / pass identity
 - **`loc_id`**: short human Location number (phone / UI / one-pager)
 - **`pass_id`**: timed instance (outbound/return and unpaired rows)

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -91,7 +91,7 @@
                 <span id="rf-tabler-context-label" class="rf-tabler-context-label">—</span>
                 <span id="rf-tabler-context-id" class="rf-tabler-context-id"></span>
                 <span id="rf-tabler-context-day" class="rf-tabler-context-day" hidden></span>
-                <a id="rf-tabler-open-package" class="rf-tabler-context-pkg" href="/config" hidden>Package</a>
+                <a id="rf-tabler-open-package" class="rf-tabler-context-pkg" href="/config" hidden>Open source package</a>
             </div>
         </div>
         <div class="page-wrapper">
@@ -236,6 +236,9 @@
             const dayEl = document.getElementById("rf-tabler-context-day");
             const trigger = document.getElementById("rf-runs-trigger-label");
 
+            // Issue #815: Build mode does not need Active run chrome (avoids Package vs Packages clash)
+            const onBuild = isConfigRoutePath(window.location.pathname);
+
             if (!hasRun) {
                 if (strip) strip.hidden = true;
                 if (trigger) trigger.textContent = "Runs";
@@ -251,7 +254,7 @@
                 if (cached) label = cached;
             } catch (e) { /* ignore */ }
 
-            if (strip) strip.hidden = false;
+            if (strip) strip.hidden = onBuild;
             if (labelEl) labelEl.textContent = label;
             if (idEl) {
                 idEl.textContent = shortRunId(id);
@@ -271,7 +274,8 @@
                 const trunc = label.length > 28 ? label.slice(0, 26) + "…" : label;
                 trigger.textContent = trunc + " · " + shortRunId(id);
             }
-            syncTablerPackageLink(id);
+            // Package deep-link is analysis chrome only
+            syncTablerPackageLink(onBuild ? null : id);
             refreshRunsDropdown(id);
         }
 
@@ -302,7 +306,8 @@
                     }
                     localStorage.setItem("selected_config_id", configId);
                     link.href = "/config?config_id=" + encodeURIComponent(configId);
-                    link.title = "Open package " + configId;
+                    link.textContent = "Open source package";
+                    link.title = "Open source package " + configId;
                     link.hidden = false;
                 })
                 .catch(function () {
@@ -439,7 +444,7 @@
             if (configId) {
                 localStorage.setItem("selected_config_id", configId);
             }
-            // Keep Results nest visible while on Build/Package (Issue #796)
+            // Keep Results nest visible while on Build (Issue #796); Active run strip hidden on Build (#815)
             const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
             const storedDay = (localStorage.getItem("selected_day") || "").trim() || null;
             updateNavLinks(storedDay, storedRun);

--- a/frontend/templates/pages/density.html
+++ b/frontend/templates/pages/density.html
@@ -123,10 +123,10 @@
             </div>
         </div>
         
-        <!-- Heatmap -->
+        <!-- Heatmap (Issue #815: ~30% smaller on laptop; full width on narrow viewports) -->
         <div id="heatmap-container" style="margin: 1.5rem 0;">
             <h4 style="margin-bottom: 0.75rem;">Density Heatmap</h4>
-            <img id="heatmap-image" src="" alt="Density heatmap" style="max-width: 100%; border-radius: 4px;" />
+            <img id="heatmap-image" class="rf-density-heatmap" src="" alt="Density heatmap" />
             <div id="heatmap-placeholder" class="placeholder">No heatmap data available for this segment.</div>
         </div>
         <p style="margin: -0.5rem 0 1.5rem; color: #666; font-size: 0.9rem;">
@@ -257,6 +257,19 @@
     .pagination-buttons button:disabled {
         opacity: 0.5;
         cursor: not-allowed;
+    }
+
+    /* Issue #815: ~30% smaller heatmap on laptop; full width on narrow screens */
+    .rf-density-heatmap {
+        max-width: 70%;
+        height: auto;
+        border-radius: 4px;
+        display: block;
+    }
+    @media (max-width: 768px) {
+        .rf-density-heatmap {
+            max-width: 100%;
+        }
     }
 </style>
 {% endblock %}

--- a/frontend/templates/pages/reports.html
+++ b/frontend/templates/pages/reports.html
@@ -35,28 +35,20 @@
 
 {% block extra_scripts %}
 <script>
-    // Load reports on page load
+    // Issue #815: per-section select + Download (no per-row action columns)
     document.addEventListener('DOMContentLoaded', function() {
         loadReports();
     });
     
     function loadReports() {
-        // Get run_id and day from URL or global state
         const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
         const runParam = params.get('run_id');
-        
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
         const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
         
-        // Build API URL - if day is provided, filter by day; otherwise show all days
         let apiUrl = '/api/reports/list';
         const queryParams = [];
         if (run_id) queryParams.push(`run_id=${encodeURIComponent(run_id)}`);
-        // Note: We don't pass day parameter - we want to show ALL days for the run_id
         if (queryParams.length) apiUrl += `?${queryParams.join('&')}`;
-        
-        console.log('Loading reports via API...', { apiUrl, run_id });
         
         fetch(apiUrl, { cache: 'no-store' })
             .then(response => {
@@ -66,7 +58,6 @@
                 return response.json();
             })
             .then(data => {
-                // API now returns {reports, run_id, available_days, days_listed}
                 renderReportsList(data.reports || data, data.available_days || []);
             })
             .catch(error => {
@@ -85,9 +76,7 @@
             return;
         }
         
-        // Filter and categorize files
         const relevantReports = reports.filter(r => {
-            // Include Density, Flow, Locations, Passes, finish_times, finish-area PDF (Issue #743)
             const isRelevantReport = (
                 r.name.includes('Density') ||
                 r.name.includes('Flow') ||
@@ -97,7 +86,6 @@
                 r.name === 'finish_area_demand.pdf'
             ) && (r.name.endsWith('.md') || r.name.endsWith('.csv') || r.name === 'finish_area_demand.pdf');
             
-            // Exclude technical files
             const isTechnicalFile = r.name.includes('bins.') || 
                                   r.name.includes('map_data_') || 
                                   r.name.includes('segment_windows_') ||
@@ -111,7 +99,6 @@
         
         const dataFiles = reports.filter(r => r.type === 'data_file');
         
-        // Sort by day (fri, sat, sun, mon), then by modification time (newest first)
         const dayOrder = ['fri', 'sat', 'sun', 'mon'];
         const sortByDayAndTime = (a, b) => {
             const dayA = a.day || '';
@@ -119,46 +106,34 @@
             const dayIndexA = dayOrder.indexOf(dayA);
             const dayIndexB = dayOrder.indexOf(dayB);
             
-            // If both have days, sort by day order
             if (dayIndexA >= 0 && dayIndexB >= 0) {
                 if (dayIndexA !== dayIndexB) {
                     return dayIndexA - dayIndexB;
                 }
             } else if (dayIndexA >= 0) {
-                return -1; // a has day, b doesn't - a comes first
+                return -1;
             } else if (dayIndexB >= 0) {
-                return 1; // b has day, a doesn't - b comes first
+                return 1;
             }
             
-            // Same day or no day - sort by time
-            const timeA = a.mtime || 0;
-            const timeB = b.mtime || 0;
-            return timeB - timeA; // Descending order (newest first)
+            return (b.mtime || 0) - (a.mtime || 0);
         };
         
         relevantReports.sort(sortByDayAndTime);
         
         // Issue #596: Group data files by extension (CSV first, then GPX), then sort by filename
         dataFiles.sort((a, b) => {
-            // Get file extensions (lowercase for comparison)
             const extA = (a.name.split('.').pop() || '').toLowerCase();
             const extB = (b.name.split('.').pop() || '').toLowerCase();
-            
-            // Define extension order: CSV first, then GPX, then others
             const extOrder = { 'csv': 0, 'gpx': 1 };
             const orderA = extOrder[extA] !== undefined ? extOrder[extA] : 2;
             const orderB = extOrder[extB] !== undefined ? extOrder[extB] : 2;
-            
-            // First, sort by extension order
             if (orderA !== orderB) {
                 return orderA - orderB;
             }
-            
-            // Same extension - sort by filename (case-insensitive)
             return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
         });
         
-        // Group reports by day
         const reportsByDay = {};
         relevantReports.forEach(report => {
             const day = report.day || 'unknown';
@@ -168,11 +143,9 @@
             reportsByDay[day].push(report);
         });
         
-        // Render Reports Section - grouped by day
         if (relevantReports.length > 0) {
             let reportsHtml = '';
             
-            // Sort days in order: fri, sat, sun, mon
             const sortedDays = Object.keys(reportsByDay).sort((a, b) => {
                 const indexA = dayOrder.indexOf(a);
                 const indexB = dayOrder.indexOf(b);
@@ -199,97 +172,87 @@
                     return (b.mtime || 0) - (a.mtime || 0);
                 });
                 const dayLabel = day.toUpperCase();
+                const sectionId = 'reports-' + day;
                 
-                reportsHtml += `<div style="margin-bottom: 2rem;">`;
+                reportsHtml += `<div class="rf-download-section" style="margin-bottom: 2rem;" data-section="${sectionId}">`;
                 reportsHtml += `<h4 style="margin-bottom: 0.75rem; color: #2c3e50; font-size: 1.1rem; font-weight: 600;">${dayLabel} Reports</h4>`;
-                reportsHtml += '<table style="width: 100%; border-collapse: collapse; table-layout: fixed;">';
-                reportsHtml += '<thead><tr>';
-                reportsHtml += '<th style="text-align: left; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 45%;">File</th>';
-                reportsHtml += '<th style="text-align: left; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 12%;">Size</th>';
-                reportsHtml += '<th style="text-align: left; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 28%;">Modified</th>';
-                reportsHtml += '<th style="text-align: center; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 15%;">Action</th>';
-                reportsHtml += '</tr></thead><tbody>';
-                
-                dayReports.forEach(report => {
-                    reportsHtml += renderReportTableRow(report);
-                });
-                
-                reportsHtml += '</tbody></table>';
+                reportsHtml += renderDownloadPicker(sectionId, dayReports);
                 reportsHtml += '</div>';
             });
             
             reportsContainer.innerHTML = reportsHtml;
+            sortedDays.forEach(day => bindDownloadPicker('reports-' + day, reportsByDay[day]));
         } else {
             reportsContainer.innerHTML = '<p class="placeholder">No reports available</p>';
         }
         
-        // Render Data Files Section
         if (dataFiles.length > 0) {
-            let dataFilesHtml = '<table style="width: 100%; border-collapse: collapse; table-layout: fixed;">';
-            dataFilesHtml += '<thead><tr>';
-            dataFilesHtml += '<th style="text-align: left; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 45%;">File</th>';
-            dataFilesHtml += '<th style="text-align: left; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 12%;">Size</th>';
-            dataFilesHtml += '<th style="text-align: left; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 28%;">Modified</th>';
-            dataFilesHtml += '<th style="text-align: center; padding: 0.75rem; border-bottom: 2px solid #e0e0e0; font-weight: 600; width: 15%;">Action</th>';
-            dataFilesHtml += '</tr></thead><tbody>';
-            
-            dataFiles.forEach(file => {
-                dataFilesHtml += renderDataFileTableRow(file);
-            });
-            
-            dataFilesHtml += '</tbody></table>';
-            dataFilesContainer.innerHTML = dataFilesHtml;
+            dataFilesContainer.innerHTML = renderDownloadPicker('data-files', dataFiles);
+            bindDownloadPicker('data-files', dataFiles);
         } else {
             dataFilesContainer.innerHTML = '<p class="placeholder">No data files available</p>';
         }
     }
-    
-    function renderReportTableRow(report) {
-        const size = formatFileSize(report.size);
-        const mtime = report.mtime ? new Date(report.mtime * 1000).toLocaleString() : 'N/A';
-        
+
+    function escapeHtml(str) {
+        return String(str == null ? '' : str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function escapeAttr(str) {
+        return escapeHtml(str).replace(/'/g, '&#39;');
+    }
+
+    function renderDownloadPicker(sectionId, files) {
+        let options = '';
+        files.forEach((file, idx) => {
+            const label = file.day
+                ? `${file.name}`
+                : file.name;
+            options += `<option value="${idx}">${escapeHtml(label)}</option>`;
+        });
         return `
-            <tr style="border-bottom: 1px solid #e0e0e0;">
-                <td style="padding: 0.75rem;">
-                    <div style="font-weight: 600; color: #2c3e50;">${report.name}</div>
-                    <div style="font-size: 0.875rem; color: #7f8c8d; margin-top: 0.25rem;">${report.description || 'Report file'}</div>
-                </td>
-                <td style="padding: 0.75rem; color: #666;">${size}</td>
-                <td style="padding: 0.75rem; color: #666;">${mtime}</td>
-                <td style="padding: 0.75rem; text-align: center;">
-                    <a href="/api/reports/download?path=${encodeURIComponent(report.path)}" 
-                       class="button"
-                       download="${report.name}"
-                       style="padding: 0.5rem 1rem; background: #3498db; color: white; text-decoration: none; border-radius: 4px; font-size: 0.875rem;">
-                        Download
-                    </a>
-                </td>
-            </tr>
+            <div class="rf-download-picker" style="display: flex; flex-wrap: wrap; gap: 0.75rem; align-items: center;">
+                <label for="rf-select-${escapeAttr(sectionId)}" class="visually-hidden">Select file</label>
+                <select id="rf-select-${escapeAttr(sectionId)}"
+                        style="flex: 1 1 16rem; min-width: 12rem; max-width: 28rem; padding: 0.5rem 0.75rem; border: 1px solid #ddd; border-radius: 4px; font-size: 0.95rem;">
+                    ${options}
+                </select>
+                <a id="rf-download-${escapeAttr(sectionId)}"
+                   href="#"
+                   class="button rf-download-btn"
+                   download=""
+                   style="padding: 0.5rem 1rem; background: #3498db; color: white; text-decoration: none; border-radius: 4px; font-size: 0.875rem; white-space: nowrap;">
+                    Download
+                </a>
+            </div>
+            <p id="rf-meta-${escapeAttr(sectionId)}" style="margin: 0.5rem 0 0; color: #666; font-size: 0.875rem;"></p>
         `;
     }
-    
-    function renderDataFileTableRow(file) {
-        const size = formatFileSize(file.size);
-        const mtime = file.mtime ? new Date(file.mtime * 1000).toLocaleString() : 'N/A';
-        
-        return `
-            <tr style="border-bottom: 1px solid #e0e0e0;">
-                <td style="padding: 0.75rem;">
-                    <div style="font-weight: 600; color: #2c3e50;">${file.name}</div>
-                    <div style="font-size: 0.875rem; color: #7f8c8d; margin-top: 0.25rem;">${file.description || 'Data file'}</div>
-                </td>
-                <td style="padding: 0.75rem; color: #666;">${size}</td>
-                <td style="padding: 0.75rem; color: #666;">${mtime}</td>
-                <td style="padding: 0.75rem; text-align: center;">
-                    <a href="/api/reports/download?path=${encodeURIComponent(file.path)}" 
-                       class="button"
-                       download="${file.name}"
-                       style="padding: 0.5rem 1rem; background: #3498db; color: white; text-decoration: none; border-radius: 4px; font-size: 0.875rem;">
-                        Download
-                    </a>
-                </td>
-            </tr>
-        `;
+
+    function bindDownloadPicker(sectionId, files) {
+        const select = document.getElementById('rf-select-' + sectionId);
+        const link = document.getElementById('rf-download-' + sectionId);
+        const meta = document.getElementById('rf-meta-' + sectionId);
+        if (!select || !link || !files.length) return;
+
+        function sync() {
+            const idx = parseInt(select.value, 10);
+            const file = files[idx];
+            if (!file) return;
+            link.href = '/api/reports/download?path=' + encodeURIComponent(file.path);
+            link.setAttribute('download', file.name);
+            const size = formatFileSize(file.size);
+            const mtime = file.mtime ? new Date(file.mtime * 1000).toLocaleString() : 'N/A';
+            const desc = file.description ? escapeHtml(file.description) + ' · ' : '';
+            meta.innerHTML = desc + escapeHtml(size) + ' · modified ' + escapeHtml(mtime);
+        }
+
+        select.addEventListener('change', sync);
+        sync();
     }
     
     function formatFileSize(bytes) {
@@ -310,8 +273,20 @@
 
 {% block extra_styles %}
 <style>
-    .button:hover {
+    .button:hover,
+    .rf-download-btn:hover {
         background: #2980b9;
+    }
+    .visually-hidden {
+        position: absolute;
+        width: 1px;
+        height: 1px;
+        padding: 0;
+        margin: -1px;
+        overflow: hidden;
+        clip: rect(0, 0, 0, 0);
+        white-space: nowrap;
+        border: 0;
     }
 </style>
 {% endblock %}

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -38,7 +38,7 @@
         </div>
         <div class="rf-results-actions">
             <a id="run-context-open-reports" href="/reports">Open reports</a>
-            <a id="run-context-open-package" href="/config" style="display: none;">Open package</a>
+            <a id="run-context-open-package" href="/config" style="display: none;">Open source package</a>
             <a id="run-context-change-run" href="/dashboard">Change run</a>
         </div>
     </div>
@@ -176,7 +176,8 @@
                 }
                 pkgLink.href = withTablerUi('/config?config_id=' + encodeURIComponent(configId));
                 pkgLink.style.display = '';
-                pkgLink.title = 'Open package ' + configId;
+                pkgLink.textContent = 'Open source package';
+                pkgLink.title = 'Open source package ' + configId;
             })
             .catch(function () {
                 pkgLink.style.display = 'none';


### PR DESCRIPTION
## Summary
- **Reports**: replace per-row download tables with per-section file select + Download (day reports + data files)
- **Density**: display heatmaps at ~70% width on laptop; full width under 768px
- **Build vs Analysis**: hide Active run context strip on Build routes; rename analysis chrome link to **Open source package**

Closes #815

## Test plan
- [ ] Reports: pick a day report from the select and download; same for Data Files
- [ ] Density: heatmap reads smaller on a laptop viewport; full width on a narrow window
- [ ] Build (`/config`): no Active run strip / Package link competing with Packages tab
- [ ] Analysis page (e.g. Density): Active run strip shows **Open source package** and opens the correct config

Made with [Cursor](https://cursor.com)