### PR TITLE
Junction Flow authoring: package junctions.json + Build UI (#817)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## [Unreleased]
 
+### Issue #817 — Junction Flow authoring
+- Package Build **Junctions** tab (after Courses): map pin, nearby segments by endpoint proximity (`JUNCTION_SEGMENT_PROXIMITY_M`, default 10 m), declared cross/merge interactions
+- Persist `junctions.json` at package root (streams derived from segment refs; Locations/Segments schemas unchanged)
+- API: `GET/PUT /api/config/packages/{id}/junctions`, `POST …/junctions/nearby`, `GET …/junctions/map-segments`
+- Analysis/compute deferred to #818
+
 ### Issue #815 — UX polish (Reports / Density / Build)
 - **Reports**: per-section file select + Download (day reports + data files); size/modified shown for the selected file only
 - **Density**: heatmap display ~30% smaller on laptop (`max-width: 70%`); full width under 768px

--- a/app/core/config_package/junctions.py
+++ b/app/core/config_package/junctions.py
@@ -96,7 +96,8 @@ def _normalize_interaction(raw: Any, index: int) -> Dict[str, Any]:
     itype = str(raw.get("type") or "").strip().lower()
     if itype not in _INTERACTION_TYPES:
         raise ValueError(
-            f"interactions[{index}].type must be one of {sorted(_INTERACTION_TYPES)}"
+            f"interactions[{index}].type must be one of "
+            f"{sorted(_INTERACTION_TYPES)}"
         )
     side = str(raw.get("side") or "").strip().lower()
     if side not in _SIDES:
@@ -111,16 +112,22 @@ def _normalize_interaction(raw: Any, index: int) -> Dict[str, Any]:
     if to_raw is None and raw.get("to_seg_id"):
         to_raw = [raw.get("to_seg_id")]
     if not isinstance(to_raw, list) or not to_raw:
-        raise ValueError(f"interactions[{index}].to_seg_ids must be a non-empty list")
+        raise ValueError(
+            f"interactions[{index}].to_seg_ids must be a non-empty list"
+        )
     to_segs: List[str] = []
     for t in to_raw:
         sid = str(t or "").strip()
         if sid and sid not in to_segs:
             to_segs.append(sid)
     if not to_segs:
-        raise ValueError(f"interactions[{index}].to_seg_ids must include a segment id")
+        raise ValueError(
+            f"interactions[{index}].to_seg_ids must include a segment id"
+        )
     if itype == "cross" and len(to_segs) != 1:
-        raise ValueError(f"interactions[{index}]: cross allows exactly one to_seg_id")
+        raise ValueError(
+            f"interactions[{index}]: cross allows exactly one to_seg_id"
+        )
 
     conflicts = str(raw.get("conflicts_with_seg_id") or "").strip()
     if itype == "cross" and not conflicts:
@@ -168,7 +175,7 @@ def _derive_streams(junction: Dict[str, Any]) -> List[Dict[str, Any]]:
     streams: List[Dict[str, Any]] = []
     for sid in ordered:
         near = endpoint_by_seg.get(sid) or ""
-        # Travel implication at the pin: start nearby → leaving via end; end nearby → arriving from start
+        # At pin: start nearby → leave via end; end nearby → arrive from start
         if near == "start":
             direction = "from_start"
         elif near == "end":
@@ -230,7 +237,9 @@ def validate_junctions_doc(data: Dict[str, Any]) -> Dict[str, Any]:
     junctions_raw = data.get("junctions") or []
     if not isinstance(junctions_raw, list):
         raise ValueError("junctions must be a list")
-    junctions = [_normalize_junction(j, i) for i, j in enumerate(junctions_raw)]
+    junctions = [
+        _normalize_junction(j, i) for i, j in enumerate(junctions_raw)
+    ]
     seen: Set[str] = set()
     for j in junctions:
         if j["id"] in seen:
@@ -247,7 +256,9 @@ def new_junction_id() -> str:
     return generate_run_id()
 
 
-def _leg_gpx_path(lib_dir: Path, leg_manifest: Dict[str, Any], leg_id: str) -> Optional[Path]:
+def _leg_gpx_path(
+    lib_dir: Path, leg_manifest: Dict[str, Any], leg_id: str
+) -> Optional[Path]:
     lid = str(leg_id or "").strip()
     if not lid:
         return None
@@ -341,15 +352,17 @@ def find_nearby_segments(
     radius_m: Optional[float] = None,
 ) -> List[Dict[str, Any]]:
     """
-    Return course segments whose leg start and/or end is within radius_m of the pin.
+    Return course segments whose leg start/end is within radius_m of the pin.
 
     Each row includes distance_m, near_endpoint (start|end|both), events, and
     per-event km for UI hover tiles.
     """
     cid = validate_config_id(config_id)
-    # Keep endpoint cache across nearby lookups in the same process; clear explicitly
-    # when leg GPX/course inputs change (tests call clear_leg_endpoint_cache()).
-    radius = float(radius_m if radius_m is not None else JUNCTION_SEGMENT_PROXIMITY_M)
+    # Keep endpoint cache across nearby lookups; tests clear via
+    # clear_leg_endpoint_cache().
+    radius = float(
+        radius_m if radius_m is not None else JUNCTION_SEGMENT_PROXIMITY_M
+    )
     if radius <= 0:
         raise ValueError("radius_m must be positive")
 
@@ -393,7 +406,9 @@ def find_nearby_segments(
         results.append(
             {
                 "seg_id": seg_id,
-                "seg_label": seg.get("seg_label") or seg.get("description") or seg_id,
+                "seg_label": (
+                    seg.get("seg_label") or seg.get("description") or seg_id
+                ),
                 "leg_id": leg_id,
                 "length_km": seg.get("length_km"),
                 "width_m": seg.get("width_m"),

--- a/app/core/config_package/junctions.py
+++ b/app/core/config_package/junctions.py
@@ -1,0 +1,457 @@
+"""
+Junction Flow authoring (Issue #817).
+
+Package-root ``junctions.json`` — independent of Locations / Segments schemas.
+Nearby discovery: segment leg start/end within JUNCTION_SEGMENT_PROXIMITY_M.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+from app.core.config_package.leg_library_resolver import resolve_leg_library
+from app.core.config_package.storage import (
+    load_config_course,
+    resolve_config_package_path,
+    validate_config_id,
+)
+from app.core.course.segment_library import manifest_legs, parse_leg_gpx
+from app.core.gpx.processor import haversine_m
+from app.utils.constants import JUNCTION_SEGMENT_PROXIMITY_M
+from app.utils.run_id import generate_run_id
+
+logger = logging.getLogger(__name__)
+
+JUNCTIONS_NAME = "junctions.json"
+JUNCTIONS_DOC_VERSION = 1
+
+_INTERACTION_TYPES = frozenset({"cross", "merge"})
+_SIDES = frozenset({"left", "right", ""})
+
+
+def junctions_path(config_id: str) -> Path:
+    return resolve_config_package_path(config_id) / JUNCTIONS_NAME
+
+
+def empty_junctions_doc() -> Dict[str, Any]:
+    return {"version": JUNCTIONS_DOC_VERSION, "junctions": [], "updated": None}
+
+
+def load_config_junctions(config_id: str) -> Dict[str, Any]:
+    """Load junctions.json or return an empty document if missing."""
+    cid = validate_config_id(config_id)
+    path = junctions_path(cid)
+    if not path.is_file():
+        return empty_junctions_doc()
+    with open(path, "r", encoding="utf-8") as f:
+        data = json.load(f)
+    if not isinstance(data, dict):
+        raise ValueError(f"Invalid {JUNCTIONS_NAME} in package {cid}")
+    return validate_junctions_doc(data)
+
+
+def save_config_junctions(config_id: str, data: Dict[str, Any]) -> Path:
+    """Validate and write junctions.json for a config package."""
+    cid = validate_config_id(config_id)
+    package_path = resolve_config_package_path(cid)
+    doc = validate_junctions_doc(data)
+    doc["updated"] = datetime.now(timezone.utc).isoformat()
+    path = package_path / JUNCTIONS_NAME
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(doc, f, indent=2, ensure_ascii=False)
+        f.write("\n")
+    return path
+
+
+def _as_float(value: Any, field: str) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError) as e:
+        raise ValueError(f"{field} must be a number") from e
+
+
+def _normalize_events(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, str):
+        parts = [p.strip().lower() for p in raw.split(",") if p.strip()]
+        return parts
+    if not isinstance(raw, list):
+        raise ValueError("events must be a list of event ids")
+    out: List[str] = []
+    for item in raw:
+        eid = str(item or "").strip().lower()
+        if eid and eid not in out:
+            out.append(eid)
+    return out
+
+
+def _normalize_interaction(raw: Any, index: int) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError(f"interactions[{index}] must be an object")
+    itype = str(raw.get("type") or "").strip().lower()
+    if itype not in _INTERACTION_TYPES:
+        raise ValueError(
+            f"interactions[{index}].type must be one of {sorted(_INTERACTION_TYPES)}"
+        )
+    side = str(raw.get("side") or "").strip().lower()
+    if side not in _SIDES:
+        raise ValueError(
+            f"interactions[{index}].side must be left, right, or empty"
+        )
+    from_seg = str(raw.get("from_seg_id") or "").strip()
+    if not from_seg:
+        raise ValueError(f"interactions[{index}].from_seg_id is required")
+
+    to_raw = raw.get("to_seg_ids")
+    if to_raw is None and raw.get("to_seg_id"):
+        to_raw = [raw.get("to_seg_id")]
+    if not isinstance(to_raw, list) or not to_raw:
+        raise ValueError(f"interactions[{index}].to_seg_ids must be a non-empty list")
+    to_segs: List[str] = []
+    for t in to_raw:
+        sid = str(t or "").strip()
+        if sid and sid not in to_segs:
+            to_segs.append(sid)
+    if not to_segs:
+        raise ValueError(f"interactions[{index}].to_seg_ids must include a segment id")
+    if itype == "cross" and len(to_segs) != 1:
+        raise ValueError(f"interactions[{index}]: cross allows exactly one to_seg_id")
+
+    conflicts = str(raw.get("conflicts_with_seg_id") or "").strip()
+    if itype == "cross" and not conflicts:
+        raise ValueError(
+            f"interactions[{index}]: cross requires conflicts_with_seg_id"
+        )
+    if itype == "merge":
+        conflicts = ""
+
+    iid = str(raw.get("id") or "").strip() or f"ix_{index + 1}"
+    return {
+        "id": iid,
+        "type": itype,
+        "side": side,
+        "from_seg_id": from_seg,
+        "to_seg_ids": to_segs,
+        "conflicts_with_seg_id": conflicts,
+        "events": _normalize_events(raw.get("events")),
+    }
+
+
+def _derive_streams(junction: Dict[str, Any]) -> List[Dict[str, Any]]:
+    """Build stream list from nearby segments + interaction segment refs."""
+    ordered: List[str] = []
+    for sid in junction.get("nearby_seg_ids") or []:
+        s = str(sid or "").strip()
+        if s and s not in ordered:
+            ordered.append(s)
+    for ix in junction.get("interactions") or []:
+        if not isinstance(ix, dict):
+            continue
+        for key in ("from_seg_id", "conflicts_with_seg_id"):
+            s = str(ix.get(key) or "").strip()
+            if s and s not in ordered:
+                ordered.append(s)
+        for s in ix.get("to_seg_ids") or []:
+            sid = str(s or "").strip()
+            if sid and sid not in ordered:
+                ordered.append(sid)
+    endpoint_by_seg = {
+        str(r.get("seg_id")): str(r.get("near_endpoint") or "")
+        for r in (junction.get("nearby_segments") or [])
+        if isinstance(r, dict) and r.get("seg_id")
+    }
+    streams: List[Dict[str, Any]] = []
+    for sid in ordered:
+        near = endpoint_by_seg.get(sid) or ""
+        # Travel implication at the pin: start nearby → leaving via end; end nearby → arriving from start
+        if near == "start":
+            direction = "from_start"
+        elif near == "end":
+            direction = "to_end"
+        elif near == "both":
+            direction = "both_ends"
+        else:
+            direction = "unspecified"
+        streams.append(
+            {
+                "stream_id": sid,
+                "seg_id": sid,
+                "direction": direction,
+                "near_endpoint": near or None,
+            }
+        )
+    return streams
+
+
+def _normalize_junction(raw: Any, index: int) -> Dict[str, Any]:
+    if not isinstance(raw, dict):
+        raise ValueError(f"junctions[{index}] must be an object")
+    jid = str(raw.get("id") or "").strip() or generate_run_id()
+    label = str(raw.get("label") or "").strip() or f"Junction {index + 1}"
+    lat = _as_float(raw.get("lat"), f"junctions[{index}].lat")
+    lon = _as_float(raw.get("lon"), f"junctions[{index}].lon")
+    if not (-90.0 <= lat <= 90.0) or not (-180.0 <= lon <= 180.0):
+        raise ValueError(f"junctions[{index}] lat/lon out of range")
+
+    nearby_ids: List[str] = []
+    for sid in raw.get("nearby_seg_ids") or []:
+        s = str(sid or "").strip()
+        if s and s not in nearby_ids:
+            nearby_ids.append(s)
+
+    interactions = [
+        _normalize_interaction(ix, i)
+        for i, ix in enumerate(raw.get("interactions") or [])
+    ]
+
+    junction: Dict[str, Any] = {
+        "id": jid,
+        "label": label,
+        "lat": lat,
+        "lon": lon,
+        "nearby_seg_ids": nearby_ids,
+        "interactions": interactions,
+    }
+    # Optional cache of last discovery rows (UI convenience; not required)
+    nearby_segments = raw.get("nearby_segments")
+    if isinstance(nearby_segments, list):
+        junction["nearby_segments"] = nearby_segments
+    junction["streams"] = _derive_streams(junction)
+    return junction
+
+
+def validate_junctions_doc(data: Dict[str, Any]) -> Dict[str, Any]:
+    version = int(data.get("version") or JUNCTIONS_DOC_VERSION)
+    junctions_raw = data.get("junctions") or []
+    if not isinstance(junctions_raw, list):
+        raise ValueError("junctions must be a list")
+    junctions = [_normalize_junction(j, i) for i, j in enumerate(junctions_raw)]
+    seen: Set[str] = set()
+    for j in junctions:
+        if j["id"] in seen:
+            raise ValueError(f"Duplicate junction id: {j['id']}")
+        seen.add(j["id"])
+    return {
+        "version": version,
+        "junctions": junctions,
+        "updated": data.get("updated"),
+    }
+
+
+def new_junction_id() -> str:
+    return generate_run_id()
+
+
+def _leg_gpx_path(lib_dir: Path, leg_manifest: Dict[str, Any], leg_id: str) -> Optional[Path]:
+    lid = str(leg_id or "").strip()
+    if not lid:
+        return None
+    for entry in manifest_legs(leg_manifest):
+        if str(entry.get("id") or "").strip() != lid:
+            continue
+        file_name = entry.get("file") or f"{lid}.gpx"
+        path = lib_dir / str(file_name)
+        if path.is_file():
+            return path
+        # Org legs sometimes use slug filenames; try id.gpx
+        alt = lib_dir / f"{lid}.gpx"
+        if alt.is_file():
+            return alt
+        return path if path.is_file() else None
+    # Fallback: id.gpx without manifest row
+    alt = lib_dir / f"{lid}.gpx"
+    return alt if alt.is_file() else None
+
+
+_leg_endpoint_cache: Dict[
+    Tuple[str, str], Optional[Tuple[Tuple[float, float], Tuple[float, float]]]
+] = {}
+
+
+def clear_leg_endpoint_cache() -> None:
+    _leg_endpoint_cache.clear()
+
+
+def _leg_endpoints(
+    config_id: str, leg_id: str
+) -> Optional[Tuple[Tuple[float, float], Tuple[float, float]]]:
+    """Return ((start_lon, start_lat), (end_lon, end_lat)) for a leg GPX."""
+    key = (config_id, str(leg_id))
+    if key in _leg_endpoint_cache:
+        return _leg_endpoint_cache[key]
+    try:
+        lib_dir, leg_manifest, _source, _pkg = resolve_leg_library(config_id)
+    except Exception:
+        _leg_endpoint_cache[key] = None
+        return None
+    path = _leg_gpx_path(lib_dir, leg_manifest, leg_id)
+    if path is None or not path.is_file():
+        _leg_endpoint_cache[key] = None
+        return None
+    try:
+        parsed = parse_leg_gpx(path)
+    except Exception as e:
+        logger.warning("Failed to parse leg GPX %s: %s", path, e)
+        _leg_endpoint_cache[key] = None
+        return None
+    coords = parsed.get("coordinates") or []
+    if len(coords) < 2:
+        _leg_endpoint_cache[key] = None
+        return None
+    start = (float(coords[0][0]), float(coords[0][1]))
+    end = (float(coords[-1][0]), float(coords[-1][1]))
+    _leg_endpoint_cache[key] = (start, end)
+    return start, end
+
+
+def _segment_event_kms(seg: Dict[str, Any]) -> Dict[str, Dict[str, float]]:
+    """Per-event from/to km for hover tiles."""
+    events = seg.get("events") or []
+    if isinstance(events, str):
+        events = [e.strip() for e in events.split(",") if e.strip()]
+    out: Dict[str, Dict[str, float]] = {}
+    for eid in events:
+        el = str(eid).strip().lower()
+        if not el:
+            continue
+        fk = seg.get(f"{el}_from_km")
+        tk = seg.get(f"{el}_to_km")
+        if fk is None and tk is None:
+            continue
+        try:
+            out[el] = {
+                "from_km": float(fk) if fk is not None else None,
+                "to_km": float(tk) if tk is not None else None,
+            }
+        except (TypeError, ValueError):
+            continue
+    return out
+
+
+def find_nearby_segments(
+    config_id: str,
+    lat: float,
+    lon: float,
+    *,
+    radius_m: Optional[float] = None,
+) -> List[Dict[str, Any]]:
+    """
+    Return course segments whose leg start and/or end is within radius_m of the pin.
+
+    Each row includes distance_m, near_endpoint (start|end|both), events, and
+    per-event km for UI hover tiles.
+    """
+    cid = validate_config_id(config_id)
+    # Keep endpoint cache across nearby lookups in the same process; clear explicitly
+    # when leg GPX/course inputs change (tests call clear_leg_endpoint_cache()).
+    radius = float(radius_m if radius_m is not None else JUNCTION_SEGMENT_PROXIMITY_M)
+    if radius <= 0:
+        raise ValueError("radius_m must be positive")
+
+    course = load_config_course(cid)
+    segments = course.get("segments") or []
+    results: List[Dict[str, Any]] = []
+
+    for seg in segments:
+        if not isinstance(seg, dict):
+            continue
+        seg_id = str(seg.get("seg_id") or "").strip()
+        if not seg_id:
+            continue
+        leg_id = str(seg.get("leg_id") or "").strip()
+        endpoints = _leg_endpoints(cid, leg_id) if leg_id else None
+        if not endpoints:
+            continue
+        (start_lon, start_lat), (end_lon, end_lat) = endpoints
+        d_start = haversine_m(lat, lon, start_lat, start_lon)
+        d_end = haversine_m(lat, lon, end_lat, end_lon)
+        near_start = d_start <= radius
+        near_end = d_end <= radius
+        if not near_start and not near_end:
+            continue
+        if near_start and near_end:
+            near_endpoint = "both"
+            distance_m = min(d_start, d_end)
+        elif near_start:
+            near_endpoint = "start"
+            distance_m = d_start
+        else:
+            near_endpoint = "end"
+            distance_m = d_end
+
+        events = seg.get("events") or []
+        if isinstance(events, str):
+            events = [e.strip() for e in events.split(",") if e.strip()]
+        else:
+            events = [str(e).strip() for e in events if str(e).strip()]
+
+        results.append(
+            {
+                "seg_id": seg_id,
+                "seg_label": seg.get("seg_label") or seg.get("description") or seg_id,
+                "leg_id": leg_id,
+                "length_km": seg.get("length_km"),
+                "width_m": seg.get("width_m"),
+                "direction": seg.get("direction"),
+                "events": events,
+                "event_kms": _segment_event_kms(seg),
+                "near_endpoint": near_endpoint,
+                "distance_m": round(distance_m, 2),
+                "start_lat": start_lat,
+                "start_lon": start_lon,
+                "end_lat": end_lat,
+                "end_lon": end_lon,
+            }
+        )
+
+    results.sort(key=lambda r: (r["distance_m"], r["seg_id"]))
+    return results
+
+
+def course_segment_line_features(config_id: str) -> List[Dict[str, Any]]:
+    """GeoJSON features for each course segment leg (map rendering)."""
+    cid = validate_config_id(config_id)
+    course = load_config_course(cid)
+    try:
+        lib_dir, leg_manifest, _source, _pkg = resolve_leg_library(cid)
+    except Exception:
+        return []
+
+    features: List[Dict[str, Any]] = []
+    seen_legs: Set[str] = set()
+    for seg in course.get("segments") or []:
+        if not isinstance(seg, dict):
+            continue
+        seg_id = str(seg.get("seg_id") or "").strip()
+        leg_id = str(seg.get("leg_id") or "").strip()
+        if not seg_id or not leg_id:
+            continue
+        path = _leg_gpx_path(lib_dir, leg_manifest, leg_id)
+        if path is None or not path.is_file():
+            continue
+        try:
+            parsed = parse_leg_gpx(path)
+        except Exception:
+            continue
+        coords = parsed.get("coordinates") or []
+        if len(coords) < 2:
+            continue
+        features.append(
+            {
+                "type": "Feature",
+                "properties": {
+                    "seg_id": seg_id,
+                    "seg_label": seg.get("seg_label") or seg_id,
+                    "leg_id": leg_id,
+                    "events": seg.get("events") or [],
+                },
+                "geometry": {"type": "LineString", "coordinates": coords},
+            }
+        )
+        seen_legs.add(leg_id)
+    return features

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -121,6 +121,21 @@ class SaveConfigCourseRequest(BaseModel):
     course: Dict[str, Any]
 
 
+class SaveConfigJunctionsRequest(BaseModel):
+    """Issue #817: package junctions.json document."""
+
+    junctions: Optional[List[Dict[str, Any]]] = None
+    version: Optional[int] = 1
+    # Allow full document or {junctions: [...]}
+    updated: Optional[str] = None
+
+
+class JunctionNearbyRequest(BaseModel):
+    lat: float
+    lon: float
+    radius_m: Optional[float] = None
+
+
 class SavePackageResourcesRequest(BaseModel):
     resources: List[PackageResourceEntry]
 
@@ -396,11 +411,138 @@ async def api_save_config_course(
         )
 
 
+@router.get("/api/config/packages/{config_id}/junctions")
+async def api_load_config_junctions(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """Load junctions.json for a config package (Issue #817)."""
+    require_auth(request)
+    try:
+        from app.core.config_package.junctions import load_config_junctions
+        from app.utils.constants import JUNCTION_SEGMENT_PROXIMITY_M
+
+        doc = load_config_junctions(config_id)
+        return JSONResponse(
+            content={
+                "ok": True,
+                "config_id": config_id,
+                "proximity_m": JUNCTION_SEGMENT_PROXIMITY_M,
+                **doc,
+            }
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.put("/api/config/packages/{config_id}/junctions")
+async def api_save_config_junctions(
+    request: Request,
+    config_id: str,
+    body: SaveConfigJunctionsRequest,
+) -> JSONResponse:
+    """Save junctions.json for a config package (Issue #817)."""
+    require_auth(request)
+    try:
+        from app.core.config_package.junctions import (
+            load_config_junctions,
+            save_config_junctions,
+        )
+
+        payload = {
+            "version": body.version or 1,
+            "junctions": body.junctions or [],
+            "updated": body.updated,
+        }
+        save_config_junctions(config_id, payload)
+        doc = load_config_junctions(config_id)
+        return JSONResponse(content={"ok": True, "config_id": config_id, **doc})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+    except Exception as e:
+        logger.exception("Failed to save config package junctions")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to save junctions: {e}",
+        )
+
+
+@router.post("/api/config/packages/{config_id}/junctions/nearby")
+async def api_junction_nearby_segments(
+    request: Request,
+    config_id: str,
+    body: JunctionNearbyRequest,
+) -> JSONResponse:
+    """List course segments whose start/end is within proximity of a pin (#817)."""
+    require_auth(request)
+    try:
+        from app.core.config_package.junctions import find_nearby_segments
+        from app.utils.constants import JUNCTION_SEGMENT_PROXIMITY_M
+
+        nearby = find_nearby_segments(
+            config_id, body.lat, body.lon, radius_m=body.radius_m
+        )
+        return JSONResponse(
+            content={
+                "ok": True,
+                "config_id": config_id,
+                "lat": body.lat,
+                "lon": body.lon,
+                "radius_m": body.radius_m
+                if body.radius_m is not None
+                else JUNCTION_SEGMENT_PROXIMITY_M,
+                "segments": nearby,
+            }
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.get("/api/config/packages/{config_id}/junctions/map-segments")
+async def api_junction_map_segments(
+    request: Request,
+    config_id: str,
+) -> JSONResponse:
+    """GeoJSON features for course segment legs (Junctions map, Issue #817)."""
+    require_auth(request)
+    try:
+        from app.core.config_package.junctions import course_segment_line_features
+
+        features = course_segment_line_features(config_id)
+        return JSONResponse(
+            content={
+                "ok": True,
+                "config_id": config_id,
+                "type": "FeatureCollection",
+                "features": features,
+            }
+        )
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
 @router.get("/api/config/packages/{config_id}/segment-library")
 async def api_get_segment_library(
     request: Request,
     config_id: str,
 ) -> JSONResponse:
+    """Load segment library legs, recipes, and per-event km totals."""
+    require_auth(request)
+    try:
+        state = get_package_segment_library_state(config_id)
+        return JSONResponse(content={"ok": True, **state})
+    except FileNotFoundError as e:
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail=str(e))
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
     """Load segment library legs, recipes, and per-event km totals."""
     require_auth(request)
     try:

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -201,6 +201,10 @@ LOCATION_SETUP_BUFFER_MINUTES = 45  # Minutes before earliest runner start for l
 # segment end are clamped to the boundary and accepted.
 LOCATION_SEGMENT_CLAMP_M = 50.0
 
+# Junction Flow authoring (Issue #817): segment start/end within this distance
+# of a junction pin is treated as meeting at the junction.
+JUNCTION_SEGMENT_PROXIMITY_M = 10.0
+
 # Course Mapping location types (Issue #732 / #747) — alphabetical for UI dropdown
 LOCATION_TYPE_CHOICES = [
     "aid",

--- a/frontend/static/js/map/junctions_authoring.js
+++ b/frontend/static/js/map/junctions_authoring.js
@@ -1,0 +1,1051 @@
+/**
+ * Junction Flow authoring (Issue #817) — Package Build → Junctions tab.
+ */
+(function () {
+    'use strict';
+
+    let state = {
+        configId: null,
+        proximityM: 10,
+        doc: { version: 1, junctions: [] },
+        selectedId: null,
+        dirty: false,
+        placeMode: false,
+        map: null,
+        pinMarker: null,
+        segLayer: null,
+        highlightLayer: null,
+        nearby: [],
+        mapFeatures: [],
+        nearbySortCol: 'seg_id',
+        nearbySortDir: 'asc',
+        chromeBound: false,
+        editingIxId: null,
+        unloadBound: false,
+        nearbyRequestSeq: 0,
+    };
+
+    function getConfigId() {
+        const params = new URLSearchParams(window.location.search);
+        return (params.get('config_id') || '').trim() || null;
+    }
+
+    function status(msg, isError) {
+        const el = document.getElementById('junctions-status');
+        if (!el) return;
+        el.textContent = msg || '';
+        el.style.color = isError ? '#c0392b' : '#666';
+    }
+
+    function escapeHtml(str) {
+        return String(str == null ? '' : str)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function selectedJunction() {
+        return (state.doc.junctions || []).find(function (j) {
+            return j.id === state.selectedId;
+        }) || null;
+    }
+
+    function markDirty() {
+        state.dirty = true;
+        status('Unsaved changes');
+    }
+
+    function hasCourseSegments() {
+        if (window.configPackageCourse && window.configPackageCourse.hasCombinedCourse) {
+            return !!window.configPackageCourse.hasCombinedCourse();
+        }
+        return false;
+    }
+
+    function ensureCourseLoaded() {
+        if (hasCourseSegments()) return Promise.resolve(true);
+        if (!state.configId) return Promise.resolve(false);
+        return fetch('/api/config/packages/' + encodeURIComponent(state.configId) + '/course', {
+            credentials: 'same-origin',
+        })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                const segs = data && data.course && data.course.segments;
+                return !!(segs && segs.length);
+            })
+            .catch(function () { return false; });
+    }
+
+    function ensureMap() {
+        if (state.map) {
+            setTimeout(function () { state.map.invalidateSize(); }, 50);
+            return state.map;
+        }
+        const el = document.getElementById('junctions-map');
+        if (!el || typeof L === 'undefined') return null;
+        state.map = L.map(el, { zoomControl: true }).setView([45.95, -66.64], 14);
+        L.tileLayer('https://{s}.basemaps.cartocdn.com/rastertiles/voyager/{z}/{x}/{y}{r}.png', {
+            attribution: '© OpenStreetMap, © CARTO',
+            maxZoom: 19,
+        }).addTo(state.map);
+        state.segLayer = L.layerGroup().addTo(state.map);
+        state.highlightLayer = L.layerGroup().addTo(state.map);
+        // Clicks on polylines must reach the map (interactive:false on lines below)
+        state.map.on('click', onMapClick);
+        return state.map;
+    }
+
+    function onMapClick(ev) {
+        if (!state.placeMode) return;
+        ensureDraftJunction();
+        setPin(ev.latlng.lat, ev.latlng.lng, true);
+        stopPlaceMode();
+        discoverNearby();
+    }
+
+    function stopPlaceMode() {
+        state.placeMode = false;
+        const btn = document.getElementById('junctions-btn-place');
+        if (btn) {
+            btn.classList.remove('active');
+            btn.style.outline = '';
+            btn.style.background = '';
+        }
+        if (state.map) state.map.getContainer().style.cursor = '';
+    }
+
+    function ensureDraftJunction() {
+        if (selectedJunction()) return selectedJunction();
+        const id = 'junc_' + Date.now().toString(36);
+        const labelEl = document.getElementById('junction-label');
+        const label = (labelEl && labelEl.value.trim()) || 'New junction';
+        const j = {
+            id: id,
+            label: label,
+            lat: null,
+            lon: null,
+            nearby_seg_ids: [],
+            nearby_segments: [],
+            interactions: [],
+            streams: [],
+        };
+        state.doc.junctions = state.doc.junctions || [];
+        state.doc.junctions.push(j);
+        state.selectedId = id;
+        renderList();
+        if (labelEl) labelEl.value = j.label;
+        markDirty();
+        return j;
+    }
+
+    function startPlaceMode() {
+        ensureMap();
+        ensureDraftJunction();
+        state.placeMode = true;
+        const btn = document.getElementById('junctions-btn-place');
+        if (btn) {
+            btn.classList.add('active');
+            btn.style.outline = '2px solid #2980b9';
+            btn.style.background = '#eaf4fb';
+        }
+        if (state.map) {
+            state.map.getContainer().style.cursor = 'crosshair';
+            setTimeout(function () { state.map.invalidateSize(); }, 50);
+        }
+        status('Place pin active — click the map (including on course lines)');
+    }
+
+    function setPin(lat, lon, fromUser) {
+        const j = ensureDraftJunction();
+        if (!j) return;
+        j.lat = Number(lat);
+        j.lon = Number(lon);
+        const latEl = document.getElementById('junction-lat');
+        const lonEl = document.getElementById('junction-lon');
+        if (latEl) latEl.value = String(j.lat);
+        if (lonEl) lonEl.value = String(j.lon);
+        const map = ensureMap();
+        if (!map) return;
+        if (state.pinMarker) {
+            state.pinMarker.setLatLng([j.lat, j.lon]);
+        } else {
+            state.pinMarker = L.circleMarker([j.lat, j.lon], {
+                radius: 10,
+                color: '#111',
+                weight: 2,
+                fillColor: '#111',
+                fillOpacity: 0.45,
+                interactive: false,
+            }).addTo(map);
+        }
+        map.panTo([j.lat, j.lon]);
+        if (fromUser) markDirty();
+    }
+
+    function fitMapToNearby() {
+        const map = state.map;
+        if (!map || !(state.nearby || []).length) return;
+        const points = [];
+        if (state.pinMarker) points.push(state.pinMarker.getLatLng());
+        // Zoom to the junction cluster (near-side endpoints), not full spur polylines
+        state.nearby.forEach(function (s) {
+            const near = s.near_endpoint || '';
+            if ((near === 'start' || near === 'both') &&
+                s.start_lat != null && s.start_lon != null) {
+                points.push([s.start_lat, s.start_lon]);
+            }
+            if ((near === 'end' || near === 'both') &&
+                s.end_lat != null && s.end_lon != null) {
+                points.push([s.end_lat, s.end_lon]);
+            }
+        });
+        if (!points.length) return;
+        try {
+            map.fitBounds(L.latLngBounds(points), {
+                padding: [48, 48],
+                maxZoom: 17,
+            });
+        } catch (e) { /* ignore */ }
+    }
+
+    function renderSegLines(highlightIds, options) {
+        const map = ensureMap();
+        if (!map || !state.segLayer) return;
+        options = options || {};
+        state.segLayer.clearLayers();
+        state.highlightLayer.clearLayers();
+        const hi = {};
+        (highlightIds || []).forEach(function (id) { hi[id] = true; });
+        const allBounds = [];
+        state.mapFeatures.forEach(function (f) {
+            const coords = (f.geometry && f.geometry.coordinates) || [];
+            if (coords.length < 2) return;
+            const latlngs = coords.map(function (c) { return [c[1], c[0]]; });
+            const segId = (f.properties && f.properties.seg_id) || '';
+            const isHi = !!hi[segId];
+            const line = L.polyline(latlngs, {
+                color: isHi ? '#c0392b' : '#8B7355',
+                weight: isHi ? 5 : 3,
+                opacity: isHi ? 0.95 : 0.7,
+                interactive: false,
+            });
+            line.bindTooltip(segId + (f.properties.seg_label ? ' — ' + f.properties.seg_label : ''));
+            (isHi ? state.highlightLayer : state.segLayer).addLayer(line);
+            latlngs.forEach(function (ll) { allBounds.push(ll); });
+        });
+        if (options.fit === 'nearby' && (highlightIds || []).length) {
+            fitMapToNearby();
+        } else if (options.fit === 'all' && allBounds.length) {
+            if (state.pinMarker) allBounds.push(state.pinMarker.getLatLng());
+            try {
+                map.fitBounds(allBounds, { padding: [24, 24], maxZoom: 15 });
+            } catch (e) { /* ignore */ }
+        }
+    }
+
+    function loadMapSegments() {
+        if (!state.configId) return Promise.resolve();
+        return fetch('/api/config/packages/' + encodeURIComponent(state.configId) + '/junctions/map-segments', {
+            credentials: 'same-origin',
+        })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                state.mapFeatures = (data && data.features) || [];
+                const nearbyIds = (state.nearby || []).map(function (s) { return s.seg_id; });
+                renderSegLines(nearbyIds, {
+                    fit: nearbyIds.length ? 'nearby' : 'all',
+                });
+            })
+            .catch(function () {
+                state.mapFeatures = [];
+            });
+    }
+
+    function classifyNearbyRow(seg) {
+        const id = seg.seg_id || '';
+        // Heuristic for legend: "(2)" / later full pass vs university spur naming
+        if (/\(2\)\s*$/.test(seg.seg_label || '') || / \(2\)$/.test(seg.seg_label || '')) {
+            return 'second-pass';
+        }
+        const events = (seg.events || []).map(function (e) { return String(e).toLowerCase(); });
+        if (events.length === 1 && events[0] === '10k' && /university|forest hill/i.test(seg.seg_label || '')) {
+            return 'spur';
+        }
+        return '';
+    }
+
+    function eventLabelForTableId(eventId) {
+        const eid = String(eventId || '').toLowerCase();
+        if (eid === '10k') return '10K';
+        if (!eid) return '';
+        return eid.charAt(0).toUpperCase() + eid.slice(1);
+    }
+
+    function formatKmRange(fromKm, toKm) {
+        if (fromKm == null || toKm == null || fromKm === '' || toKm === '') return '—';
+        const a = Number(fromKm);
+        const b = Number(toKm);
+        if (!isFinite(a) || !isFinite(b)) return '—';
+        if (a === 0 && b === 0) return '0';
+        return a.toFixed(2) + '–' + b.toFixed(2);
+    }
+
+    function eventsDisplayList(events) {
+        return (events || []).map(function (e) {
+            return eventLabelForTableId(e);
+        }).join(', ');
+    }
+
+    function segIdSortKey(segId) {
+        const s = String(segId || '');
+        const m = s.match(/^([A-Za-z]*)(\d+)(.*)$/);
+        if (!m) return [s.toLowerCase(), 0, ''];
+        return [m[1].toLowerCase(), parseInt(m[2], 10) || 0, m[3].toLowerCase()];
+    }
+
+    function compareSegIds(a, b) {
+        const ka = segIdSortKey(a);
+        const kb = segIdSortKey(b);
+        for (let i = 0; i < 3; i++) {
+            if (ka[i] < kb[i]) return -1;
+            if (ka[i] > kb[i]) return 1;
+        }
+        return 0;
+    }
+
+    function sortNearbyRows() {
+        const dir = state.nearbySortDir === 'desc' ? -1 : 1;
+        state.nearby.sort(function (a, b) {
+            return dir * compareSegIds(a.seg_id, b.seg_id);
+        });
+    }
+
+    function renderSegmentsTableHeader(eventIds) {
+        const thead = document.getElementById('junctions-segments-thead-row');
+        if (!thead) return;
+        thead.innerHTML = '';
+        const idTh = document.createElement('th');
+        idTh.id = 'junctions-segments-sort-id';
+        idTh.className = 'table-sortable';
+        idTh.setAttribute('data-sort', 'seg_id');
+        idTh.style.cursor = 'pointer';
+        idTh.innerHTML = 'ID <span class="table-sortable-indicator">▲</span>';
+        idTh.setAttribute('aria-sort', state.nearbySortDir === 'desc' ? 'descending' : 'ascending');
+        const ind = idTh.querySelector('.table-sortable-indicator');
+        if (ind) ind.textContent = state.nearbySortDir === 'desc' ? '▼' : '▲';
+        thead.appendChild(idTh);
+        ['Label', 'End', 'Dist m', 'Events'].forEach(function (label) {
+            const th = document.createElement('th');
+            th.textContent = label;
+            thead.appendChild(th);
+        });
+        (eventIds || []).forEach(function (eid) {
+            const th = document.createElement('th');
+            th.textContent = eventLabelForTableId(eid);
+            thead.appendChild(th);
+        });
+        const lenTh = document.createElement('th');
+        lenTh.textContent = 'Length';
+        thead.appendChild(lenTh);
+    }
+
+    function renderNearby() {
+        const tbody = document.getElementById('junctions-segments-tbody');
+        if (!tbody) return;
+        const eventIds = packageEventIds();
+        renderSegmentsTableHeader(eventIds);
+        tbody.innerHTML = '';
+        const colCount = 5 + eventIds.length + 1;
+        if (!state.nearby.length) {
+            tbody.innerHTML =
+                '<tr><td colspan="' + colCount + '" class="text-secondary">' +
+                'No segments within proximity. Place a pin and Find nearby.</td></tr>';
+            const legend = document.getElementById('junctions-segments-legend');
+            if (legend) legend.textContent = '';
+            renderSegLines([]);
+            return;
+        }
+        sortNearbyRows();
+        state.nearby.forEach(function (seg) {
+            const tr = document.createElement('tr');
+            const kind = classifyNearbyRow(seg);
+            if (kind === 'second-pass') tr.className = 'junctions-row-second-pass';
+            if (kind === 'spur') tr.className = 'junctions-row-spur';
+            const ek = seg.event_kms || {};
+            let html =
+                '<td style="font-weight:600;">' + escapeHtml(seg.seg_id) + '</td>' +
+                '<td>' + escapeHtml(seg.seg_label || '') + '</td>' +
+                '<td>' + escapeHtml(seg.near_endpoint || '—') + '</td>' +
+                '<td>' + escapeHtml(seg.distance_m != null ? seg.distance_m : '—') + '</td>' +
+                '<td>' + escapeHtml(eventsDisplayList(seg.events)) + '</td>';
+            eventIds.forEach(function (eid) {
+                const row = ek[eid] || ek[String(eid).toLowerCase()] || {};
+                html += '<td>' + escapeHtml(formatKmRange(row.from_km, row.to_km)) + '</td>';
+            });
+            html += '<td>' + escapeHtml(
+                seg.length_km != null && isFinite(Number(seg.length_km))
+                    ? String(Math.round(Number(seg.length_km) * 100) / 100)
+                    : '—'
+            ) + '</td>';
+            tr.innerHTML = html;
+            tbody.appendChild(tr);
+        });
+        const legend = document.getElementById('junctions-segments-legend');
+        if (legend) {
+            legend.textContent = state.nearby.length + ' within ' + state.proximityM + ' m';
+        }
+        renderSegLines(state.nearby.map(function (s) { return s.seg_id; }), { fit: 'nearby' });
+    }
+
+    function deriveEvents(fromId, toIds) {
+        const byId = {};
+        state.nearby.forEach(function (s) { byId[s.seg_id] = s; });
+        const from = byId[fromId];
+        if (!from) return [];
+        let set = {};
+        (from.events || []).forEach(function (e) { set[String(e).toLowerCase()] = true; });
+        const toList = Array.isArray(toIds) ? toIds : String(toIds || '').split(',');
+        let union = {};
+        toList.forEach(function (tid) {
+            const t = byId[String(tid).trim()];
+            if (!t) return;
+            (t.events || []).forEach(function (e) { union[String(e).toLowerCase()] = true; });
+        });
+        return Object.keys(set).filter(function (e) { return union[e]; });
+    }
+
+    function packageEventIds() {
+        if (window.CONFIG_PACKAGE_EVENTS && window.CONFIG_PACKAGE_EVENTS.length) {
+            return window.CONFIG_PACKAGE_EVENTS.map(function (e) {
+                return String(e).toLowerCase();
+            });
+        }
+        const raw = window.EVENT_CHOICES_FROM_SERVER || [];
+        return raw.map(function (item) {
+            if (typeof item === 'string') return item.toLowerCase();
+            return String(item.value || item.label || '').toLowerCase();
+        }).filter(Boolean);
+    }
+
+    function nearbySegIds(extra) {
+        const ids = state.nearby.map(function (s) { return s.seg_id; });
+        const extras = Array.isArray(extra) ? extra : (extra ? [extra] : []);
+        extras.forEach(function (id) {
+            const sid = String(id || '').trim();
+            if (sid && ids.indexOf(sid) < 0) ids.push(sid);
+        });
+        return ids;
+    }
+
+    function segSelectHtml(field, selected, includeBlank) {
+        let html = '<select data-f="' + field + '" class="config-package-input">';
+        if (includeBlank) html += '<option value="">—</option>';
+        nearbySegIds(selected).forEach(function (id) {
+            html += '<option value="' + escapeHtml(id) + '"' +
+                (id === selected ? ' selected' : '') + '>' + escapeHtml(id) + '</option>';
+        });
+        html += '</select>';
+        return html;
+    }
+
+    function multiSelectHtml(field, options, selectedValues) {
+        const selectedSet = {};
+        (selectedValues || []).forEach(function (v) {
+            selectedSet[String(v).toLowerCase()] = true;
+        });
+        const opts = options || [];
+        const size = Math.min(5, Math.max(2, opts.length || 2));
+        let html = '<select data-f="' + field + '" class="config-package-input" multiple size="' +
+            size + '" style="min-width:5.5rem; max-width:8rem;">';
+        opts.forEach(function (val) {
+            const v = String(val);
+            html += '<option value="' + escapeHtml(v) + '"' +
+                (selectedSet[v.toLowerCase()] ? ' selected' : '') + '>' +
+                escapeHtml(v) + '</option>';
+        });
+        html += '</select>';
+        return html;
+    }
+
+    function selectedOptions(el) {
+        if (!el) return [];
+        return Array.prototype.slice.call(el.selectedOptions || [])
+            .map(function (o) { return o.value; })
+            .filter(Boolean);
+    }
+
+    function displayText(value) {
+        if (value == null || value === '') return '—';
+        if (Array.isArray(value)) {
+            const parts = value.filter(Boolean);
+            return parts.length ? parts.join(', ') : '—';
+        }
+        return String(value);
+    }
+
+    function typeLabel(type) {
+        return type === 'merge' ? 'Merge' : 'Cross';
+    }
+
+    function sideLabel(side) {
+        if (side === 'left') return 'Left';
+        if (side === 'right') return 'Right';
+        return '—';
+    }
+
+    function finishEditingInteraction() {
+        syncEditingInteractionFromDom();
+        state.editingIxId = null;
+    }
+
+    function syncEditingInteractionFromDom() {
+        const j = selectedJunction();
+        if (!j || !state.editingIxId) return;
+        const tr = document.querySelector(
+            '#junctions-ix-tbody tr[data-ix="' + state.editingIxId + '"]'
+        );
+        if (!tr) return;
+        const ix = (j.interactions || []).find(function (x) {
+            return x.id === state.editingIxId;
+        });
+        if (!ix) return;
+        const typeEl = tr.querySelector('[data-f=type]');
+        if (!typeEl) return;
+        const type = typeEl.value || 'cross';
+        const side = (tr.querySelector('[data-f=side]') || {}).value || '';
+        const from = (tr.querySelector('[data-f=from]') || {}).value || '';
+        let toSegs = [];
+        const toEl = tr.querySelector('[data-f=to]');
+        if (type === 'merge') {
+            toSegs = selectedOptions(toEl);
+        } else if (toEl && toEl.value) {
+            toSegs = [toEl.value];
+        }
+        const conflictsEl = tr.querySelector('[data-f=conflicts]');
+        const conflicts = type === 'cross' && conflictsEl ? (conflictsEl.value || '') : '';
+        let events = selectedOptions(tr.querySelector('[data-f=events]'));
+        if (!events.length) events = deriveEvents(from, toSegs);
+        ix.type = type;
+        ix.side = side;
+        ix.from_seg_id = from;
+        ix.to_seg_ids = toSegs;
+        ix.conflicts_with_seg_id = conflicts;
+        ix.events = events;
+        j.nearby_seg_ids = state.nearby.map(function (s) { return s.seg_id; });
+        j.nearby_segments = state.nearby.slice();
+    }
+
+    function syncInteractionsFromDom() {
+        syncEditingInteractionFromDom();
+        const j = selectedJunction();
+        if (!j) return;
+        j.nearby_seg_ids = state.nearby.map(function (s) { return s.seg_id; });
+        j.nearby_segments = state.nearby.slice();
+    }
+
+    function deleteInteraction(ixId) {
+        const j = selectedJunction();
+        if (!j) return;
+        const ta = window.TableActions;
+        if (ta && !ta.doubleConfirmDelete({
+            subject: 'this interaction',
+            detail: 'It will remain until you click Save junctions (or discard by leaving).',
+        })) {
+            return;
+        }
+        if (!ta && !window.confirm('Delete this interaction?')) return;
+        syncEditingInteractionFromDom();
+        j.interactions = (j.interactions || []).filter(function (x) { return x.id !== ixId; });
+        if (state.editingIxId === ixId) state.editingIxId = null;
+        renderInteractions();
+        markDirty();
+    }
+
+    function beginEditInteraction(ixId) {
+        if (state.editingIxId && state.editingIxId !== ixId) {
+            syncEditingInteractionFromDom();
+        }
+        if (state.editingIxId === ixId) {
+            finishEditingInteraction();
+            renderInteractions();
+            return;
+        }
+        state.editingIxId = ixId;
+        renderInteractions();
+    }
+
+    function wireInteractionRow(tr, ix) {
+        tr.querySelectorAll('select').forEach(function (el) {
+            el.addEventListener('change', function () {
+                syncEditingInteractionFromDom();
+                markDirty();
+                if (el.getAttribute('data-f') === 'type') {
+                    renderInteractions();
+                }
+            });
+        });
+        const actions = document.createElement('td');
+        actions.className = 'course-map-action-cell';
+        const ta = window.TableActions;
+        if (ta) {
+            actions.appendChild(
+                ta.createIconButton(
+                    'edit',
+                    state.editingIxId === ix.id ? 'Done editing' : 'Edit interaction',
+                    function (ev) {
+                        ev.stopPropagation();
+                        beginEditInteraction(ix.id);
+                    }
+                )
+            );
+            actions.appendChild(
+                ta.createIconButton('delete', 'Delete interaction', function (ev) {
+                    ev.stopPropagation();
+                    deleteInteraction(ix.id);
+                })
+            );
+        }
+        tr.appendChild(actions);
+    }
+
+    function renderInteractions() {
+        const j = selectedJunction();
+        const tbody = document.getElementById('junctions-ix-tbody');
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        if (!j) return;
+        if (!(j.interactions || []).length) {
+            tbody.innerHTML =
+                '<tr><td colspan="7" class="text-secondary">' +
+                'No interactions yet. Add a cross or merge.</td></tr>';
+            return;
+        }
+        (j.interactions || []).forEach(function (ix, idx) {
+            const id = ix.id || ('ix_' + (idx + 1));
+            ix.id = id;
+            const tr = document.createElement('tr');
+            tr.setAttribute('data-ix', id);
+            const editing = state.editingIxId === id;
+            const isMerge = ix.type === 'merge';
+            const toIds = ix.to_seg_ids || [];
+
+            if (!editing) {
+                tr.innerHTML =
+                    '<td>' + escapeHtml(typeLabel(ix.type)) + '</td>' +
+                    '<td>' + escapeHtml(sideLabel(ix.side)) + '</td>' +
+                    '<td>' + escapeHtml(displayText(ix.from_seg_id)) + '</td>' +
+                    '<td>' + escapeHtml(displayText(toIds)) + '</td>' +
+                    '<td>' + escapeHtml(isMerge ? '—' : displayText(ix.conflicts_with_seg_id)) + '</td>' +
+                    '<td>' + escapeHtml(eventsDisplayList(ix.events || [])) + '</td>';
+                tbody.appendChild(tr);
+                wireInteractionRow(tr, ix);
+                return;
+            }
+
+            const toCell = isMerge
+                ? multiSelectHtml('to', nearbySegIds(toIds), toIds)
+                : segSelectHtml('to', toIds[0] || '', true);
+            const conflictsCell = isMerge
+                ? '<select data-f="conflicts" class="config-package-input" disabled>' +
+                  '<option value="">—</option></select>'
+                : segSelectHtml('conflicts', ix.conflicts_with_seg_id || '', true);
+
+            tr.innerHTML =
+                '<td>' +
+                '<select data-f="type" class="config-package-input">' +
+                '<option value="cross"' + (!isMerge ? ' selected' : '') + '>Cross</option>' +
+                '<option value="merge"' + (isMerge ? ' selected' : '') + '>Merge</option></select></td>' +
+                '<td>' +
+                '<select data-f="side" class="config-package-input" title="Direction the runner turns">' +
+                '<option value=""' + (!ix.side ? ' selected' : '') + '>—</option>' +
+                '<option value="left"' + (ix.side === 'left' ? ' selected' : '') + '>Left</option>' +
+                '<option value="right"' + (ix.side === 'right' ? ' selected' : '') + '>Right</option></select></td>' +
+                '<td>' + segSelectHtml('from', ix.from_seg_id || '', true) + '</td>' +
+                '<td>' + toCell + '</td>' +
+                '<td>' + conflictsCell + '</td>' +
+                '<td>' + multiSelectHtml('events', packageEventIds(), ix.events || []) + '</td>';
+
+            tbody.appendChild(tr);
+            wireInteractionRow(tr, ix);
+        });
+    }
+
+    function renderList() {
+        const ul = document.getElementById('junctions-list');
+        if (!ul) return;
+        ul.innerHTML = '';
+        (state.doc.junctions || []).forEach(function (j) {
+            const li = document.createElement('li');
+            li.style.cssText = 'padding:0.5rem 0.75rem; border-bottom:1px solid #eee; cursor:pointer;';
+            if (j.id === state.selectedId) {
+                li.style.background = '#eef5fb';
+                li.style.fontWeight = '600';
+            }
+            li.textContent = j.label || j.id;
+            li.addEventListener('click', function () {
+                syncFormToSelected();
+                selectJunction(j.id);
+            });
+            ul.appendChild(li);
+        });
+        if (!(state.doc.junctions || []).length) {
+            ul.innerHTML = '<li style="padding:0.75rem; color:#666;">No junctions yet</li>';
+        }
+    }
+
+    function syncFormToSelected() {
+        const j = selectedJunction();
+        if (!j) return;
+        const labelEl = document.getElementById('junction-label');
+        if (labelEl) j.label = labelEl.value.trim() || j.label;
+        const latEl = document.getElementById('junction-lat');
+        const lonEl = document.getElementById('junction-lon');
+        if (latEl && latEl.value !== '') j.lat = Number(latEl.value);
+        if (lonEl && lonEl.value !== '') j.lon = Number(lonEl.value);
+        syncInteractionsFromDom();
+    }
+
+    function clearPin() {
+        if (state.pinMarker && state.map) {
+            state.map.removeLayer(state.pinMarker);
+        }
+        state.pinMarker = null;
+    }
+
+    function resetEditorSurfaces() {
+        state.nearby = [];
+        state.editingIxId = null;
+        clearPin();
+        const labelEl = document.getElementById('junction-label');
+        const latEl = document.getElementById('junction-lat');
+        const lonEl = document.getElementById('junction-lon');
+        const j = selectedJunction();
+        if (labelEl) labelEl.value = j ? (j.label || '') : '';
+        if (latEl) latEl.value = j && j.lat != null ? j.lat : '';
+        if (lonEl) lonEl.value = j && j.lon != null ? j.lon : '';
+        renderNearby();
+        renderInteractions();
+        renderSegLines([], { fit: 'all' });
+    }
+
+    function selectJunction(id, opts) {
+        opts = opts || {};
+        if (state.selectedId && state.selectedId !== id) {
+            syncFormToSelected();
+            state.editingIxId = null;
+        }
+        // Invalidate in-flight nearby lookups from the previous junction
+        if (!opts.keepNearbyRequest) state.nearbyRequestSeq += 1;
+        state.selectedId = id;
+        const j = selectedJunction();
+        renderList();
+        if (!j) {
+            resetEditorSurfaces();
+            return;
+        }
+        document.getElementById('junction-label').value = j.label || '';
+        document.getElementById('junction-lat').value = j.lat != null ? j.lat : '';
+        document.getElementById('junction-lon').value = j.lon != null ? j.lon : '';
+        state.nearby = Array.isArray(j.nearby_segments) ? j.nearby_segments.slice() : [];
+        state.editingIxId = null;
+        if (j.lat != null && j.lon != null && isFinite(Number(j.lat)) && isFinite(Number(j.lon))) {
+            setPin(j.lat, j.lon, false);
+            if (!state.nearby.length && !opts.skipDiscover) discoverNearby();
+            else {
+                renderNearby();
+                renderInteractions();
+            }
+        } else {
+            clearPin();
+            renderNearby();
+            renderInteractions();
+            renderSegLines([], { fit: 'all' });
+        }
+        if (opts.preserveStatus) status(opts.preserveStatus);
+    }
+
+    function newJunction() {
+        syncFormToSelected();
+        finishEditingInteraction();
+        const id = 'junc_' + Date.now().toString(36);
+        const j = {
+            id: id,
+            label: 'New junction',
+            lat: null,
+            lon: null,
+            nearby_seg_ids: [],
+            nearby_segments: [],
+            interactions: [],
+            streams: [],
+        };
+        state.doc.junctions = state.doc.junctions || [];
+        state.doc.junctions.push(j);
+        markDirty();
+        state.nearbyRequestSeq += 1;
+        state.selectedId = id;
+        state.editingIxId = null;
+        state.nearby = [];
+        renderList();
+        document.getElementById('junction-label').value = j.label;
+        document.getElementById('junction-lat').value = '';
+        document.getElementById('junction-lon').value = '';
+        clearPin();
+        renderNearby();
+        renderInteractions();
+        renderSegLines([], { fit: 'all' });
+        startPlaceMode();
+        status('New junction — place a pin on the map');
+    }
+
+    function deleteSelected() {
+        const j = selectedJunction();
+        if (!j) return;
+        if (!window.confirm('Delete junction "' + (j.label || j.id) + '"?')) return;
+        state.doc.junctions = (state.doc.junctions || []).filter(function (x) { return x.id !== j.id; });
+        state.selectedId = (state.doc.junctions[0] && state.doc.junctions[0].id) || null;
+        markDirty();
+        renderList();
+        if (state.selectedId) selectJunction(state.selectedId);
+        else {
+            state.nearbyRequestSeq += 1;
+            resetEditorSurfaces();
+            status('No junctions');
+        }
+    }
+
+    function discoverNearby() {
+        const j = selectedJunction();
+        if (!j || !state.configId) return;
+        const lat = Number(document.getElementById('junction-lat').value);
+        const lon = Number(document.getElementById('junction-lon').value);
+        if (!isFinite(lat) || !isFinite(lon)) {
+            status('Set lat/lon or place a pin first', true);
+            return;
+        }
+        j.lat = lat;
+        j.lon = lon;
+        stopPlaceMode();
+        status('Finding nearby segments…');
+        state.nearbyRequestSeq += 1;
+        const seq = state.nearbyRequestSeq;
+        const forId = j.id;
+        fetch('/api/config/packages/' + encodeURIComponent(state.configId) + '/junctions/nearby', {
+            method: 'POST',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ lat: lat, lon: lon }),
+        })
+            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
+            .then(function (res) {
+                if (seq !== state.nearbyRequestSeq || state.selectedId !== forId) return;
+                const target = selectedJunction();
+                if (!target || target.id !== forId) return;
+                if (!res.ok) throw new Error((res.d && res.d.detail) || 'Nearby lookup failed');
+                state.nearby = res.d.segments || [];
+                if (res.d.radius_m != null) state.proximityM = res.d.radius_m;
+                const proxLabel = document.getElementById('junctions-proximity-label');
+                if (proxLabel) proxLabel.textContent = String(state.proximityM);
+                target.nearby_seg_ids = state.nearby.map(function (s) { return s.seg_id; });
+                target.nearby_segments = state.nearby.slice();
+                renderNearby();
+                renderInteractions();
+                markDirty();
+                status(
+                    state.nearby.length
+                        ? (state.nearby.length + ' segment(s) within ' + state.proximityM + ' m')
+                        : ('0 segments within ' + state.proximityM +
+                            ' m — move the pin onto a segment start/end (not mid-corridor)')
+                );
+            })
+            .catch(function (err) {
+                if (seq !== state.nearbyRequestSeq || state.selectedId !== forId) return;
+                status(err.message || String(err), true);
+            });
+    }
+
+    function saveAll() {
+        finishEditingInteraction();
+        syncFormToSelected();
+        if (!state.configId) return Promise.reject(new Error('No package open'));
+        status('Saving…');
+        return fetch('/api/config/packages/' + encodeURIComponent(state.configId) + '/junctions', {
+            method: 'PUT',
+            credentials: 'same-origin',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                version: state.doc.version || 1,
+                junctions: state.doc.junctions || [],
+            }),
+        })
+            .then(function (r) { return r.json().then(function (d) { return { ok: r.ok, d: d }; }); })
+            .then(function (res) {
+                if (!res.ok) throw new Error((res.d && res.d.detail) || 'Save failed');
+                state.doc = {
+                    version: res.d.version || 1,
+                    junctions: res.d.junctions || [],
+                    updated: res.d.updated,
+                };
+                state.dirty = false;
+                state.editingIxId = null;
+                const savedMsg = 'Saved' + (res.d.updated ? ' · ' + res.d.updated : '');
+                status(savedMsg);
+                renderList();
+                if (state.selectedId) {
+                    selectJunction(state.selectedId, {
+                        skipDiscover: true,
+                        keepNearbyRequest: true,
+                        preserveStatus: savedMsg,
+                    });
+                }
+            })
+            .catch(function (err) {
+                status(err.message || String(err), true);
+                throw err;
+            });
+    }
+
+    function loadDoc() {
+        if (!state.configId) return Promise.resolve();
+        // Don't wipe in-progress authoring when re-entering the tab
+        if (state.dirty && (state.doc.junctions || []).length) {
+            renderList();
+            if (state.selectedId) selectJunction(state.selectedId);
+            return Promise.resolve();
+        }
+        return fetch('/api/config/packages/' + encodeURIComponent(state.configId) + '/junctions', {
+            credentials: 'same-origin',
+        })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (data) {
+                if (!data) return;
+                state.doc = {
+                    version: data.version || 1,
+                    junctions: data.junctions || [],
+                    updated: data.updated,
+                };
+                if (data.proximity_m != null) state.proximityM = data.proximity_m;
+                const proxLabel = document.getElementById('junctions-proximity-label');
+                if (proxLabel) proxLabel.textContent = String(state.proximityM);
+                state.dirty = false;
+                renderList();
+                if (state.doc.junctions.length) {
+                    selectJunction(state.doc.junctions[0].id);
+                }
+            });
+    }
+
+    function showWorkspace(show) {
+        const gate = document.getElementById('junctions-gate');
+        const ws = document.getElementById('junctions-workspace');
+        if (gate) gate.style.display = show ? 'none' : 'block';
+        if (ws) ws.style.display = show ? 'block' : 'none';
+    }
+
+    function bindChrome() {
+        if (state.chromeBound) return;
+        state.chromeBound = true;
+        const btnNew = document.getElementById('junctions-btn-new');
+        const btnSave = document.getElementById('junctions-btn-save');
+        const btnPlace = document.getElementById('junctions-btn-place');
+        const btnDiscover = document.getElementById('junctions-btn-discover');
+        const btnDelete = document.getElementById('junctions-btn-delete');
+        const btnAddIx = document.getElementById('junctions-btn-add-ix');
+        const segmentsTable = document.getElementById('junctions-segments-table');
+        if (btnNew) btnNew.onclick = newJunction;
+        if (btnSave) {
+            btnSave.onclick = function () {
+                saveAll().catch(function () { /* status already set */ });
+            };
+        }
+        if (btnPlace) btnPlace.onclick = startPlaceMode;
+        if (btnDiscover) btnDiscover.onclick = discoverNearby;
+        if (btnDelete) btnDelete.onclick = deleteSelected;
+        if (segmentsTable) {
+            segmentsTable.addEventListener('click', function (e) {
+                const th = e.target.closest('#junctions-segments-sort-id');
+                if (!th) return;
+                if (state.nearbySortCol === 'seg_id') {
+                    state.nearbySortDir = state.nearbySortDir === 'asc' ? 'desc' : 'asc';
+                } else {
+                    state.nearbySortCol = 'seg_id';
+                    state.nearbySortDir = 'asc';
+                }
+                renderNearby();
+            });
+        }
+        if (btnAddIx) {
+            btnAddIx.onclick = function () {
+                const j = selectedJunction();
+                if (!j) return;
+                finishEditingInteraction();
+                j.interactions = j.interactions || [];
+                const newId = 'ix_' + Date.now().toString(36);
+                j.interactions.push({
+                    id: newId,
+                    type: 'cross',
+                    side: 'left',
+                    from_seg_id: (state.nearby[0] && state.nearby[0].seg_id) || '',
+                    to_seg_ids: [(state.nearby[1] && state.nearby[1].seg_id) || ''],
+                    conflicts_with_seg_id: (state.nearby[2] && state.nearby[2].seg_id) || '',
+                    events: [],
+                });
+                state.editingIxId = newId;
+                renderInteractions();
+                markDirty();
+            };
+        }
+        ['junction-label', 'junction-lat', 'junction-lon'].forEach(function (id) {
+            const el = document.getElementById(id);
+            if (!el) return;
+            el.addEventListener('change', function () {
+                syncFormToSelected();
+                const j = selectedJunction();
+                if (j && (id === 'junction-lat' || id === 'junction-lon')) {
+                    if (j.lat != null && j.lon != null) setPin(j.lat, j.lon, false);
+                }
+                markDirty();
+            });
+        });
+        if (!state.unloadBound) {
+            state.unloadBound = true;
+            window.addEventListener('beforeunload', function (e) {
+                if (!state.dirty) return;
+                e.preventDefault();
+                e.returnValue = '';
+            });
+        }
+    }
+
+    function initJunctionsAuthoring() {
+        const root = document.getElementById('junctions-authoring-root');
+        if (!root) return;
+        state.configId = getConfigId();
+        if (!state.configId) {
+            status('Open a package to author junctions', true);
+            showWorkspace(false);
+            return;
+        }
+        bindChrome();
+        ensureCourseLoaded().then(function (ready) {
+            showWorkspace(ready);
+            if (!ready) {
+                status('Waiting for course segments', true);
+                return;
+            }
+            ensureMap();
+            Promise.all([loadDoc(), loadMapSegments()]).then(function () {
+                status((state.doc.junctions || []).length + ' junction(s) loaded');
+                setTimeout(function () {
+                    if (state.map) state.map.invalidateSize();
+                }, 100);
+            });
+        });
+    }
+
+    window.initJunctionsAuthoring = initJunctionsAuthoring;
+    window.junctionsAuthoring = {
+        isDirty: function () { return !!state.dirty; },
+        saveAll: saveAll,
+    };
+})();

--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -39,6 +39,7 @@
     function getTab() {
         const raw = getQuery().get('tab');
         if (raw === 'runners') return 'runners';
+        if (raw === 'junctions') return 'junctions';
         if (raw === 'legs') return 'course'; // Legs moved to global hub
         return 'course';
     }
@@ -305,6 +306,19 @@
         return window.configPackageCourse && window.configPackageCourse.isDirty();
     }
 
+    function isJunctionsDirty() {
+        return !!(window.junctionsAuthoring && window.junctionsAuthoring.isDirty());
+    }
+
+    /** Confirm before leaving Junctions with unsaved edits (does not auto-save). */
+    function confirmLeaveDirtyJunctions() {
+        if (!isJunctionsDirty()) return true;
+        return window.confirm(
+            'You have unsaved junction changes. Leave without saving?\n\n' +
+                'Use Save junctions to write junctions.json.'
+        );
+    }
+
     function showWorkspace(manifest, configId) {
         const entry = document.getElementById('race-config-entry');
         const workspace = document.getElementById('race-config-workspace');
@@ -357,13 +371,18 @@
             btn.setAttribute('aria-selected', isActive ? 'true' : 'false');
         });
         const workspacePanel = document.getElementById('race-config-tab-workspace');
+        const junctionsPanel = document.getElementById('race-config-tab-junctions');
         const runnersPanel = document.getElementById('race-config-tab-runners');
         const isWorkspace = tab === 'course';
         if (workspacePanel) workspacePanel.style.display = isWorkspace ? 'block' : 'none';
+        if (junctionsPanel) junctionsPanel.style.display = tab === 'junctions' ? 'block' : 'none';
         if (runnersPanel) runnersPanel.style.display = tab === 'runners' ? 'block' : 'none';
         syncConfigPackagePanels(tab);
         if (tab === 'runners' && window.initRunnersBaseline) {
             window.initRunnersBaseline();
+        }
+        if (tab === 'junctions' && window.initJunctionsAuthoring) {
+            window.initJunctionsAuthoring();
         }
     }
 
@@ -881,6 +900,7 @@
                 if (!cid || !tab) return;
                 if (tab === getTab()) return;
                 e.preventDefault();
+                if (getTab() === 'junctions' && !confirmLeaveDirtyJunctions()) return;
                 if (isPackageWorkspaceDirty() && window.configPackageCourse && window.configPackageCourse.saveAll) {
                     window.configPackageCourse
                         .saveAll()

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -279,6 +279,7 @@
             </div>
             <nav class="subnav-tabs" role="tablist" aria-label="Package authoring">
                 <button type="button" class="subnav-tab active" data-tab="course" role="tab" aria-selected="true">Courses</button>
+                <button type="button" class="subnav-tab" data-tab="junctions" role="tab" aria-selected="false">Junctions</button>
                 <button type="button" class="subnav-tab" data-tab="runners" role="tab" aria-selected="false">Runners</button>
             </nav>
         </div>
@@ -286,6 +287,10 @@
         <div class="tab-panel-card content-card">
             <div id="race-config-tab-workspace" role="tabpanel">
                 {% include 'partials/course_mapping_workspace.html' %}
+            </div>
+
+            <div id="race-config-tab-junctions" role="tabpanel" style="display: none;">
+                {% include 'partials/junctions_workspace.html' %}
             </div>
 
             <div id="race-config-tab-runners" role="tabpanel" style="display: none;">
@@ -316,5 +321,6 @@
 <script src="/static/js/map/segment_recipes.js?v=810-onepage-close"></script>
 <script src="/static/js/map/saved_courses.js?v=791p2"></script>
 <script src="/static/js/runners_baseline.js?v=756k"></script>
-<script src="/static/js/race_configuration.js?v=791p2"></script>
+<script src="/static/js/map/junctions_authoring.js?v=817m"></script>
+<script src="/static/js/race_configuration.js?v=817f"></script>
 {% endblock %}

--- a/frontend/templates/partials/junctions_workspace.html
+++ b/frontend/templates/partials/junctions_workspace.html
@@ -1,0 +1,126 @@
+{# Issue #817: Junction Flow authoring (package-scoped) #}
+<style>
+.junctions-field { display: flex; flex-direction: column; gap: 0.25rem; }
+.junctions-field-label { font-size: 0.75rem; color: #666; font-weight: 600; letter-spacing: 0.02em; }
+#junctions-segments-table th,
+#junctions-segments-table td,
+#junctions-ix-table th,
+#junctions-ix-table td {
+    padding: 0.35rem 0.5rem;
+    text-align: left;
+    vertical-align: middle;
+}
+#junctions-segments-table td.junctions-row-second-pass { background: rgba(240, 173, 78, 0.2); }
+#junctions-segments-table tr.junctions-row-second-pass td { background: rgba(240, 173, 78, 0.2); }
+#junctions-segments-table tr.junctions-row-spur td { background: rgba(91, 192, 222, 0.2); }
+#junctions-ix-table td.course-map-action-cell {
+    text-align: center;
+    white-space: nowrap;
+    width: 5.5rem;
+}
+</style>
+<div id="junctions-authoring-root" class="junctions-authoring">
+    <div class="junctions-toolbar" style="display:flex; flex-wrap:wrap; gap:0.75rem; align-items:center; margin-bottom:1rem;">
+        <h3 style="margin:0; flex:1 1 auto;">Junctions</h3>
+        <button type="button" id="junctions-btn-new" class="course-btn primary">New junction</button>
+        <button type="button" id="junctions-btn-save" class="course-btn">Save junctions</button>
+        <span id="junctions-status" class="text-secondary" style="font-size:0.875rem;"></span>
+    </div>
+    <p style="margin:0 0 1rem; color:#666; font-size:0.9rem; max-width:48rem;">
+        Place a pin on the courses map. Segments whose <strong>start or end</strong> is within
+        <span id="junctions-proximity-label">10</span>&nbsp;m are listed. Author stream interactions
+        (cross / merge) between streams at the pin. Requires course segments from recipes.
+    </p>
+
+    <div id="junctions-gate" class="placeholder" style="display:none; padding:1rem; border:1px solid #e0e0e0; border-radius:4px;">
+        Build race exports / apply recipes so this package has course segments before authoring junctions.
+    </div>
+
+    <div id="junctions-workspace" style="display:none;">
+        <div style="display:grid; grid-template-columns: minmax(12rem, 16rem) 1fr; gap:1rem; margin-bottom:1rem;">
+            <div>
+                <h4 class="card-title" style="margin:0 0 0.5rem;">Saved</h4>
+                <ul id="junctions-list" style="list-style:none; margin:0; padding:0; border:1px solid #e0e0e0; border-radius:4px; max-height:280px; overflow:auto;"></ul>
+            </div>
+            <div>
+                <div style="display:flex; flex-wrap:wrap; gap:0.75rem; align-items:flex-end; margin-bottom:0.75rem;">
+                    <label style="flex:1 1 12rem;">
+                        <span style="display:block; font-size:0.8rem; color:#666;">Label</span>
+                        <input type="text" id="junction-label" class="config-package-input" style="width:100%;" />
+                    </label>
+                    <label>
+                        <span style="display:block; font-size:0.8rem; color:#666;">Lat</span>
+                        <input type="number" step="any" id="junction-lat" class="config-package-input" style="width:8rem;" />
+                    </label>
+                    <label>
+                        <span style="display:block; font-size:0.8rem; color:#666;">Lon</span>
+                        <input type="number" step="any" id="junction-lon" class="config-package-input" style="width:8rem;" />
+                    </label>
+                    <button type="button" id="junctions-btn-place" class="course-btn">Place pin on map</button>
+                    <button type="button" id="junctions-btn-discover" class="course-btn">Find nearby</button>
+                    <button type="button" id="junctions-btn-delete" class="course-btn" style="color:#c0392b;">Delete</button>
+                </div>
+                <div id="junctions-map" style="height:360px; border:1px solid #e0e0e0; border-radius:4px; background:#f8f9fa;"></div>
+                <p style="margin:0.35rem 0 0; font-size:0.8rem; color:#666;">
+                    Click <strong>Place pin on map</strong> (button highlights), then click the map — including on course lines.
+                    Lat/lon fill automatically; then matching segments load.
+                </p>
+            </div>
+        </div>
+
+        <section class="course-derived-section" style="margin-bottom:1.25rem;">
+            <div class="card-header" style="padding-left:0; padding-right:0;">
+                <h4 class="card-title" style="margin:0;">Segments</h4>
+                <span id="junctions-segments-legend" class="text-secondary" style="font-size:0.8rem;"></span>
+            </div>
+            <div class="scrollable-table-container course-derived-table-scroll">
+                <table id="junctions-segments-table" class="table-sticky-header" style="width:100%; font-size:0.875rem;">
+                    <thead>
+                        <tr id="junctions-segments-thead-row"></tr>
+                    </thead>
+                    <tbody id="junctions-segments-tbody"></tbody>
+                </table>
+            </div>
+            <p style="margin:0.5rem 0 0; font-size:0.8rem; color:#666;">
+                <span style="display:inline-block; width:0.75rem; height:0.75rem; background:#f0ad4e; margin-right:0.25rem;"></span>
+                Full 2nd corridor pass (same geometry, later race km)
+                &nbsp;&nbsp;
+                <span style="display:inline-block; width:0.75rem; height:0.75rem; background:#5bc0de; margin-right:0.25rem;"></span>
+                Spur leave/return (e.g. 10k university)
+            </p>
+        </section>
+
+        <section class="course-derived-section">
+            <div class="card-header" style="padding-left:0; padding-right:0;">
+                <h4 class="card-title" style="margin:0;">Stream Interactions</h4>
+                <div class="card-actions">
+                    <button type="button" id="junctions-btn-add-ix" class="course-btn">Add interaction</button>
+                </div>
+            </div>
+            <div class="scrollable-table-container course-derived-table-scroll">
+                <table id="junctions-ix-table" class="table-sticky-header" style="width:100%; font-size:0.875rem;">
+                    <thead>
+                        <tr>
+                            <th>Type</th>
+                            <th>Turn</th>
+                            <th>From</th>
+                            <th>To</th>
+                            <th>Conflicts with</th>
+                            <th>Events</th>
+                            <th class="rf-table-actions course-map-action-cell">Actions</th>
+                        </tr>
+                    </thead>
+                    <tbody id="junctions-ix-tbody"></tbody>
+                </table>
+            </div>
+            <p style="margin:0.5rem 0 0; font-size:0.8rem; color:#666;">
+                Table is read-only until you edit a row.
+                <strong>Cross:</strong> From → To + Conflicts with.
+                <strong>Merge:</strong> From → one or more To segments (multi-select); Conflicts unused.
+                <strong>Turn:</strong> left/right as the runner turns.
+                <strong>Events:</strong> all events involved in the conflict.
+                Changes stay local until <strong>Save junctions</strong>.
+            </p>
+        </section>
+    </div>
+</div>

--- a/tests/unit/test_junctions_authoring.py
+++ b/tests/unit/test_junctions_authoring.py
@@ -1,0 +1,228 @@
+"""Unit tests for Junction Flow authoring (Issue #817)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.core.config_package.junctions import (
+    find_nearby_segments,
+    load_config_junctions,
+    save_config_junctions,
+    validate_junctions_doc,
+)
+from app.core.config_package.storage import create_config_package, save_config_course
+from app.utils.constants import JUNCTION_SEGMENT_PROXIMITY_M
+
+
+def test_junction_proximity_constant():
+    assert JUNCTION_SEGMENT_PROXIMITY_M == 10.0
+
+
+def test_validate_junctions_cross_and_merge():
+    doc = validate_junctions_doc(
+        {
+            "version": 1,
+            "junctions": [
+                {
+                    "id": "j1",
+                    "label": "George",
+                    "lat": 45.95,
+                    "lon": -66.63,
+                    "nearby_seg_ids": ["S8", "S9", "S11", "S25", "S26", "S22"],
+                    "interactions": [
+                        {
+                            "type": "cross",
+                            "side": "left",
+                            "from_seg_id": "S8",
+                            "to_seg_ids": ["S25"],
+                            "conflicts_with_seg_id": "S11",
+                            "events": ["10k", "full", "half"],
+                        },
+                        {
+                            "type": "merge",
+                            "from_seg_id": "S26",
+                            "to_seg_ids": ["S9", "S22"],
+                            "events": ["10k", "full"],
+                        },
+                    ],
+                }
+            ],
+        }
+    )
+    j = doc["junctions"][0]
+    assert j["interactions"][0]["type"] == "cross"
+    assert j["interactions"][0]["to_seg_ids"] == ["S25"]
+    assert j["interactions"][1]["to_seg_ids"] == ["S9", "S22"]
+    assert j["interactions"][1]["conflicts_with_seg_id"] == ""
+    stream_ids = {s["seg_id"] for s in j["streams"]}
+    assert {"S8", "S9", "S11", "S25", "S26", "S22"} <= stream_ids
+
+
+def test_validate_rejects_cross_without_conflicts():
+    with pytest.raises(ValueError, match="conflicts_with_seg_id"):
+        validate_junctions_doc(
+            {
+                "junctions": [
+                    {
+                        "id": "j1",
+                        "label": "x",
+                        "lat": 1,
+                        "lon": 2,
+                        "interactions": [
+                            {
+                                "type": "cross",
+                                "from_seg_id": "S8",
+                                "to_seg_ids": ["S25"],
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+
+def test_validate_rejects_cross_multi_to():
+    with pytest.raises(ValueError, match="exactly one"):
+        validate_junctions_doc(
+            {
+                "junctions": [
+                    {
+                        "id": "j1",
+                        "label": "x",
+                        "lat": 1,
+                        "lon": 2,
+                        "interactions": [
+                            {
+                                "type": "cross",
+                                "from_seg_id": "S8",
+                                "to_seg_ids": ["S25", "S9"],
+                                "conflicts_with_seg_id": "S11",
+                            }
+                        ],
+                    }
+                ]
+            }
+        )
+
+
+def test_load_save_junctions_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "app.core.config_package.junctions.resolve_config_package_path",
+        lambda config_id: tmp_path / config_id,
+    )
+    pkg = create_config_package(
+        "Junc Test",
+        "",
+        event_day="sun",
+        package_events=["full", "10k"],
+    )
+    cid = pkg["config_id"]
+    empty = load_config_junctions(cid)
+    assert empty["junctions"] == []
+
+    save_config_junctions(
+        cid,
+        {
+            "version": 1,
+            "junctions": [
+                {
+                    "id": "j1",
+                    "label": "Test",
+                    "lat": 45.0,
+                    "lon": -66.0,
+                    "nearby_seg_ids": ["S1"],
+                    "interactions": [],
+                }
+            ],
+        },
+    )
+    loaded = load_config_junctions(cid)
+    assert len(loaded["junctions"]) == 1
+    assert loaded["junctions"][0]["label"] == "Test"
+    assert (tmp_path / cid / "junctions.json").is_file()
+
+
+def _write_two_point_gpx(path: Path, lon0: float, lat0: float, lon1: float, lat1: float) -> None:
+    path.write_text(
+        f"""<?xml version="1.0"?>
+<gpx xmlns="http://www.topografix.com/GPX/1/1">
+  <trk><trkseg>
+    <trkpt lat="{lat0}" lon="{lon0}"/>
+    <trkpt lat="{lat1}" lon="{lon1}"/>
+  </trkseg></trk>
+</gpx>
+""",
+        encoding="utf-8",
+    )
+
+
+def test_find_nearby_segments_uses_endpoints(tmp_path, monkeypatch):
+    """Synthetic course + GPX: only endpoint-near segments are returned."""
+    monkeypatch.setattr(
+        "app.core.config_package.storage.get_config_root",
+        lambda: tmp_path,
+    )
+    monkeypatch.setattr(
+        "app.core.config_package.junctions.resolve_leg_library",
+        lambda config_id: (
+            tmp_path / config_id / "legs",
+            {
+                "legs": [
+                    {"id": "01", "file": "01.gpx", "seg_label": "Near"},
+                    {"id": "02", "file": "02.gpx", "seg_label": "Far"},
+                ]
+            },
+            "package",
+            {"recipes": {}},
+        ),
+    )
+
+    pkg = create_config_package(
+        "Nearby",
+        "",
+        event_day="sun",
+        package_events=["full"],
+    )
+    cid = pkg["config_id"]
+    legs_dir = tmp_path / cid / "legs"
+    legs_dir.mkdir(parents=True, exist_ok=True)
+
+    # Pin at (0,0); near leg ends at origin; far leg is ~1km away
+    _write_two_point_gpx(legs_dir / "01.gpx", -0.00005, 0.0, 0.0, 0.0)
+    _write_two_point_gpx(legs_dir / "02.gpx", 0.01, 0.01, 0.011, 0.011)
+
+    course = {
+        "segments": [
+            {
+                "seg_id": "S1",
+                "seg_label": "Near",
+                "leg_id": "01",
+                "events": ["full"],
+                "full_from_km": 0.0,
+                "full_to_km": 0.1,
+                "length_km": 0.1,
+            },
+            {
+                "seg_id": "S2",
+                "seg_label": "Far",
+                "leg_id": "02",
+                "events": ["full"],
+                "full_from_km": 1.0,
+                "full_to_km": 1.2,
+                "length_km": 0.2,
+            },
+        ]
+    }
+    save_config_course(cid, course)
+
+    nearby = find_nearby_segments(cid, 0.0, 0.0, radius_m=10.0)
+    ids = [r["seg_id"] for r in nearby]
+    assert ids == ["S1"]
+    assert nearby[0]["near_endpoint"] in ("start", "end", "both")


### PR DESCRIPTION
## Summary
- Adds package-root `junctions.json` authoring (independent of Locations/Segments) with GET/PUT + nearby discovery + map-segments APIs
- Package Build **Junctions** tab: pin placement, Segments table (endpoint proximity), Stream Interactions (cross/merge) with read-only/edit rows
- Pilot package validated with three junctions (Trail at George, Barker, Friel) and declared stream interactions
- Analysis/compute remains **#818**

## Test plan
- [x] `pytest tests/unit/test_junctions_authoring.py` (6 passed)
- [ ] Open Build → Junctions on a package with course segments
- [ ] Place pin at a segment meeting (e.g. Friel); confirm nearby segments load
- [ ] Author cross/merge Stream Interactions; Save junctions; reload tab and confirm persistence
- [ ] New junction clears canvas; switching saved junctions loads only that junction’s data
- [ ] Unsaved edits warn when leaving the Junctions tab / closing the browser


Made with [Cursor](https://cursor.com)