### PR TITLE
Junction Flow analysis: core pipeline + Results page (#818)

### DIFF
--- a/app/api/junctions.py
+++ b/app/api/junctions.py
@@ -1,0 +1,73 @@
+"""
+API routes for Junction Flow results (Issue #818).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional
+
+from fastapi import APIRouter, Query
+from fastapi.responses import JSONResponse
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+@router.get("/api/junctions")
+async def get_junctions(
+    run_id: Optional[str] = Query(None, description="Run ID (defaults to latest)"),
+    day: Optional[str] = Query(None, description="Day code (fri|sat|sun|mon)"),
+):
+    """
+    Load Junction Flow UI metrics for a run/day.
+
+    SSOT: ``{day}/ui/metrics/junctions.json`` (written in Phase 6.4).
+    """
+    try:
+        from app.storage import create_runflow_storage
+        from app.utils.run_id import get_latest_run_id, resolve_selected_day
+
+        if not run_id:
+            run_id = get_latest_run_id()
+        selected_day, available_days = resolve_selected_day(run_id, day)
+        storage = create_runflow_storage(run_id)
+
+        try:
+            raw = storage.read_text(f"{selected_day}/ui/metrics/junctions.json")
+            if not raw:
+                payload: Dict[str, Any] = {"ok": True, "method": {}, "junctions": []}
+            else:
+                payload = json.loads(raw)
+        except FileNotFoundError:
+            logger.warning(
+                "junctions.json UI metrics missing for run=%s day=%s",
+                run_id,
+                selected_day,
+            )
+            payload = {
+                "ok": True,
+                "method": {},
+                "junctions": [],
+                "notes": ["Junction Flow artifact not found for this run/day."],
+            }
+        except Exception as e:
+            logger.error("Failed to load junctions UI metrics: %s", e)
+            payload = {"ok": False, "method": {}, "junctions": [], "error": str(e)}
+
+        return JSONResponse(
+            content={
+                "selected_day": selected_day,
+                "available_days": available_days,
+                "run_id": run_id,
+                **payload,
+            }
+        )
+    except Exception as e:
+        logger.exception("get_junctions failed")
+        return JSONResponse(
+            status_code=500,
+            content={"ok": False, "error": str(e), "junctions": []},
+        )

--- a/app/core/junction_flow/__init__.py
+++ b/app/core/junction_flow/__init__.py
@@ -1,0 +1,25 @@
+"""Junction Flow analysis (Issue #818)."""
+
+from app.core.junction_flow.compute import (
+    MERGE_PARTNER_EVENTS,
+    NODE_DWELL_SEC,
+    InteractionResult,
+    analyze_interaction,
+    analyze_junction,
+    analyze_junctions_doc,
+    interaction_to_dict,
+    prepare_runners_by_event,
+    result_to_ui_payload,
+)
+
+__all__ = [
+    "MERGE_PARTNER_EVENTS",
+    "NODE_DWELL_SEC",
+    "InteractionResult",
+    "analyze_interaction",
+    "analyze_junction",
+    "analyze_junctions_doc",
+    "interaction_to_dict",
+    "prepare_runners_by_event",
+    "result_to_ui_payload",
+]

--- a/app/core/junction_flow/compute.py
+++ b/app/core/junction_flow/compute.py
@@ -1,0 +1,843 @@
+"""
+Junction Flow compute (Issue #818).
+
+Constant-pace presence at junction nodes with dwell co-presence gating.
+Merge partners are full/half on To streams only.
+"""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+NODE_DWELL_SEC = 30.0
+MERGE_PARTNER_EVENTS = ("full", "half")
+
+
+@dataclass
+class StreamPresence:
+    role: str  # crossing | crossed | joining | through
+    seg_id: str
+    event: str
+    runner_ids: np.ndarray
+    node_times_sec: np.ndarray  # instant at junction node
+    paces: np.ndarray
+    quintiles: np.ndarray  # 1=lead (fast) .. 5=rear (slow) within event
+
+
+@dataclass
+class InteractionResult:
+    interaction_id: str
+    type: str
+    side: str
+    label: str
+    events: List[str]
+    window_start_hhmm: str
+    window_end_hhmm: str
+    window_minutes: float
+    unique_by_role_event: Dict[str, Dict[str, int]]
+    peak_concurrent: Dict[str, int]
+    field_crosstab: List[Dict[str, Any]]
+    minute_rows: List[Dict[str, Any]]
+    notes: List[str] = field(default_factory=list)
+
+
+def _hhmm(seconds: float) -> str:
+    minutes = int(max(0, seconds) // 60)
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def _load_runners(package_dir: Path, event: str) -> pd.DataFrame:
+    path = package_dir / f"{event}_runners.csv"
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    df = pd.read_csv(path)
+    df["event"] = event
+    df["pace"] = pd.to_numeric(df["pace"], errors="coerce")
+    df["start_offset"] = pd.to_numeric(df["start_offset"], errors="coerce").fillna(0.0)
+    df = df.dropna(subset=["pace", "runner_id"])
+    df = df[df["pace"] > 0].copy()
+    # Q1 = lead (fastest / lowest pace), Q5 = rear
+    try:
+        df["quintile"] = pd.qcut(
+            df["pace"], 5, labels=[1, 2, 3, 4, 5], duplicates="drop"
+        )
+        df["quintile"] = df["quintile"].astype(int)
+    except ValueError:
+        # Too few distinct paces — rank into up to 5 bins
+        ranks = df["pace"].rank(method="first")
+        df["quintile"] = pd.qcut(ranks, min(5, len(df)), labels=False) + 1
+        df["quintile"] = df["quintile"].astype(int)
+    return df
+
+
+def _node_km_for_segment(
+    nearby_by_id: Dict[str, Dict[str, Any]],
+    seg_id: str,
+    event: str,
+) -> Optional[float]:
+    """Km along the event course at the junction endpoint of this segment."""
+    row = nearby_by_id.get(seg_id) or {}
+    ek = (row.get("event_kms") or {}).get(event) or {}
+    near = str(row.get("near_endpoint") or "")
+    if near in ("end", "both") and ek.get("to_km") is not None:
+        return float(ek["to_km"])
+    if near in ("start", "both") and ek.get("from_km") is not None:
+        return float(ek["from_km"])
+    # Fallback: prefer to_km then from_km
+    if ek.get("to_km") is not None:
+        return float(ek["to_km"])
+    if ek.get("from_km") is not None:
+        return float(ek["from_km"])
+    return None
+
+
+def _presence_at_node(
+    runners: pd.DataFrame,
+    gun_min: float,
+    node_km: float,
+    role: str,
+    seg_id: str,
+    event: str,
+) -> StreamPresence:
+    pace_sec = runners["pace"].to_numpy(dtype=float) * 60.0
+    offset = runners["start_offset"].to_numpy(dtype=float)
+    t0 = float(gun_min) * 60.0
+    node_times = t0 + offset + pace_sec * float(node_km)
+    return StreamPresence(
+        role=role,
+        seg_id=seg_id,
+        event=event,
+        runner_ids=runners["runner_id"].astype(str).to_numpy(),
+        node_times_sec=node_times,
+        paces=runners["pace"].to_numpy(dtype=float),
+        quintiles=runners["quintile"].to_numpy(dtype=int),
+    )
+
+
+def _minute_metrics(
+    node_times: np.ndarray,
+    start_sec: float,
+    end_sec: float,
+    dwell_sec: float = NODE_DWELL_SEC,
+) -> Tuple[List[float], List[Dict[str, int]]]:
+    """
+    Treat each runner as present for dwell_sec centered on node transit.
+    Entries = arrivals in minute; exits = departures; concurrent ≈ present.
+    """
+    if node_times.size == 0:
+        return [], []
+    entry = node_times - dwell_sec / 2.0
+    exit_ = node_times + dwell_sec / 2.0
+    entry_sorted = np.sort(entry)
+    exit_sorted = np.sort(exit_)
+    start_floor = int(math.floor(start_sec / 60.0) * 60)
+    end_ceil = int(math.ceil(end_sec / 60.0) * 60)
+    if end_ceil <= start_floor:
+        return [], []
+    minute_starts = list(range(start_floor, end_ceil, 60))
+    out: List[Dict[str, int]] = []
+    for ms in minute_starts:
+        me = ms + 60
+        entries = int(
+            np.searchsorted(entry_sorted, me, side="left")
+            - np.searchsorted(entry_sorted, ms, side="left")
+        )
+        exits = int(
+            np.searchsorted(exit_sorted, me, side="left")
+            - np.searchsorted(exit_sorted, ms, side="left")
+        )
+        concurrent = int(
+            np.searchsorted(entry_sorted, me, side="left")
+            - np.searchsorted(exit_sorted, ms, side="left")
+        )
+        out.append({"concurrent": concurrent, "entries": entries, "exits": exits})
+    return [float(s) for s in minute_starts], out
+
+
+def _combine_presences(parts: Sequence[StreamPresence]) -> StreamPresence:
+    if not parts:
+        raise ValueError("no stream parts to combine")
+    return StreamPresence(
+        role=parts[0].role,
+        seg_id=",".join(sorted({p.seg_id for p in parts})),
+        event=",".join(sorted({p.event for p in parts})),
+        runner_ids=np.concatenate([p.runner_ids for p in parts]),
+        node_times_sec=np.concatenate([p.node_times_sec for p in parts]),
+        paces=np.concatenate([p.paces for p in parts]),
+        quintiles=np.concatenate([p.quintiles for p in parts]),
+    )
+
+
+def _unique_in_window(p: StreamPresence, start_sec: float, end_sec: float) -> int:
+    mask = (p.node_times_sec >= start_sec) & (p.node_times_sec <= end_sec)
+    return int(np.unique(p.runner_ids[mask]).size)
+
+
+def _nearest_partner_dt(
+    t: float,
+    partner_times_sorted: np.ndarray,
+) -> Optional[float]:
+    if partner_times_sorted.size == 0:
+        return None
+    idx = int(np.searchsorted(partner_times_sorted, t, side="left"))
+    best_dt: Optional[float] = None
+    for j in (idx - 1, idx):
+        if 0 <= j < partner_times_sorted.size:
+            dt = abs(float(partner_times_sorted[j] - t))
+            if best_dt is None or dt < best_dt:
+                best_dt = dt
+    return best_dt
+
+
+def _unique_with_copresence(
+    primary: StreamPresence,
+    partner: StreamPresence,
+    start_sec: float,
+    end_sec: float,
+    dwell_sec: float = NODE_DWELL_SEC,
+) -> Dict[str, int]:
+    """
+    Per-runner co-presence at the node.
+
+    A primary runner counts as "with_partner" only if some partner runner's
+    node transit is within dwell_sec of theirs (not merely in the same window).
+    """
+    p_mask = (primary.node_times_sec >= start_sec) & (primary.node_times_sec <= end_sec)
+    partner_mask = (partner.node_times_sec >= start_sec - dwell_sec) & (
+        partner.node_times_sec <= end_sec + dwell_sec
+    )
+    p_t = primary.node_times_sec[p_mask]
+    p_id = primary.runner_ids[p_mask].astype(str)
+    partner_t = np.sort(partner.node_times_sec[partner_mask])
+    with_ids: set = set()
+    without_ids: set = set()
+    for i in range(p_t.size):
+        rid = str(p_id[i])
+        if rid in with_ids:
+            continue
+        dt = _nearest_partner_dt(float(p_t[i]), partner_t)
+        if dt is not None and dt <= dwell_sec:
+            with_ids.add(rid)
+            without_ids.discard(rid)
+        elif rid not in with_ids:
+            without_ids.add(rid)
+    return {
+        "in_window": len(with_ids | without_ids),
+        "with_partner": len(with_ids),
+        "without_partner": len(without_ids - with_ids),
+    }
+
+
+def _filter_presence_events(
+    parts: Sequence[StreamPresence], events: Sequence[str]
+) -> List[StreamPresence]:
+    wanted = {str(e).lower() for e in events}
+    return [p for p in parts if str(p.event).lower() in wanted]
+
+
+def _by_event_combined(
+    parts: Sequence[StreamPresence],
+) -> Dict[str, StreamPresence]:
+    buckets: Dict[str, List[StreamPresence]] = {}
+    for p in parts:
+        buckets.setdefault(str(p.event).lower(), []).append(p)
+    return {
+        event: parts_e[0] if len(parts_e) == 1 else _combine_presences(parts_e)
+        for event, parts_e in buckets.items()
+    }
+
+
+def _crosstab(
+    a: StreamPresence,
+    b: StreamPresence,
+    start_sec: float,
+    end_sec: float,
+    dwell_sec: float = NODE_DWELL_SEC,
+) -> List[Dict[str, Any]]:
+    """
+    Concurrent-participation crosstab by quintile:
+    count unique A runners whose node time overlaps (±dwell/2) with some B runner,
+    bucketed by (A quintile, B quintile of a concurrent partner).
+    Simplified: for each A in window, find if any B within dwell of A's time;
+    use nearest B's quintile.
+    """
+    a_mask = (a.node_times_sec >= start_sec) & (a.node_times_sec <= end_sec)
+    b_mask = (b.node_times_sec >= start_sec - dwell_sec) & (
+        b.node_times_sec <= end_sec + dwell_sec
+    )
+    a_t = a.node_times_sec[a_mask]
+    a_q = a.quintiles[a_mask]
+    a_id = a.runner_ids[a_mask]
+    b_t = b.node_times_sec[b_mask]
+    b_q = b.quintiles[b_mask]
+    if a_t.size == 0 or b_t.size == 0:
+        return []
+    order = np.argsort(b_t)
+    b_t_s = b_t[order]
+    b_q_s = b_q[order]
+    counts: Dict[Tuple[int, int], set] = {}
+    seen_a: set = set()
+    for i in range(a_t.size):
+        rid = str(a_id[i])
+        if rid in seen_a:
+            continue
+        idx = int(np.searchsorted(b_t_s, a_t[i], side="left"))
+        candidates = []
+        if idx < b_t_s.size:
+            candidates.append(idx)
+        if idx > 0:
+            candidates.append(idx - 1)
+        best = None
+        best_dt = None
+        for j in candidates:
+            dt = abs(float(b_t_s[j] - a_t[i]))
+            if best_dt is None or dt < best_dt:
+                best_dt = dt
+                best = j
+        if best is None or best_dt is None or best_dt > dwell_sec:
+            continue
+        seen_a.add(rid)
+        key = (int(a_q[i]), int(b_q_s[best]))
+        counts.setdefault(key, set()).add(rid)
+    rows = []
+    for (qa, qb), ids in sorted(counts.items()):
+        rows.append(
+            {
+                "crossing_or_joining_quintile": qa,
+                "crossed_or_through_quintile": qb,
+                "unique_crossing_or_joining_runners": len(ids),
+            }
+        )
+    return rows
+
+
+def _analyze_pair(
+    *,
+    ix: Dict[str, Any],
+    primary: StreamPresence,
+    secondary: StreamPresence,
+    primary_label: str,
+    secondary_label: str,
+    notes: List[str],
+) -> InteractionResult:
+    if primary.node_times_sec.size == 0 or secondary.node_times_sec.size == 0:
+        return InteractionResult(
+            interaction_id=str(ix.get("id") or ""),
+            type=str(ix.get("type") or ""),
+            side=str(ix.get("side") or ""),
+            label=f"{primary_label} vs {secondary_label}",
+            events=list(ix.get("events") or []),
+            window_start_hhmm="—",
+            window_end_hhmm="—",
+            window_minutes=0.0,
+            unique_by_role_event={},
+            peak_concurrent={},
+            field_crosstab=[],
+            minute_rows=[],
+            notes=notes + ["No runners on one or both streams for scoped events."],
+        )
+
+    t0 = float(min(primary.node_times_sec.min(), secondary.node_times_sec.min()))
+    t1 = float(max(primary.node_times_sec.max(), secondary.node_times_sec.max()))
+    m_pri, met_pri = _minute_metrics(primary.node_times_sec, t0, t1)
+    m_sec, met_sec = _minute_metrics(secondary.node_times_sec, t0, t1)
+    # Align on primary minutes (same grid)
+    concurrent_both = []
+    minute_rows = []
+    for i, ms in enumerate(m_pri):
+        ca = met_pri[i]["concurrent"]
+        cb = met_sec[i]["concurrent"] if i < len(met_sec) else 0
+        concurrent_both.append(ca > 0 and cb > 0)
+        minute_rows.append(
+            {
+                "minute_start": _hhmm(ms),
+                "minute_end": _hhmm(ms + 60),
+                f"{primary_label}_count": ca,
+                f"{primary_label}_entries": met_pri[i]["entries"],
+                f"{primary_label}_exits": met_pri[i]["exits"],
+                f"{secondary_label}_count": cb,
+                f"{secondary_label}_entries": met_sec[i]["entries"] if i < len(met_sec) else 0,
+                f"{secondary_label}_exits": met_sec[i]["exits"] if i < len(met_sec) else 0,
+                "both_present": bool(ca > 0 and cb > 0),
+            }
+        )
+
+    if any(concurrent_both):
+        idxs = [i for i, v in enumerate(concurrent_both) if v]
+        w0 = m_pri[idxs[0]]
+        w1 = m_pri[idxs[-1]] + 60
+    else:
+        w0, w1 = t0, t1
+        notes.append("No minute with both streams concurrent; window falls back to full span.")
+
+    # Unique by role × event
+    unique: Dict[str, Dict[str, int]] = {primary_label: {}, secondary_label: {}}
+    for p, label in ((primary, primary_label), (secondary, secondary_label)):
+        # split combined events if needed
+        mask = (p.node_times_sec >= w0) & (p.node_times_sec <= w1)
+        # event field may be comma-joined when combined; regroup via runner list sizes per building
+        unique[label]["all"] = int(np.unique(p.runner_ids[mask]).size)
+
+    # Per-event unique: recompute from parts stored in notes? Simpler: parse from building below in caller.
+    peak = {
+        primary_label: max(
+            (r[f"{primary_label}_count"] for r in minute_rows if r["both_present"]),
+            default=0,
+        ),
+        secondary_label: max(
+            (r[f"{secondary_label}_count"] for r in minute_rows if r["both_present"]),
+            default=0,
+        ),
+    }
+
+    return InteractionResult(
+        interaction_id=str(ix.get("id") or ""),
+        type=str(ix.get("type") or ""),
+        side=str(ix.get("side") or ""),
+        label=f"{primary_label} vs {secondary_label}",
+        events=list(ix.get("events") or []),
+        window_start_hhmm=_hhmm(w0),
+        window_end_hhmm=_hhmm(w1),
+        window_minutes=max(0.0, (w1 - w0) / 60.0),
+        unique_by_role_event=unique,
+        peak_concurrent=peak,
+        field_crosstab=_crosstab(primary, secondary, w0, w1),
+        minute_rows=minute_rows,
+        notes=notes,
+    )
+
+
+def build_stream_parts(
+    *,
+    seg_id: str,
+    role: str,
+    events: Sequence[str],
+    nearby_by_id: Dict[str, Dict[str, Any]],
+    runners_by_event: Dict[str, pd.DataFrame],
+    gun_by_event: Dict[str, float],
+) -> Tuple[List[StreamPresence], List[str]]:
+    parts: List[StreamPresence] = []
+    notes: List[str] = []
+    for event in events:
+        if event not in runners_by_event:
+            notes.append(f"No runners file for event={event}")
+            continue
+        node_km = _node_km_for_segment(nearby_by_id, seg_id, event)
+        if node_km is None:
+            notes.append(f"No node km for {seg_id}/{event}")
+            continue
+        # Only include runners whose event uses this segment (event_kms present)
+        row = nearby_by_id.get(seg_id) or {}
+        if event not in (row.get("event_kms") or {}):
+            notes.append(f"{seg_id} not on event={event}; skipped")
+            continue
+        parts.append(
+            _presence_at_node(
+                runners_by_event[event],
+                gun_by_event[event],
+                node_km,
+                role,
+                seg_id,
+                event,
+            )
+        )
+    return parts, notes
+
+
+def analyze_interaction(
+    ix: Dict[str, Any],
+    nearby_by_id: Dict[str, Dict[str, Any]],
+    runners_by_event: Dict[str, pd.DataFrame],
+    gun_by_event: Dict[str, float],
+) -> InteractionResult:
+    events = [str(e).lower() for e in (ix.get("events") or [])]
+    itype = str(ix.get("type") or "").lower()
+    notes: List[str] = []
+
+    if itype == "cross":
+        from_seg = str(ix.get("from_seg_id") or "")
+        to_seg = (ix.get("to_seg_ids") or [None])[0]
+        conflicts = str(ix.get("conflicts_with_seg_id") or "")
+        # Crossing stream: runners who use From (at node). Path To is used to
+        # identify the turning stream events (intersection with To's events).
+        crossing_events = []
+        for e in events:
+            from_km = _node_km_for_segment(nearby_by_id, from_seg, e)
+            to_km = _node_km_for_segment(nearby_by_id, str(to_seg), e)
+            if from_km is not None and to_km is not None:
+                crossing_events.append(e)
+        if not crossing_events:
+            crossing_events = events
+            notes.append("Could not refine crossing events via From∩To; using interaction events.")
+
+        crossed_events = []
+        for e in events:
+            if _node_km_for_segment(nearby_by_id, conflicts, e) is not None:
+                crossed_events.append(e)
+        if not crossed_events:
+            crossed_events = events
+            notes.append("Conflicts stream missing for some events; using interaction events.")
+
+        pri_parts, n1 = build_stream_parts(
+            seg_id=from_seg,
+            role="crossing",
+            events=crossing_events,
+            nearby_by_id=nearby_by_id,
+            runners_by_event=runners_by_event,
+            gun_by_event=gun_by_event,
+        )
+        sec_parts, n2 = build_stream_parts(
+            seg_id=conflicts,
+            role="crossed",
+            events=crossed_events,
+            nearby_by_id=nearby_by_id,
+            runners_by_event=runners_by_event,
+            gun_by_event=gun_by_event,
+        )
+        notes.extend(n1 + n2)
+        # Annotate To for mapping
+        notes.append(f"Cross path {from_seg}→{to_seg} conflicts {conflicts}; side={ix.get('side')}")
+        for e in crossing_events:
+            notes.append(
+                f"map crossing {e}: {from_seg}@{_node_km_for_segment(nearby_by_id, from_seg, e)}km "
+                f"→ {to_seg}@{_node_km_for_segment(nearby_by_id, str(to_seg), e)}km"
+            )
+        for e in crossed_events:
+            notes.append(
+                f"map crossed {e}: {conflicts}@{_node_km_for_segment(nearby_by_id, conflicts, e)}km"
+            )
+
+        if not pri_parts or not sec_parts:
+            return InteractionResult(
+                interaction_id=str(ix.get("id") or ""),
+                type="cross",
+                side=str(ix.get("side") or ""),
+                label=f"{from_seg}→{to_seg} vs {conflicts}",
+                events=events,
+                window_start_hhmm="—",
+                window_end_hhmm="—",
+                window_minutes=0.0,
+                unique_by_role_event={},
+                peak_concurrent={},
+                field_crosstab=[],
+                minute_rows=[],
+                notes=notes,
+            )
+
+        primary = _combine_presences(pri_parts)
+        secondary = _combine_presences(sec_parts)
+        # Concurrent minutes + peaks use full streams; unique counts require
+        # per-runner dwell co-presence (same gate as merge).
+        result = _analyze_pair(
+            ix=ix,
+            primary=primary,
+            secondary=secondary,
+            primary_label="crossing",
+            secondary_label="crossed",
+            notes=notes,
+        )
+
+        def _parse_hhmm(s: str) -> float:
+            if not s or s == "—":
+                return 0.0
+            hh, mm = s.split(":")
+            return int(hh) * 3600 + int(mm) * 60
+
+        w0 = _parse_hhmm(result.window_start_hhmm)
+        w1 = _parse_hhmm(result.window_end_hhmm)
+        crossing_cp = _unique_with_copresence(primary, secondary, w0, w1)
+        crossed_cp = _unique_with_copresence(secondary, primary, w0, w1)
+        notes.append(
+            "Cross uniques gated by dwell co-presence at node "
+            f"(±{int(NODE_DWELL_SEC) // 2}s); window-only counts kept for comparison."
+        )
+        result.notes = notes
+        result.unique_by_role_event = {
+            "crossing_in_window": {
+                event: _unique_in_window(p, w0, w1)
+                for event, p in _by_event_combined(pri_parts).items()
+            },
+            "crossed_in_window": {
+                event: _unique_in_window(p, w0, w1)
+                for event, p in _by_event_combined(sec_parts).items()
+            },
+            "crossing_with_copresence": {
+                "all": crossing_cp["with_partner"],
+                **{
+                    event: _unique_with_copresence(p, secondary, w0, w1)["with_partner"]
+                    for event, p in _by_event_combined(pri_parts).items()
+                },
+            },
+            "crossing_without_copresence": {"all": crossing_cp["without_partner"]},
+            "crossed_with_copresence": {
+                "all": crossed_cp["with_partner"],
+                **{
+                    event: _unique_with_copresence(p, primary, w0, w1)["with_partner"]
+                    for event, p in _by_event_combined(sec_parts).items()
+                },
+            },
+            "crossed_without_copresence": {"all": crossed_cp["without_partner"]},
+        }
+        result.field_crosstab = _crosstab(primary, secondary, w0, w1)
+        result.label = f"{from_seg}→{to_seg} vs {conflicts}"
+        return result
+
+    # merge
+    from_seg = str(ix.get("from_seg_id") or "")
+    to_segs = [str(s) for s in (ix.get("to_seg_ids") or [])]
+    join_parts, n1 = build_stream_parts(
+        seg_id=from_seg,
+        role="joining",
+        events=events,
+        nearby_by_id=nearby_by_id,
+        runners_by_event=runners_by_event,
+        gun_by_event=gun_by_event,
+    )
+    through_parts: List[StreamPresence] = []
+    notes.extend(n1)
+    notes.append(
+        "Merge is junction-level: through stream unions all To segments; "
+        "each To keeps event km/time for map/context."
+    )
+    # A merge "counts" only when a full/half runner is at the node with the
+    # joining runner — not merely because full/half use S9/S22 sometime.
+    merge_partner_events = MERGE_PARTNER_EVENTS
+    notes.append(
+        "Merge co-presence partners = full/half at To node within dwell; "
+        "same-event through (e.g. 10k already on trail) does not count."
+    )
+    for to_seg in to_segs:
+        parts, n = build_stream_parts(
+            seg_id=to_seg,
+            role="through",
+            events=events,
+            nearby_by_id=nearby_by_id,
+            runners_by_event=runners_by_event,
+            gun_by_event=gun_by_event,
+        )
+        notes.extend(n)
+        through_parts.extend(parts)
+        for e in events:
+            km = _node_km_for_segment(nearby_by_id, to_seg, e)
+            if km is not None:
+                notes.append(f"map through {to_seg}/{e} @ {km} km")
+
+    partner_parts = _filter_presence_events(through_parts, merge_partner_events)
+    if not join_parts or not partner_parts:
+        return InteractionResult(
+            interaction_id=str(ix.get("id") or ""),
+            type="merge",
+            side=str(ix.get("side") or ""),
+            label=f"{from_seg}→{','.join(to_segs)}",
+            events=events,
+            window_start_hhmm="—",
+            window_end_hhmm="—",
+            window_minutes=0.0,
+            unique_by_role_event={},
+            peak_concurrent={},
+            field_crosstab=[],
+            minute_rows=[],
+            notes=notes
+            + (
+                ["No full/half through presence at To streams."]
+                if join_parts and not partner_parts
+                else []
+            ),
+        )
+
+    primary = _combine_presences(join_parts)
+    # Minute concurrency / involvement window vs full+half partners only
+    secondary = _combine_presences(partner_parts)
+    result = _analyze_pair(
+        ix=ix,
+        primary=primary,
+        secondary=secondary,
+        primary_label="joining",
+        secondary_label="through_full_half",
+        notes=notes,
+    )
+
+    def _parse_hhmm(s: str) -> float:
+        if not s or s == "—":
+            return 0.0
+        hh, mm = s.split(":")
+        return int(hh) * 3600 + int(mm) * 60
+
+    w0 = _parse_hhmm(result.window_start_hhmm)
+    w1 = _parse_hhmm(result.window_end_hhmm)
+    joining_cp = _unique_with_copresence(primary, secondary, w0, w1)
+    partner_cp = _unique_with_copresence(secondary, primary, w0, w1)
+
+    # Through uniques (window) for context — all To events, deduped
+    through_ids = set()
+    through_by_event: Dict[str, set] = {}
+    for p in through_parts:
+        mask = (p.node_times_sec >= w0) & (p.node_times_sec <= w1)
+        ids = set(p.runner_ids[mask].astype(str))
+        through_ids |= ids
+        through_by_event.setdefault(p.event, set()).update(ids)
+
+    result.unique_by_role_event = {
+        "joining_in_window": {
+            event: _unique_in_window(p, w0, w1)
+            for event, p in _by_event_combined(join_parts).items()
+        },
+        "joining_with_full_half_copresence": {
+            "all": joining_cp["with_partner"],
+            **{
+                event: _unique_with_copresence(p, secondary, w0, w1)["with_partner"]
+                for event, p in _by_event_combined(join_parts).items()
+            },
+        },
+        "joining_without_full_half": {"all": joining_cp["without_partner"]},
+        "through_full_half_with_joining_copresence": {
+            "all": partner_cp["with_partner"],
+            **{
+                event: _unique_with_copresence(p, primary, w0, w1)["with_partner"]
+                for event, p in _by_event_combined(partner_parts).items()
+            },
+        },
+        "through_in_window": {e: len(ids) for e, ids in through_by_event.items()},
+        "through_all_deduped_in_window": {"all": len(through_ids)},
+    }
+    result.field_crosstab = _crosstab(primary, secondary, w0, w1)
+    result.label = f"{from_seg}→{','.join(to_segs)}"
+    return result
+
+
+def prepare_runners_by_event(runners_df: pd.DataFrame) -> Dict[str, pd.DataFrame]:
+    """Split runners DataFrame by event and attach pace quintiles (Q1 lead … Q5 rear)."""
+    if runners_df is None or runners_df.empty:
+        return {}
+    out: Dict[str, pd.DataFrame] = {}
+    df = runners_df.copy()
+    df["event"] = df["event"].astype(str).str.lower()
+    df["pace"] = pd.to_numeric(df["pace"], errors="coerce")
+    df["start_offset"] = pd.to_numeric(df["start_offset"], errors="coerce").fillna(0.0)
+    df = df.dropna(subset=["pace", "runner_id"])
+    df = df[df["pace"] > 0]
+    for event, part in df.groupby("event"):
+        part = part.copy()
+        try:
+            part["quintile"] = pd.qcut(
+                part["pace"], 5, labels=[1, 2, 3, 4, 5], duplicates="drop"
+            )
+            part["quintile"] = part["quintile"].astype(int)
+        except ValueError:
+            ranks = part["pace"].rank(method="first")
+            part["quintile"] = pd.qcut(ranks, min(5, len(part)), labels=False) + 1
+            part["quintile"] = part["quintile"].astype(int)
+        out[str(event)] = part
+    return out
+
+
+def interaction_to_dict(result: InteractionResult) -> Dict[str, Any]:
+    return {
+        "id": result.interaction_id,
+        "type": result.type,
+        "side": result.side,
+        "label": result.label,
+        "events": result.events,
+        "window_start": result.window_start_hhmm,
+        "window_end": result.window_end_hhmm,
+        "window_minutes": round(result.window_minutes, 2),
+        "unique_by_role_event": result.unique_by_role_event,
+        "peak_concurrent": result.peak_concurrent,
+        "field_crosstab": result.field_crosstab,
+        "minute_rows": result.minute_rows,
+        "notes": result.notes,
+    }
+
+
+def analyze_junction(
+    junction: Dict[str, Any],
+    runners_by_event: Dict[str, pd.DataFrame],
+    gun_by_event: Dict[str, float],
+) -> Dict[str, Any]:
+    """Analyze all interactions for one authored junction."""
+    nearby_by_id = {
+        str(s["seg_id"]): s
+        for s in (junction.get("nearby_segments") or [])
+        if s.get("seg_id")
+    }
+    interactions = []
+    for ix in junction.get("interactions") or []:
+        result = analyze_interaction(ix, nearby_by_id, runners_by_event, gun_by_event)
+        interactions.append(interaction_to_dict(result))
+    return {
+        "junction_id": junction.get("id"),
+        "junction_label": junction.get("label"),
+        "lat": junction.get("lat"),
+        "lon": junction.get("lon"),
+        "interactions": interactions,
+    }
+
+
+def analyze_junctions_doc(
+    junctions_doc: Dict[str, Any],
+    runners_by_event: Dict[str, pd.DataFrame],
+    gun_by_event: Dict[str, float],
+) -> Dict[str, Any]:
+    """Analyze all junctions in a package junctions.json document."""
+    junctions = []
+    for junction in junctions_doc.get("junctions") or []:
+        junctions.append(analyze_junction(junction, runners_by_event, gun_by_event))
+    return {
+        "ok": True,
+        "method": {
+            "participation": "dwell_copresence_at_node",
+            "field_bands": "event_relative_pace_quintiles_Q1_lead_Q5_rear",
+            "timing_model": "gun + start_offset + pace*node_km (Flow-overlap equivalent)",
+            "node_dwell_sec": NODE_DWELL_SEC,
+            "merge_partner_events": list(MERGE_PARTNER_EVENTS),
+            "unique_count_rule": (
+                "runner counts only if a partner-stream runner is within "
+                "node_dwell_sec of their node transit"
+            ),
+        },
+        "junctions": junctions,
+    }
+
+
+def result_to_ui_payload(day_result: Dict[str, Any]) -> Dict[str, Any]:
+    """Slim UI metrics payload (omit verbose notes by default; keep minute series)."""
+    junctions = []
+    for j in day_result.get("junctions") or []:
+        interactions = []
+        for ix in j.get("interactions") or []:
+            interactions.append(
+                {
+                    "id": ix.get("id"),
+                    "type": ix.get("type"),
+                    "side": ix.get("side"),
+                    "label": ix.get("label"),
+                    "events": ix.get("events"),
+                    "window_start": ix.get("window_start"),
+                    "window_end": ix.get("window_end"),
+                    "window_minutes": ix.get("window_minutes"),
+                    "unique_by_role_event": ix.get("unique_by_role_event"),
+                    "peak_concurrent": ix.get("peak_concurrent"),
+                    "field_crosstab": ix.get("field_crosstab"),
+                    "minute_rows": ix.get("minute_rows"),
+                }
+            )
+        junctions.append(
+            {
+                "junction_id": j.get("junction_id"),
+                "junction_label": j.get("junction_label"),
+                "lat": j.get("lat"),
+                "lon": j.get("lon"),
+                "interactions": interactions,
+            }
+        )
+    return {
+        "ok": bool(day_result.get("ok", True)),
+        "method": day_result.get("method") or {},
+        "junctions": junctions,
+    }

--- a/app/core/v2/junction_flow.py
+++ b/app/core/v2/junction_flow.py
@@ -1,0 +1,201 @@
+"""
+Junction Flow v2 pipeline integration (Issue #818).
+
+Reads package ``junctions.json`` from ``data_dir`` and computes dwell
+co-presence metrics per day using constant-pace node timing.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TYPE_CHECKING
+
+import pandas as pd
+
+from app.core.config_package.junctions import JUNCTIONS_NAME, empty_junctions_doc, validate_junctions_doc
+from app.core.junction_flow import (
+    analyze_junctions_doc,
+    prepare_runners_by_event,
+    result_to_ui_payload,
+)
+from app.core.v2.density import filter_runners_by_day
+from app.core.v2.models import Day, Event
+
+if TYPE_CHECKING:
+    from app.core.v2.performance import PerformanceMonitor
+
+logger = logging.getLogger(__name__)
+
+
+def load_junctions_from_data_dir(data_dir: str | Path) -> Dict[str, Any]:
+    """Load and validate junctions.json from the analysis package directory."""
+    path = Path(data_dir) / JUNCTIONS_NAME
+    if not path.is_file():
+        logger.info("No %s in %s — Junction Flow will write empty results", JUNCTIONS_NAME, data_dir)
+        return empty_junctions_doc()
+    with open(path, "r", encoding="utf-8") as f:
+        raw = json.load(f)
+    return validate_junctions_doc(raw)
+
+
+def analyze_junction_flow_v2(
+    *,
+    events: List[Event],
+    events_by_day: Dict[Day, List[Event]],
+    all_runners_df: pd.DataFrame,
+    data_dir: str,
+    perf_monitor: Optional["PerformanceMonitor"] = None,
+) -> Dict[Day, Dict[str, Any]]:
+    """
+    Compute Junction Flow for each analysis day.
+
+    Returns:
+        Mapping Day → result dict (ok, method, junctions[...]).
+    """
+    phase = None
+    if perf_monitor is not None:
+        phase = perf_monitor.start_phase(
+            "phase_4_3_junction_flow",
+            phase_number="Phase 4.3",
+            phase_description="Junction Flow Compute",
+        )
+
+    junctions_doc = load_junctions_from_data_dir(data_dir)
+    gun_by_event = {event.name.lower(): float(event.start_time) for event in events}
+    results: Dict[Day, Dict[str, Any]] = {}
+
+    for day, day_events in events_by_day.items():
+        day_runners = filter_runners_by_day(all_runners_df, day, events)
+        runners_by_event = prepare_runners_by_event(day_runners)
+        # Only include guns for events on this day
+        day_guns = {
+            e.name.lower(): gun_by_event[e.name.lower()]
+            for e in day_events
+            if e.name.lower() in gun_by_event
+        }
+        if not (junctions_doc.get("junctions") or []):
+            results[day] = {
+                "ok": True,
+                "method": {},
+                "junctions": [],
+                "notes": ["No authored junctions in package."],
+            }
+            continue
+        day_result = analyze_junctions_doc(junctions_doc, runners_by_event, day_guns)
+        results[day] = day_result
+        n_ix = sum(len(j.get("interactions") or []) for j in day_result.get("junctions") or [])
+        logger.info(
+            "[Phase 4.3] Junction Flow day=%s junctions=%s interactions=%s",
+            day.value,
+            len(day_result.get("junctions") or []),
+            n_ix,
+        )
+
+    if phase is not None and perf_monitor is not None:
+        from app.core.v2.performance import get_memory_usage_mb
+
+        phase.finish(memory_mb=get_memory_usage_mb())
+        perf_monitor.complete_phase(
+            phase,
+            phase_number="Phase 4.3",
+            phase_description="Junction Flow Compute",
+            summary_stats={"days": len(results)},
+        )
+
+    return results
+
+
+def persist_junction_flow_day(
+    *,
+    day_path: Path,
+    day_code: str,
+    day_result: Dict[str, Any],
+) -> Dict[str, str]:
+    """
+    Write computation SSOT, UI metrics, and report CSVs for one day.
+
+    Returns relative artifact names written.
+    """
+    written: Dict[str, str] = {}
+    computation_dir = day_path / "computation"
+    computation_dir.mkdir(parents=True, exist_ok=True)
+    ui_metrics_dir = day_path / "ui" / "metrics"
+    ui_metrics_dir.mkdir(parents=True, exist_ok=True)
+    reports_dir = day_path / "reports" / "junctions"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    payload = {
+        "day": day_code,
+        "ok": bool(day_result.get("ok", True)),
+        "method": day_result.get("method") or {},
+        "junctions": day_result.get("junctions") or [],
+        "notes": day_result.get("notes") or [],
+    }
+
+    comp_path = computation_dir / "junction_flow_results.json"
+    comp_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    written["computation"] = str(comp_path.relative_to(day_path))
+
+    ui_payload = result_to_ui_payload(payload)
+    ui_payload["day"] = day_code
+    ui_path = ui_metrics_dir / "junctions.json"
+    ui_path.write_text(json.dumps(ui_payload, indent=2) + "\n", encoding="utf-8")
+    written["ui_metrics"] = str(ui_path.relative_to(day_path))
+
+    summary = {
+        "day": day_code,
+        "method": payload["method"],
+        "junctions": [
+            {
+                "junction_id": j.get("junction_id"),
+                "junction_label": j.get("junction_label"),
+                "interactions": [
+                    {
+                        "id": ix.get("id"),
+                        "type": ix.get("type"),
+                        "side": ix.get("side"),
+                        "label": ix.get("label"),
+                        "events": ix.get("events"),
+                        "window_start": ix.get("window_start"),
+                        "window_end": ix.get("window_end"),
+                        "window_minutes": ix.get("window_minutes"),
+                        "unique_by_role_event": ix.get("unique_by_role_event"),
+                        "peak_concurrent": ix.get("peak_concurrent"),
+                        "field_crosstab": ix.get("field_crosstab"),
+                    }
+                    for ix in (j.get("interactions") or [])
+                ],
+            }
+            for j in (payload.get("junctions") or [])
+        ],
+    }
+    summary_path = reports_dir / "junction_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    written["summary"] = str(summary_path.relative_to(day_path))
+
+    for j in payload.get("junctions") or []:
+        jid = str(j.get("junction_id") or "junction")
+        for ix in j.get("interactions") or []:
+            iid = str(ix.get("id") or "ix")
+            itype = str(ix.get("type") or "interaction")
+            minute_rows = ix.get("minute_rows") or []
+            if minute_rows:
+                csv_name = f"{jid}_{iid}_{itype}_per_minute.csv"
+                csv_path = reports_dir / csv_name
+                with csv_path.open("w", encoding="utf-8", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=list(minute_rows[0].keys()))
+                    writer.writeheader()
+                    writer.writerows(minute_rows)
+            crosstab = ix.get("field_crosstab") or []
+            if crosstab:
+                ct_name = f"{jid}_{iid}_{itype}_field_crosstab.csv"
+                ct_path = reports_dir / ct_name
+                with ct_path.open("w", encoding="utf-8", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=list(crosstab[0].keys()))
+                    writer.writeheader()
+                    writer.writerows(crosstab)
+
+    return written

--- a/app/core/v2/pipeline.py
+++ b/app/core/v2/pipeline.py
@@ -23,6 +23,7 @@ from app.core.v2.density import (
     filter_runners_by_day,
 )
 from app.core.v2.flow import analyze_temporal_flow_segments_v2
+from app.core.v2.junction_flow import analyze_junction_flow_v2, persist_junction_flow_day
 from app.core.v2.reports import generate_reports_per_day
 from app.core.v2.overlaps import generate_bidirectional_overlap_reports
 from app.core.v2.bins import generate_bins_v2
@@ -88,11 +89,13 @@ PHASE_MAPPING = {
     "phase_3_2_density_compute": {"number": "Phase 3.2", "description": "Density Per-Day Compute"},
     "phase_4_1_flow_build_segments": {"number": "Phase 4.1", "description": "Flow Build Segments"},
     "phase_4_2_flow_compute": {"number": "Phase 4.2", "description": "Flow Per-Day Compute"},
+    "phase_4_3_junction_flow": {"number": "Phase 4.3", "description": "Junction Flow Compute"},
     "phase_5_1_bin_generation": {"number": "Phase 5.1", "description": "Bin Generation"},
     "phase_5_2_bin_validation": {"number": "Phase 5.2", "description": "Bin Validation"},
     "phase_6_1_persist_density": {"number": "Phase 6.1", "description": "Persist Density Results"},
     "phase_6_2_persist_flow": {"number": "Phase 6.2", "description": "Persist Flow Results"},
     "phase_6_3_persist_locations": {"number": "Phase 6.3", "description": "Persist Locations Results"},
+    "phase_6_4_persist_junction_flow": {"number": "Phase 6.4", "description": "Persist Junction Flow Results"},
     "phase_7_ui_artifacts": {"number": "Phase 7", "description": "UI Artifacts Generation"},
     "phase_8_derived_metrics": {"number": "Phase 8", "description": "Derived Metrics Calculation"},
     "phase_9_map_data": {"number": "Phase 9", "description": "Map Data Generation"},
@@ -885,6 +888,20 @@ def create_full_analysis_pipeline(
         )
         flow_days = len(flow_results)
         logger.info(f"[Phase 4] Flow analysis complete: {flow_days} days")
+
+        # Phase 4.3: Junction Flow (Issue #818) — core path
+        logger.info("[Phase 4.3] Processing junction flow analysis...")
+        junction_flow_results = analyze_junction_flow_v2(
+            events=events,
+            events_by_day=events_by_day,
+            all_runners_df=all_runners_df,
+            data_dir=data_dir,
+            perf_monitor=perf_monitor,
+        )
+        logger.info(
+            "[Phase 4.3] Junction Flow complete: %s days",
+            len(junction_flow_results),
+        )
         
         # Phase 6.1: Persist Density Results
         density_persistence_metrics = perf_monitor.start_phase(
@@ -1217,6 +1234,40 @@ def create_full_analysis_pipeline(
                 phase_description="Persist Locations Results",
                 summary_stats={"locations": locations_count, "days": len(events_by_day)}
             )
+
+        # Phase 6.4: Persist Junction Flow (computation + UI metrics + reports)
+        junction_persist_metrics = perf_monitor.start_phase(
+            "phase_6_4_persist_junction_flow",
+            phase_number="Phase 6.4",
+            phase_description="Persist Junction Flow Results",
+        )
+        junction_files = []
+        for day, _day_events in events_by_day.items():
+            day_code = day.value
+            day_path = run_path / day_code
+            day_result = junction_flow_results.get(day) or {
+                "ok": True,
+                "method": {},
+                "junctions": [],
+            }
+            written = persist_junction_flow_day(
+                day_path=day_path,
+                day_code=day_code,
+                day_result=day_result,
+            )
+            junction_files.extend(written.values())
+            logger.info(
+                "[Phase 6.4] Persisted junction flow for %s: %s",
+                day_code,
+                ", ".join(written.values()),
+            )
+        junction_persist_metrics.finish(memory_mb=get_memory_usage_mb())
+        perf_monitor.complete_phase(
+            junction_persist_metrics,
+            phase_number="Phase 6.4",
+            phase_description="Persist Junction Flow Results",
+            summary_stats={"artifacts": len(junction_files)},
+        )
         
         # Phase 7: UI Artifacts Generation
         artifacts_metrics = perf_monitor.start_phase(

--- a/app/main.py
+++ b/app/main.py
@@ -28,6 +28,7 @@ from app.routes.api_dashboard import router as api_dashboard_router
 from app.routes.api_health import router as api_health_router
 from app.routes.api_density import router as api_density_router
 from app.api.flow import router as api_flow_router
+from app.api.junctions import router as api_junctions_router
 from app.api.bidirectional import router as api_bidirectional_router
 from app.routes.api_reports import router as api_reports_router
 from app.routes.api_bins import router as api_bins_router
@@ -143,6 +144,7 @@ app.include_router(api_dashboard_router)
 app.include_router(api_health_router)
 app.include_router(api_density_router)
 app.include_router(api_flow_router)
+app.include_router(api_junctions_router)
 app.include_router(api_bidirectional_router)
 app.include_router(api_reports_router)
 app.include_router(api_bins_router)

--- a/app/routes/ui.py
+++ b/app/routes/ui.py
@@ -312,6 +312,24 @@ async def flow(request: Request):
     )
 
 
+@router.get("/junctions", response_class=HTMLResponse)
+async def junctions(request: Request):
+    """
+    Junction Flow results page (Issue #818).
+
+    Authored package junctions analyzed for the selected run/day.
+    """
+    auth_redirect = require_auth(request)
+    if auth_redirect:
+        return auth_redirect
+    meta = get_stub_meta()
+    return templates.TemplateResponse(
+        request=request,
+        name="pages/junctions.html",
+        context={"request": request, "meta": meta},
+    )
+
+
 @router.get("/locations", response_class=HTMLResponse)
 async def locations(request: Request):
     """

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -72,6 +72,9 @@
                             <a class="nav-link{% if request.url and request.url.path == '/flow' %} active{% endif %}" href="/flow" data-rf-run-view="1">Flow</a>
                         </li>
                         <li class="nav-item rf-tabler-run-view-link" hidden>
+                            <a class="nav-link{% if request.url and request.url.path == '/junctions' %} active{% endif %}" href="/junctions" data-rf-run-view="1">Junctions</a>
+                        </li>
+                        <li class="nav-item rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/locations' %} active{% endif %}" href="/locations" data-rf-run-view="1">Locations</a>
                         </li>
                         <li class="nav-item rf-tabler-run-view-link" hidden>
@@ -184,6 +187,7 @@
             "/segments",
             "/density",
             "/flow",
+            "/junctions",
             "/locations",
             "/reports",
         ];

--- a/frontend/templates/pages/junctions.html
+++ b/frontend/templates/pages/junctions.html
@@ -1,0 +1,333 @@
+{% extends "base.html" %}
+
+{% block title %}Junctions{% endblock %}
+
+{% block content %}
+<div class="page-header">
+    <h2>Junction Flow</h2>
+    <p class="text-secondary" style="margin-top: 0.25rem;">
+        Cross and merge participation at authored junctions (dwell co-presence at the node).
+    </p>
+</div>
+{% include "partials/run_context.html" %}
+
+<div id="junctions-empty" class="card" style="display:none;">
+    <p class="text-secondary mb-0">
+        No Junction Flow artifact for this run. Author junctions on the package, then re-run analysis.
+    </p>
+</div>
+
+<div id="junctions-root"></div>
+
+<!-- Junction Reference -->
+<div class="card">
+    <h3 style="margin-bottom: 1rem;">Junction Reference</h3>
+    <p style="margin-bottom: 1rem; color: #666; font-size: 0.9rem;">
+        Definitions for Junction Flow analysis. Junctions are authored on the package;
+        metrics are computed for the selected run.
+    </p>
+    <table>
+        <thead>
+            <tr>
+                <th>Term</th>
+                <th>Description</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr>
+                <td><strong>Junction</strong></td>
+                <td>A pin where course streams meet. Nearby segments are discovered from segment endpoints near the pin. Interactions (cross / merge) are declared by operators.</td>
+            </tr>
+            <tr>
+                <td><strong>Cross</strong></td>
+                <td>One stream turns across another (From → To conflicts with a Conflicts stream). <em>Crossing</em> runners are on the turning path; <em>crossed</em> runners are on the conflict stream at the node.</td>
+            </tr>
+            <tr>
+                <td><strong>Merge</strong></td>
+                <td>A joining stream enters one or more through (To) streams in the same direction. <em>Joining</em> runners arrive on From; <em>through</em> partners for counts are <strong>full and half</strong> on the To streams (same-event trail traffic does not unlock a merge count).</td>
+            </tr>
+            <tr>
+                <td><strong>Node / dwell</strong></td>
+                <td>Presence is estimated at the junction endpoint (segment km at the pin) using gun time + start offset + pace × km. Each runner is treated as at the node for a short dwell (±15 s, 30 s total).</td>
+            </tr>
+            <tr>
+                <td><strong>Co-presence</strong></td>
+                <td>A runner counts only if a partner-stream runner is also at the node within dwell of their transit — not merely because both appear somewhere in the involvement window.</td>
+            </tr>
+            <tr>
+                <td><strong>Involvement window</strong></td>
+                <td>First to last minute where both roles have concurrent presence at the node. Used for timeline span and peak concurrent; unique headlines use co-presence.</td>
+            </tr>
+            <tr>
+                <td><strong>Pace quintiles</strong></td>
+                <td>Event-relative field bands from runner pace: <strong>Q1 = lead (fastest)</strong> … <strong>Q5 = rear (slowest)</strong>. The crosstab shows unique primary runners by their quintile × nearest co-present partner’s quintile.</td>
+            </tr>
+            <tr>
+                <td><strong>How to read</strong></td>
+                <td>Headline numbers are co-present uniques. Charts show concurrent count over time (hover for minute values). Crosstab cells answer “where in each field did mixing happen?” — e.g. rear 10k meeting lead full.</td>
+            </tr>
+        </tbody>
+    </table>
+</div>
+
+<script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.1/dist/chart.umd.min.js"></script>
+<script>
+(function () {
+    const charts = [];
+
+    function resolveRunId() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get("run_id")
+            || (window.runflowDay && window.runflowDay.runId)
+            || localStorage.getItem("runflow_run_id")
+            || null;
+    }
+
+    function resolveDay() {
+        const params = new URLSearchParams(window.location.search);
+        return params.get("day")
+            || (window.runflowDay && window.runflowDay.day)
+            || null;
+    }
+
+    function headlineUniques(ix) {
+        const u = ix.unique_by_role_event || {};
+        if (ix.type === "merge") {
+            return {
+                primaryLabel: "Joining (co-present)",
+                primary: (u.joining_with_full_half_copresence || {}).all ?? "—",
+                secondaryLabel: "Through full+half",
+                secondary: (u.through_full_half_with_joining_copresence || {}).all ?? "—",
+            };
+        }
+        return {
+            primaryLabel: "Crossing (co-present)",
+            primary: (u.crossing_with_copresence || {}).all ?? "—",
+            secondaryLabel: "Crossed (co-present)",
+            secondary: (u.crossed_with_copresence || {}).all ?? "—",
+        };
+    }
+
+    function primarySecondaryKeys(ix) {
+        const row = (ix.minute_rows || [])[0] || {};
+        const keys = Object.keys(row).filter((k) => k.endsWith("_count"));
+        if (keys.length >= 2) return [keys[0], keys[1]];
+        if (ix.type === "merge") return ["joining_count", "through_full_half_count"];
+        return ["crossing_count", "crossed_count"];
+    }
+
+    function seriesLabels(priKey, secKey) {
+        const map = {
+            crossing_count: "Crossing",
+            crossed_count: "Crossed",
+            joining_count: "Joining",
+            through_full_half_count: "Through full+half",
+            through_count: "Through",
+        };
+        return [map[priKey] || priKey, map[secKey] || secKey];
+    }
+
+    function buildCrosstabTable(ct) {
+        const mat = {};
+        (ct || []).forEach((r) => {
+            const qa = Number(r.crossing_or_joining_quintile);
+            const qb = Number(r.crossed_or_through_quintile);
+            mat[`${qa}-${qb}`] = Number(r.unique_crossing_or_joining_runners) || 0;
+        });
+        const colTot = [0, 0, 0, 0, 0, 0];
+        let grand = 0;
+        let html = '<table class="table table-sm table-vcenter"><thead><tr><th>Q↓ / partner →</th>';
+        for (let qb = 1; qb <= 5; qb++) html += `<th class="text-end">Q${qb}</th>`;
+        html += '<th class="text-end">Total</th></tr></thead><tbody>';
+        for (let qa = 1; qa <= 5; qa++) {
+            let rowTot = 0;
+            html += `<tr><td>Q${qa}${qa === 1 ? " lead" : qa === 5 ? " rear" : ""}</td>`;
+            for (let qb = 1; qb <= 5; qb++) {
+                const n = mat[`${qa}-${qb}`] || 0;
+                rowTot += n;
+                colTot[qb] += n;
+                html += `<td class="text-end">${n || "·"}</td>`;
+            }
+            grand += rowTot;
+            html += `<td class="text-end"><strong>${rowTot || "·"}</strong></td></tr>`;
+        }
+        html += '<tr><td><strong>Total</strong></td>';
+        for (let qb = 1; qb <= 5; qb++) {
+            html += `<td class="text-end"><strong>${colTot[qb] || "·"}</strong></td>`;
+        }
+        html += `<td class="text-end"><strong>${grand || "·"}</strong></td></tr>`;
+        html += "</tbody></table>";
+        return html;
+    }
+
+    function renderChart(canvas, ix) {
+        const rows = ix.minute_rows || [];
+        if (!rows.length || typeof Chart === "undefined") return;
+        const [priKey, secKey] = primarySecondaryKeys(ix);
+        const [priName, secName] = seriesLabels(priKey, secKey);
+        // Downsample long series for readability
+        const step = rows.length > 80 ? 3 : rows.length > 40 ? 2 : 1;
+        const sampled = rows.filter((_, i) => i % step === 0 || i === rows.length - 1);
+        const labels = sampled.map((r) => r.minute_start);
+        const a = sampled.map((r) => Number(r[priKey]) || 0);
+        const b = sampled.map((r) => Number(r[secKey]) || 0);
+        charts.push(
+            new Chart(canvas.getContext("2d"), {
+                type: "line",
+                data: {
+                    labels,
+                    datasets: [
+                        {
+                            label: priName,
+                            data: a,
+                            borderColor: "#206bc4",
+                            backgroundColor: "rgba(32,107,196,0.15)",
+                            fill: true,
+                            tension: 0.2,
+                            pointRadius: 0,
+                            pointHoverRadius: 4,
+                            pointStyle: "circle",
+                        },
+                        {
+                            label: secName,
+                            data: b,
+                            borderColor: "#f76707",
+                            backgroundColor: "rgba(247,103,7,0.12)",
+                            fill: true,
+                            tension: 0.2,
+                            pointRadius: 0,
+                            pointHoverRadius: 4,
+                            pointStyle: "circle",
+                        },
+                    ],
+                },
+                options: {
+                    responsive: true,
+                    maintainAspectRatio: false,
+                    interaction: { mode: "index", intersect: false },
+                    plugins: {
+                        legend: {
+                            position: "bottom",
+                            labels: {
+                                usePointStyle: true,
+                                pointStyle: "circle",
+                                boxWidth: 8,
+                                boxHeight: 8,
+                                padding: 16,
+                            },
+                        },
+                        tooltip: {
+                            callbacks: {
+                                title(items) {
+                                    return items[0] ? `Minute ${items[0].label}` : "";
+                                },
+                            },
+                        },
+                    },
+                    scales: {
+                        x: {
+                            title: { display: true, text: "Time" },
+                            ticks: { maxTicksLimit: 10 },
+                        },
+                        y: {
+                            beginAtZero: true,
+                            title: { display: true, text: "Concurrent at node" },
+                        },
+                    },
+                },
+            })
+        );
+    }
+
+    function renderInteraction(j, ix) {
+        const h = headlineUniques(ix);
+        const peaks = ix.peak_concurrent || {};
+        const peakVals = Object.entries(peaks)
+            .map(([k, v]) => `${k}: ${v}`)
+            .join(" · ");
+        const card = document.createElement("div");
+        card.className = "card mb-3";
+        card.innerHTML = `
+            <div class="card-header">
+                <div>
+                    <span class="badge ${ix.type === "merge" ? "bg-green-lt" : "bg-blue-lt"} me-2">${ix.type}</span>
+                    <strong>${ix.label || ""}</strong>
+                    <span class="text-secondary ms-2">${ix.window_start || "—"}–${ix.window_end || "—"}
+                    (${ix.window_minutes || 0} min)</span>
+                </div>
+            </div>
+            <div class="card-body">
+                <div class="row g-3 mb-3">
+                    <div class="col-sm-4">
+                        <div class="text-secondary">${h.primaryLabel}</div>
+                        <div class="h2 mb-0">${h.primary}</div>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class="text-secondary">${h.secondaryLabel}</div>
+                        <div class="h2 mb-0">${h.secondary}</div>
+                    </div>
+                    <div class="col-sm-4">
+                        <div class="text-secondary">Peak concurrent</div>
+                        <div class="mt-1">${peakVals || "—"}</div>
+                    </div>
+                </div>
+                <h4 class="mb-2">Concurrent at node</h4>
+                <div style="height:220px;"><canvas></canvas></div>
+                <p class="text-secondary small mt-2 mb-3">Hover for minute counts. Source: junctions UI metrics · Q1=lead / Q5=rear.</p>
+                <h4 class="mb-2">Field position (pace quintile crosstab)</h4>
+                <div class="table-responsive crosstab-wrap"></div>
+            </div>
+        `;
+        card.querySelector(".crosstab-wrap").innerHTML = buildCrosstabTable(ix.field_crosstab);
+        const canvas = card.querySelector("canvas");
+        // Defer chart until in DOM
+        setTimeout(() => renderChart(canvas, ix), 0);
+        return card;
+    }
+
+    function render(payload) {
+        charts.forEach((c) => c.destroy());
+        charts.length = 0;
+        const root = document.getElementById("junctions-root");
+        const empty = document.getElementById("junctions-empty");
+        root.innerHTML = "";
+        const junctions = payload.junctions || [];
+        if (!junctions.length) {
+            empty.style.display = "";
+            return;
+        }
+        empty.style.display = "none";
+        junctions.forEach((j) => {
+            const section = document.createElement("div");
+            section.className = "mb-4";
+            section.innerHTML = `<h3 class="mb-3">${j.junction_label || j.junction_id || "Junction"}</h3>`;
+            root.appendChild(section);
+            (j.interactions || []).forEach((ix) => {
+                section.appendChild(renderInteraction(j, ix));
+            });
+        });
+    }
+
+    async function load() {
+        const runId = resolveRunId();
+        const day = resolveDay();
+        const params = new URLSearchParams();
+        if (runId) params.set("run_id", runId);
+        if (day) params.set("day", day);
+        try {
+            const res = await fetch(`/api/junctions?${params.toString()}`);
+            const data = await res.json();
+            render(data);
+        } catch (err) {
+            console.error(err);
+            document.getElementById("junctions-empty").style.display = "";
+            document.getElementById("junctions-empty").textContent =
+                "Failed to load Junction Flow data.";
+        }
+    }
+
+    document.addEventListener("DOMContentLoaded", load);
+    window.addEventListener("runflow-context-ready", load);
+})();
+</script>
+{% endblock %}

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -2,7 +2,7 @@
   Results chrome (Issue #791 Phase 1)
 
   Shared sub-nav + run context banner on Results pages
-  (Segments, Density, Flow, Locations, Reports). Not used on Runs.
+  (Segments, Density, Flow, Junctions, Locations, Reports). Not used on Runs.
 
   When no run is selected, shows a CTA to choose a run on the Runs page.
 
@@ -17,13 +17,14 @@
         <a href="/segments" data-results-path="/segments">Segments</a>
         <a href="/density" data-results-path="/density">Density</a>
         <a href="/flow" data-results-path="/flow">Flow</a>
+        <a href="/junctions" data-results-path="/junctions">Junctions</a>
         <a href="/locations" data-results-path="/locations">Locations</a>
         <a href="/reports" data-results-path="/reports">Reports</a>
     </nav>
 
     <div id="run-context-missing" class="run-context-missing" style="display: none;" role="status">
         <strong>No analysis run selected.</strong>
-        Choose a run to view Segments, Density, Flow, Locations, and Reports.
+        Choose a run to view Segments, Density, Flow, Junctions, Locations, and Reports.
         <a id="run-context-choose-link" href="/dashboard">Choose a run</a>
     </div>
 

--- a/scripts/prototype_junction_flow.py
+++ b/scripts/prototype_junction_flow.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python3
 """
-Prototype Junction Flow metrics (#818) — post-hoc, no full re-analysis.
+Junction Flow prototype CLI (#818) — thin wrapper over core compute.
 
-Reads package junctions.json + event runners + gun times, estimates presence
-at the junction node from constant-pace timing (same model as Flow overlaps).
+Prefer a full analysis run (Phase 4.3) for SSOT artifacts. This script is for
+ad-hoc recompute against an existing package + runners without re-running the
+pipeline.
 
 Usage:
   .venv/bin/python scripts/prototype_junction_flow.py \\
@@ -17,577 +18,25 @@ from __future__ import annotations
 import argparse
 import csv
 import json
-import math
-from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Sequence, Tuple
 
-import numpy as np
-import pandas as pd
+from app.core.junction_flow.compute import (
+    NODE_DWELL_SEC,
+    MERGE_PARTNER_EVENTS,
+    _load_runners,
+    analyze_junction,
+)
 
 DEFAULT_RUNFLOW = Path("/Users/jthompson/Documents/runflow")
-
-
-@dataclass
-class StreamPresence:
-    role: str  # crossing | crossed | joining | through
-    seg_id: str
-    event: str
-    runner_ids: np.ndarray
-    node_times_sec: np.ndarray  # instant at junction node
-    paces: np.ndarray
-    quintiles: np.ndarray  # 1=lead (fast) .. 5=rear (slow) within event
-
-
-@dataclass
-class InteractionResult:
-    interaction_id: str
-    type: str
-    side: str
-    label: str
-    events: List[str]
-    window_start_hhmm: str
-    window_end_hhmm: str
-    window_minutes: float
-    unique_by_role_event: Dict[str, Dict[str, int]]
-    peak_concurrent: Dict[str, int]
-    field_crosstab: List[Dict[str, Any]]
-    minute_rows: List[Dict[str, Any]]
-    notes: List[str] = field(default_factory=list)
-
-
-def _hhmm(seconds: float) -> str:
-    minutes = int(max(0, seconds) // 60)
-    return f"{minutes // 60:02d}:{minutes % 60:02d}"
-
-
-def _load_runners(package_dir: Path, event: str) -> pd.DataFrame:
-    path = package_dir / f"{event}_runners.csv"
-    if not path.is_file():
-        raise FileNotFoundError(path)
-    df = pd.read_csv(path)
-    df["event"] = event
-    df["pace"] = pd.to_numeric(df["pace"], errors="coerce")
-    df["start_offset"] = pd.to_numeric(df["start_offset"], errors="coerce").fillna(0.0)
-    df = df.dropna(subset=["pace", "runner_id"])
-    df = df[df["pace"] > 0].copy()
-    # Q1 = lead (fastest / lowest pace), Q5 = rear
-    try:
-        df["quintile"] = pd.qcut(
-            df["pace"], 5, labels=[1, 2, 3, 4, 5], duplicates="drop"
-        )
-        df["quintile"] = df["quintile"].astype(int)
-    except ValueError:
-        # Too few distinct paces — rank into up to 5 bins
-        ranks = df["pace"].rank(method="first")
-        df["quintile"] = pd.qcut(ranks, min(5, len(df)), labels=False) + 1
-        df["quintile"] = df["quintile"].astype(int)
-    return df
-
-
-def _node_km_for_segment(
-    nearby_by_id: Dict[str, Dict[str, Any]],
-    seg_id: str,
-    event: str,
-) -> Optional[float]:
-    """Km along the event course at the junction endpoint of this segment."""
-    row = nearby_by_id.get(seg_id) or {}
-    ek = (row.get("event_kms") or {}).get(event) or {}
-    near = str(row.get("near_endpoint") or "")
-    if near in ("end", "both") and ek.get("to_km") is not None:
-        return float(ek["to_km"])
-    if near in ("start", "both") and ek.get("from_km") is not None:
-        return float(ek["from_km"])
-    # Fallback: prefer to_km then from_km
-    if ek.get("to_km") is not None:
-        return float(ek["to_km"])
-    if ek.get("from_km") is not None:
-        return float(ek["from_km"])
-    return None
-
-
-def _presence_at_node(
-    runners: pd.DataFrame,
-    gun_min: float,
-    node_km: float,
-    role: str,
-    seg_id: str,
-    event: str,
-) -> StreamPresence:
-    pace_sec = runners["pace"].to_numpy(dtype=float) * 60.0
-    offset = runners["start_offset"].to_numpy(dtype=float)
-    t0 = float(gun_min) * 60.0
-    node_times = t0 + offset + pace_sec * float(node_km)
-    return StreamPresence(
-        role=role,
-        seg_id=seg_id,
-        event=event,
-        runner_ids=runners["runner_id"].astype(str).to_numpy(),
-        node_times_sec=node_times,
-        paces=runners["pace"].to_numpy(dtype=float),
-        quintiles=runners["quintile"].to_numpy(dtype=int),
-    )
-
-
-def _minute_metrics(
-    node_times: np.ndarray,
-    start_sec: float,
-    end_sec: float,
-    dwell_sec: float = 30.0,
-) -> Tuple[List[float], List[Dict[str, int]]]:
-    """
-    Treat each runner as present for dwell_sec centered on node transit.
-    Entries = arrivals in minute; exits = departures; concurrent ≈ present.
-    """
-    if node_times.size == 0:
-        return [], []
-    entry = node_times - dwell_sec / 2.0
-    exit_ = node_times + dwell_sec / 2.0
-    entry_sorted = np.sort(entry)
-    exit_sorted = np.sort(exit_)
-    start_floor = int(math.floor(start_sec / 60.0) * 60)
-    end_ceil = int(math.ceil(end_sec / 60.0) * 60)
-    if end_ceil <= start_floor:
-        return [], []
-    minute_starts = list(range(start_floor, end_ceil, 60))
-    out: List[Dict[str, int]] = []
-    for ms in minute_starts:
-        me = ms + 60
-        entries = int(
-            np.searchsorted(entry_sorted, me, side="left")
-            - np.searchsorted(entry_sorted, ms, side="left")
-        )
-        exits = int(
-            np.searchsorted(exit_sorted, me, side="left")
-            - np.searchsorted(exit_sorted, ms, side="left")
-        )
-        concurrent = int(
-            np.searchsorted(entry_sorted, me, side="left")
-            - np.searchsorted(exit_sorted, ms, side="left")
-        )
-        out.append({"concurrent": concurrent, "entries": entries, "exits": exits})
-    return [float(s) for s in minute_starts], out
-
-
-def _combine_presences(parts: Sequence[StreamPresence]) -> StreamPresence:
-    if not parts:
-        raise ValueError("no stream parts to combine")
-    return StreamPresence(
-        role=parts[0].role,
-        seg_id=",".join(sorted({p.seg_id for p in parts})),
-        event=",".join(sorted({p.event for p in parts})),
-        runner_ids=np.concatenate([p.runner_ids for p in parts]),
-        node_times_sec=np.concatenate([p.node_times_sec for p in parts]),
-        paces=np.concatenate([p.paces for p in parts]),
-        quintiles=np.concatenate([p.quintiles for p in parts]),
-    )
-
-
-def _unique_in_window(p: StreamPresence, start_sec: float, end_sec: float) -> int:
-    mask = (p.node_times_sec >= start_sec) & (p.node_times_sec <= end_sec)
-    return int(np.unique(p.runner_ids[mask]).size)
-
-
-def _crosstab(
-    a: StreamPresence,
-    b: StreamPresence,
-    start_sec: float,
-    end_sec: float,
-    dwell_sec: float = 30.0,
-) -> List[Dict[str, Any]]:
-    """
-    Concurrent-participation crosstab by quintile:
-    count unique A runners whose node time overlaps (±dwell/2) with some B runner,
-    bucketed by (A quintile, B quintile of a concurrent partner).
-    Simplified: for each A in window, find if any B within dwell of A's time;
-    use nearest B's quintile.
-    """
-    a_mask = (a.node_times_sec >= start_sec) & (a.node_times_sec <= end_sec)
-    b_mask = (b.node_times_sec >= start_sec) & (b.node_times_sec <= end_sec)
-    a_t = a.node_times_sec[a_mask]
-    a_q = a.quintiles[a_mask]
-    a_id = a.runner_ids[a_mask]
-    b_t = b.node_times_sec[b_mask]
-    b_q = b.quintiles[b_mask]
-    if a_t.size == 0 or b_t.size == 0:
-        return []
-    order = np.argsort(b_t)
-    b_t_s = b_t[order]
-    b_q_s = b_q[order]
-    counts: Dict[Tuple[int, int], set] = {}
-    seen_a: set = set()
-    for i in range(a_t.size):
-        rid = str(a_id[i])
-        if rid in seen_a:
-            continue
-        # searchsorted nearest
-        idx = int(np.searchsorted(b_t_s, a_t[i], side="left"))
-        candidates = []
-        if idx < b_t_s.size:
-            candidates.append(idx)
-        if idx > 0:
-            candidates.append(idx - 1)
-        best = None
-        best_dt = None
-        for j in candidates:
-            dt = abs(float(b_t_s[j] - a_t[i]))
-            if best_dt is None or dt < best_dt:
-                best_dt = dt
-                best = j
-        if best is None or best_dt is None or best_dt > dwell_sec:
-            continue
-        seen_a.add(rid)
-        key = (int(a_q[i]), int(b_q_s[best]))
-        counts.setdefault(key, set()).add(rid)
-    rows = []
-    for (qa, qb), ids in sorted(counts.items()):
-        rows.append(
-            {
-                "crossing_or_joining_quintile": qa,
-                "crossed_or_through_quintile": qb,
-                "unique_crossing_or_joining_runners": len(ids),
-            }
-        )
-    return rows
-
-
-def _analyze_pair(
-    *,
-    ix: Dict[str, Any],
-    primary: StreamPresence,
-    secondary: StreamPresence,
-    primary_label: str,
-    secondary_label: str,
-    notes: List[str],
-) -> InteractionResult:
-    if primary.node_times_sec.size == 0 or secondary.node_times_sec.size == 0:
-        return InteractionResult(
-            interaction_id=str(ix.get("id") or ""),
-            type=str(ix.get("type") or ""),
-            side=str(ix.get("side") or ""),
-            label=f"{primary_label} vs {secondary_label}",
-            events=list(ix.get("events") or []),
-            window_start_hhmm="—",
-            window_end_hhmm="—",
-            window_minutes=0.0,
-            unique_by_role_event={},
-            peak_concurrent={},
-            field_crosstab=[],
-            minute_rows=[],
-            notes=notes + ["No runners on one or both streams for scoped events."],
-        )
-
-    t0 = float(min(primary.node_times_sec.min(), secondary.node_times_sec.min()))
-    t1 = float(max(primary.node_times_sec.max(), secondary.node_times_sec.max()))
-    m_pri, met_pri = _minute_metrics(primary.node_times_sec, t0, t1)
-    m_sec, met_sec = _minute_metrics(secondary.node_times_sec, t0, t1)
-    # Align on primary minutes (same grid)
-    concurrent_both = []
-    minute_rows = []
-    for i, ms in enumerate(m_pri):
-        ca = met_pri[i]["concurrent"]
-        cb = met_sec[i]["concurrent"] if i < len(met_sec) else 0
-        concurrent_both.append(ca > 0 and cb > 0)
-        minute_rows.append(
-            {
-                "minute_start": _hhmm(ms),
-                "minute_end": _hhmm(ms + 60),
-                f"{primary_label}_count": ca,
-                f"{primary_label}_entries": met_pri[i]["entries"],
-                f"{primary_label}_exits": met_pri[i]["exits"],
-                f"{secondary_label}_count": cb,
-                f"{secondary_label}_entries": met_sec[i]["entries"] if i < len(met_sec) else 0,
-                f"{secondary_label}_exits": met_sec[i]["exits"] if i < len(met_sec) else 0,
-                "both_present": bool(ca > 0 and cb > 0),
-            }
-        )
-
-    if any(concurrent_both):
-        idxs = [i for i, v in enumerate(concurrent_both) if v]
-        w0 = m_pri[idxs[0]]
-        w1 = m_pri[idxs[-1]] + 60
-    else:
-        w0, w1 = t0, t1
-        notes.append("No minute with both streams concurrent; window falls back to full span.")
-
-    # Unique by role × event
-    unique: Dict[str, Dict[str, int]] = {primary_label: {}, secondary_label: {}}
-    for p, label in ((primary, primary_label), (secondary, secondary_label)):
-        # split combined events if needed
-        mask = (p.node_times_sec >= w0) & (p.node_times_sec <= w1)
-        # event field may be comma-joined when combined; regroup via runner list sizes per building
-        unique[label]["all"] = int(np.unique(p.runner_ids[mask]).size)
-
-    # Per-event unique: recompute from parts stored in notes? Simpler: parse from building below in caller.
-    peak = {
-        primary_label: max(
-            (r[f"{primary_label}_count"] for r in minute_rows if r["both_present"]),
-            default=0,
-        ),
-        secondary_label: max(
-            (r[f"{secondary_label}_count"] for r in minute_rows if r["both_present"]),
-            default=0,
-        ),
-    }
-
-    return InteractionResult(
-        interaction_id=str(ix.get("id") or ""),
-        type=str(ix.get("type") or ""),
-        side=str(ix.get("side") or ""),
-        label=f"{primary_label} vs {secondary_label}",
-        events=list(ix.get("events") or []),
-        window_start_hhmm=_hhmm(w0),
-        window_end_hhmm=_hhmm(w1),
-        window_minutes=max(0.0, (w1 - w0) / 60.0),
-        unique_by_role_event=unique,
-        peak_concurrent=peak,
-        field_crosstab=_crosstab(primary, secondary, w0, w1),
-        minute_rows=minute_rows,
-        notes=notes,
-    )
-
-
-def build_stream_parts(
-    *,
-    seg_id: str,
-    role: str,
-    events: Sequence[str],
-    nearby_by_id: Dict[str, Dict[str, Any]],
-    runners_by_event: Dict[str, pd.DataFrame],
-    gun_by_event: Dict[str, float],
-) -> Tuple[List[StreamPresence], List[str]]:
-    parts: List[StreamPresence] = []
-    notes: List[str] = []
-    for event in events:
-        if event not in runners_by_event:
-            notes.append(f"No runners file for event={event}")
-            continue
-        node_km = _node_km_for_segment(nearby_by_id, seg_id, event)
-        if node_km is None:
-            notes.append(f"No node km for {seg_id}/{event}")
-            continue
-        # Only include runners whose event uses this segment (event_kms present)
-        row = nearby_by_id.get(seg_id) or {}
-        if event not in (row.get("event_kms") or {}):
-            notes.append(f"{seg_id} not on event={event}; skipped")
-            continue
-        parts.append(
-            _presence_at_node(
-                runners_by_event[event],
-                gun_by_event[event],
-                node_km,
-                role,
-                seg_id,
-                event,
-            )
-        )
-    return parts, notes
-
-
-def analyze_interaction(
-    ix: Dict[str, Any],
-    nearby_by_id: Dict[str, Dict[str, Any]],
-    runners_by_event: Dict[str, pd.DataFrame],
-    gun_by_event: Dict[str, float],
-) -> InteractionResult:
-    events = [str(e).lower() for e in (ix.get("events") or [])]
-    itype = str(ix.get("type") or "").lower()
-    notes: List[str] = []
-
-    if itype == "cross":
-        from_seg = str(ix.get("from_seg_id") or "")
-        to_seg = (ix.get("to_seg_ids") or [None])[0]
-        conflicts = str(ix.get("conflicts_with_seg_id") or "")
-        # Crossing stream: runners who use From (at node). Path To is used to
-        # identify the turning stream events (intersection with To's events).
-        crossing_events = []
-        for e in events:
-            from_km = _node_km_for_segment(nearby_by_id, from_seg, e)
-            to_km = _node_km_for_segment(nearby_by_id, str(to_seg), e)
-            if from_km is not None and to_km is not None:
-                crossing_events.append(e)
-        if not crossing_events:
-            crossing_events = events
-            notes.append("Could not refine crossing events via From∩To; using interaction events.")
-
-        crossed_events = []
-        for e in events:
-            if _node_km_for_segment(nearby_by_id, conflicts, e) is not None:
-                crossed_events.append(e)
-        if not crossed_events:
-            crossed_events = events
-            notes.append("Conflicts stream missing for some events; using interaction events.")
-
-        pri_parts, n1 = build_stream_parts(
-            seg_id=from_seg,
-            role="crossing",
-            events=crossing_events,
-            nearby_by_id=nearby_by_id,
-            runners_by_event=runners_by_event,
-            gun_by_event=gun_by_event,
-        )
-        sec_parts, n2 = build_stream_parts(
-            seg_id=conflicts,
-            role="crossed",
-            events=crossed_events,
-            nearby_by_id=nearby_by_id,
-            runners_by_event=runners_by_event,
-            gun_by_event=gun_by_event,
-        )
-        notes.extend(n1 + n2)
-        # Annotate To for mapping
-        notes.append(f"Cross path {from_seg}→{to_seg} conflicts {conflicts}; side={ix.get('side')}")
-        for e in crossing_events:
-            notes.append(
-                f"map crossing {e}: {from_seg}@{_node_km_for_segment(nearby_by_id, from_seg, e)}km "
-                f"→ {to_seg}@{_node_km_for_segment(nearby_by_id, str(to_seg), e)}km"
-            )
-        for e in crossed_events:
-            notes.append(
-                f"map crossed {e}: {conflicts}@{_node_km_for_segment(nearby_by_id, conflicts, e)}km"
-            )
-
-        if not pri_parts or not sec_parts:
-            return InteractionResult(
-                interaction_id=str(ix.get("id") or ""),
-                type="cross",
-                side=str(ix.get("side") or ""),
-                label=f"{from_seg}→{to_seg} vs {conflicts}",
-                events=events,
-                window_start_hhmm="—",
-                window_end_hhmm="—",
-                window_minutes=0.0,
-                unique_by_role_event={},
-                peak_concurrent={},
-                field_crosstab=[],
-                minute_rows=[],
-                notes=notes,
-            )
-
-        primary = _combine_presences(pri_parts)
-        secondary = _combine_presences(sec_parts)
-        result = _analyze_pair(
-            ix=ix,
-            primary=primary,
-            secondary=secondary,
-            primary_label="crossing",
-            secondary_label="crossed",
-            notes=notes,
-        )
-
-        def _parse_hhmm(s: str) -> float:
-            if not s or s == "—":
-                return 0.0
-            hh, mm = s.split(":")
-            return int(hh) * 3600 + int(mm) * 60
-
-        w0 = _parse_hhmm(result.window_start_hhmm)
-        w1 = _parse_hhmm(result.window_end_hhmm)
-        result.unique_by_role_event = {
-            "crossing": {p.event: _unique_in_window(p, w0, w1) for p in pri_parts},
-            "crossed": {p.event: _unique_in_window(p, w0, w1) for p in sec_parts},
-        }
-        result.label = f"{from_seg}→{to_seg} vs {conflicts}"
-        return result
-
-    # merge
-    from_seg = str(ix.get("from_seg_id") or "")
-    to_segs = [str(s) for s in (ix.get("to_seg_ids") or [])]
-    join_parts, n1 = build_stream_parts(
-        seg_id=from_seg,
-        role="joining",
-        events=events,
-        nearby_by_id=nearby_by_id,
-        runners_by_event=runners_by_event,
-        gun_by_event=gun_by_event,
-    )
-    through_parts: List[StreamPresence] = []
-    notes.extend(n1)
-    notes.append(
-        "Merge is junction-level: through stream unions all To segments; "
-        "each To keeps event km/time for map/context."
-    )
-    for to_seg in to_segs:
-        parts, n = build_stream_parts(
-            seg_id=to_seg,
-            role="through",
-            events=events,
-            nearby_by_id=nearby_by_id,
-            runners_by_event=runners_by_event,
-            gun_by_event=gun_by_event,
-        )
-        notes.extend(n)
-        through_parts.extend(parts)
-        for e in events:
-            km = _node_km_for_segment(nearby_by_id, to_seg, e)
-            if km is not None:
-                notes.append(f"map through {to_seg}/{e} @ {km} km")
-
-    if not join_parts or not through_parts:
-        return InteractionResult(
-            interaction_id=str(ix.get("id") or ""),
-            type="merge",
-            side=str(ix.get("side") or ""),
-            label=f"{from_seg}→{','.join(to_segs)}",
-            events=events,
-            window_start_hhmm="—",
-            window_end_hhmm="—",
-            window_minutes=0.0,
-            unique_by_role_event={},
-            peak_concurrent={},
-            field_crosstab=[],
-            minute_rows=[],
-            notes=notes,
-        )
-
-    primary = _combine_presences(join_parts)
-    secondary = _combine_presences(through_parts)
-    result = _analyze_pair(
-        ix=ix,
-        primary=primary,
-        secondary=secondary,
-        primary_label="joining",
-        secondary_label="through",
-        notes=notes,
-    )
-
-    def _parse_hhmm(s: str) -> float:
-        if not s or s == "—":
-            return 0.0
-        hh, mm = s.split(":")
-        return int(hh) * 3600 + int(mm) * 60
-
-    w0 = _parse_hhmm(result.window_start_hhmm)
-    w1 = _parse_hhmm(result.window_end_hhmm)
-    # Through uniques: de-dupe runner_id across To segments
-    through_ids = set()
-    through_by_event: Dict[str, set] = {}
-    for p in through_parts:
-        mask = (p.node_times_sec >= w0) & (p.node_times_sec <= w1)
-        ids = set(p.runner_ids[mask].astype(str))
-        through_ids |= ids
-        through_by_event.setdefault(p.event, set()).update(ids)
-    result.unique_by_role_event = {
-        "joining": {p.event: _unique_in_window(p, w0, w1) for p in join_parts},
-        "through": {e: len(ids) for e, ids in through_by_event.items()},
-        "through_all_deduped": {"all": len(through_ids)},
-    }
-    result.label = f"{from_seg}→{','.join(to_segs)}"
-    return result
 
 
 def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--package-id", required=True)
     parser.add_argument("--run-id", required=True)
-    parser.add_argument("--junction-label", default="Trail at George")
+    parser.add_argument("--junction-label", default=None)
     parser.add_argument("--runflow-root", type=Path, default=DEFAULT_RUNFLOW)
-    parser.add_argument(
-        "--out-dir",
-        type=Path,
-        default=None,
-        help="Default: <run>/<day>/reports/junctions_prototype",
-    )
+    parser.add_argument("--out-dir", type=Path, default=None)
     args = parser.parse_args()
 
     package_dir = args.runflow_root / "config" / args.package_id
@@ -600,79 +49,70 @@ def main() -> int:
     }
 
     junctions_doc = json.loads((package_dir / "junctions.json").read_text(encoding="utf-8"))
-    junction = next(
-        (
-            j
-            for j in junctions_doc.get("junctions") or []
-            if str(j.get("label") or "") == args.junction_label
-        ),
-        None,
-    )
-    if not junction:
-        raise SystemExit(f"Junction not found: {args.junction_label}")
+    junctions = list(junctions_doc.get("junctions") or [])
+    if args.junction_label:
+        junctions = [j for j in junctions if str(j.get("label") or "") == args.junction_label]
+        if not junctions:
+            raise SystemExit(f"Junction not found: {args.junction_label}")
 
-    nearby_by_id = {
-        str(s["seg_id"]): s for s in (junction.get("nearby_segments") or []) if s.get("seg_id")
-    }
     events_needed = set()
-    for ix in junction.get("interactions") or []:
-        events_needed.update(str(e).lower() for e in (ix.get("events") or []))
+    for junction in junctions:
+        for ix in junction.get("interactions") or []:
+            events_needed.update(str(e).lower() for e in (ix.get("events") or []))
     runners_by_event = {e: _load_runners(package_dir, e) for e in sorted(events_needed)}
 
     out_dir = args.out_dir or (run_dir / day / "reports" / "junctions_prototype")
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    summary: Dict[str, Any] = {
+    summary = {
         "run_id": args.run_id,
         "package_id": args.package_id,
-        "junction_id": junction.get("id"),
-        "junction_label": junction.get("label"),
         "method": {
-            "participation": "concurrent_stream_at_node",
-            "field_bands": "event_relative_pace_quintiles_Q1_lead_Q5_rear",
-            "timing_model": "gun + start_offset + pace*node_km (Flow-overlap equivalent)",
-            "node_dwell_sec": 30,
+            "participation": "dwell_copresence_at_node",
+            "node_dwell_sec": NODE_DWELL_SEC,
+            "merge_partner_events": list(MERGE_PARTNER_EVENTS),
         },
-        "interactions": [],
+        "junctions": [],
     }
 
-    for ix in junction.get("interactions") or []:
-        result = analyze_interaction(ix, nearby_by_id, runners_by_event, gun_by_event)
-        ix_out = {
-            "id": result.interaction_id,
-            "type": result.type,
-            "side": result.side,
-            "label": result.label,
-            "events": result.events,
-            "window_start": result.window_start_hhmm,
-            "window_end": result.window_end_hhmm,
-            "window_minutes": round(result.window_minutes, 2),
-            "unique_by_role_event": result.unique_by_role_event,
-            "peak_concurrent": result.peak_concurrent,
-            "field_crosstab_top": result.field_crosstab[:15],
-            "notes": result.notes,
-        }
-        summary["interactions"].append(ix_out)
-
-        # minute CSV
-        if result.minute_rows:
-            csv_name = f"{result.interaction_id}_{result.type}_per_minute.csv"
-            csv_path = out_dir / csv_name
-            with csv_path.open("w", encoding="utf-8", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=list(result.minute_rows[0].keys()))
-                writer.writeheader()
-                writer.writerows(result.minute_rows)
-            ix_out["minute_csv"] = csv_name
-
-        # crosstab CSV
-        if result.field_crosstab:
-            ct_name = f"{result.interaction_id}_{result.type}_field_crosstab.csv"
-            ct_path = out_dir / ct_name
-            with ct_path.open("w", encoding="utf-8", newline="") as f:
-                writer = csv.DictWriter(f, fieldnames=list(result.field_crosstab[0].keys()))
-                writer.writeheader()
-                writer.writerows(result.field_crosstab)
-            ix_out["field_crosstab_csv"] = ct_name
+    for junction in junctions:
+        analyzed = analyze_junction(junction, runners_by_event, gun_by_event)
+        summary["junctions"].append(
+            {
+                "junction_id": analyzed.get("junction_id"),
+                "junction_label": analyzed.get("junction_label"),
+                "interactions": [
+                    {
+                        "id": ix["id"],
+                        "type": ix["type"],
+                        "side": ix["side"],
+                        "label": ix["label"],
+                        "events": ix["events"],
+                        "window_start": ix["window_start"],
+                        "window_end": ix["window_end"],
+                        "window_minutes": ix["window_minutes"],
+                        "unique_by_role_event": ix["unique_by_role_event"],
+                        "peak_concurrent": ix["peak_concurrent"],
+                        "field_crosstab_top": (ix.get("field_crosstab") or [])[:15],
+                        "notes": ix.get("notes") or [],
+                    }
+                    for ix in analyzed.get("interactions") or []
+                ],
+            }
+        )
+        for ix in analyzed.get("interactions") or []:
+            if ix.get("minute_rows"):
+                name = f"{ix['id']}_{ix['type']}_per_minute.csv"
+                with (out_dir / name).open("w", encoding="utf-8", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=list(ix["minute_rows"][0].keys()))
+                    writer.writeheader()
+                    writer.writerows(ix["minute_rows"])
+            if ix.get("field_crosstab"):
+                name = f"{ix['id']}_{ix['type']}_field_crosstab.csv"
+                with (out_dir / name).open("w", encoding="utf-8", newline="") as f:
+                    writer = csv.DictWriter(f, fieldnames=list(ix["field_crosstab"][0].keys()))
+                    writer.writeheader()
+                    writer.writerows(ix["field_crosstab"])
 
     summary_path = out_dir / "junction_summary.json"
     summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")

--- a/scripts/prototype_junction_flow.py
+++ b/scripts/prototype_junction_flow.py
@@ -1,0 +1,685 @@
+#!/usr/bin/env python3
+"""
+Prototype Junction Flow metrics (#818) — post-hoc, no full re-analysis.
+
+Reads package junctions.json + event runners + gun times, estimates presence
+at the junction node from constant-pace timing (same model as Flow overlaps).
+
+Usage:
+  .venv/bin/python scripts/prototype_junction_flow.py \\
+    --package-id bGNTx9388Ah9LpXarPuLak \\
+    --run-id ek6eu8XUDy5pRUembPYTQr \\
+    --junction-label "Trail at George"
+"""
+
+from __future__ import annotations
+
+import argparse
+import csv
+import json
+import math
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import pandas as pd
+
+DEFAULT_RUNFLOW = Path("/Users/jthompson/Documents/runflow")
+
+
+@dataclass
+class StreamPresence:
+    role: str  # crossing | crossed | joining | through
+    seg_id: str
+    event: str
+    runner_ids: np.ndarray
+    node_times_sec: np.ndarray  # instant at junction node
+    paces: np.ndarray
+    quintiles: np.ndarray  # 1=lead (fast) .. 5=rear (slow) within event
+
+
+@dataclass
+class InteractionResult:
+    interaction_id: str
+    type: str
+    side: str
+    label: str
+    events: List[str]
+    window_start_hhmm: str
+    window_end_hhmm: str
+    window_minutes: float
+    unique_by_role_event: Dict[str, Dict[str, int]]
+    peak_concurrent: Dict[str, int]
+    field_crosstab: List[Dict[str, Any]]
+    minute_rows: List[Dict[str, Any]]
+    notes: List[str] = field(default_factory=list)
+
+
+def _hhmm(seconds: float) -> str:
+    minutes = int(max(0, seconds) // 60)
+    return f"{minutes // 60:02d}:{minutes % 60:02d}"
+
+
+def _load_runners(package_dir: Path, event: str) -> pd.DataFrame:
+    path = package_dir / f"{event}_runners.csv"
+    if not path.is_file():
+        raise FileNotFoundError(path)
+    df = pd.read_csv(path)
+    df["event"] = event
+    df["pace"] = pd.to_numeric(df["pace"], errors="coerce")
+    df["start_offset"] = pd.to_numeric(df["start_offset"], errors="coerce").fillna(0.0)
+    df = df.dropna(subset=["pace", "runner_id"])
+    df = df[df["pace"] > 0].copy()
+    # Q1 = lead (fastest / lowest pace), Q5 = rear
+    try:
+        df["quintile"] = pd.qcut(
+            df["pace"], 5, labels=[1, 2, 3, 4, 5], duplicates="drop"
+        )
+        df["quintile"] = df["quintile"].astype(int)
+    except ValueError:
+        # Too few distinct paces — rank into up to 5 bins
+        ranks = df["pace"].rank(method="first")
+        df["quintile"] = pd.qcut(ranks, min(5, len(df)), labels=False) + 1
+        df["quintile"] = df["quintile"].astype(int)
+    return df
+
+
+def _node_km_for_segment(
+    nearby_by_id: Dict[str, Dict[str, Any]],
+    seg_id: str,
+    event: str,
+) -> Optional[float]:
+    """Km along the event course at the junction endpoint of this segment."""
+    row = nearby_by_id.get(seg_id) or {}
+    ek = (row.get("event_kms") or {}).get(event) or {}
+    near = str(row.get("near_endpoint") or "")
+    if near in ("end", "both") and ek.get("to_km") is not None:
+        return float(ek["to_km"])
+    if near in ("start", "both") and ek.get("from_km") is not None:
+        return float(ek["from_km"])
+    # Fallback: prefer to_km then from_km
+    if ek.get("to_km") is not None:
+        return float(ek["to_km"])
+    if ek.get("from_km") is not None:
+        return float(ek["from_km"])
+    return None
+
+
+def _presence_at_node(
+    runners: pd.DataFrame,
+    gun_min: float,
+    node_km: float,
+    role: str,
+    seg_id: str,
+    event: str,
+) -> StreamPresence:
+    pace_sec = runners["pace"].to_numpy(dtype=float) * 60.0
+    offset = runners["start_offset"].to_numpy(dtype=float)
+    t0 = float(gun_min) * 60.0
+    node_times = t0 + offset + pace_sec * float(node_km)
+    return StreamPresence(
+        role=role,
+        seg_id=seg_id,
+        event=event,
+        runner_ids=runners["runner_id"].astype(str).to_numpy(),
+        node_times_sec=node_times,
+        paces=runners["pace"].to_numpy(dtype=float),
+        quintiles=runners["quintile"].to_numpy(dtype=int),
+    )
+
+
+def _minute_metrics(
+    node_times: np.ndarray,
+    start_sec: float,
+    end_sec: float,
+    dwell_sec: float = 30.0,
+) -> Tuple[List[float], List[Dict[str, int]]]:
+    """
+    Treat each runner as present for dwell_sec centered on node transit.
+    Entries = arrivals in minute; exits = departures; concurrent ≈ present.
+    """
+    if node_times.size == 0:
+        return [], []
+    entry = node_times - dwell_sec / 2.0
+    exit_ = node_times + dwell_sec / 2.0
+    entry_sorted = np.sort(entry)
+    exit_sorted = np.sort(exit_)
+    start_floor = int(math.floor(start_sec / 60.0) * 60)
+    end_ceil = int(math.ceil(end_sec / 60.0) * 60)
+    if end_ceil <= start_floor:
+        return [], []
+    minute_starts = list(range(start_floor, end_ceil, 60))
+    out: List[Dict[str, int]] = []
+    for ms in minute_starts:
+        me = ms + 60
+        entries = int(
+            np.searchsorted(entry_sorted, me, side="left")
+            - np.searchsorted(entry_sorted, ms, side="left")
+        )
+        exits = int(
+            np.searchsorted(exit_sorted, me, side="left")
+            - np.searchsorted(exit_sorted, ms, side="left")
+        )
+        concurrent = int(
+            np.searchsorted(entry_sorted, me, side="left")
+            - np.searchsorted(exit_sorted, ms, side="left")
+        )
+        out.append({"concurrent": concurrent, "entries": entries, "exits": exits})
+    return [float(s) for s in minute_starts], out
+
+
+def _combine_presences(parts: Sequence[StreamPresence]) -> StreamPresence:
+    if not parts:
+        raise ValueError("no stream parts to combine")
+    return StreamPresence(
+        role=parts[0].role,
+        seg_id=",".join(sorted({p.seg_id for p in parts})),
+        event=",".join(sorted({p.event for p in parts})),
+        runner_ids=np.concatenate([p.runner_ids for p in parts]),
+        node_times_sec=np.concatenate([p.node_times_sec for p in parts]),
+        paces=np.concatenate([p.paces for p in parts]),
+        quintiles=np.concatenate([p.quintiles for p in parts]),
+    )
+
+
+def _unique_in_window(p: StreamPresence, start_sec: float, end_sec: float) -> int:
+    mask = (p.node_times_sec >= start_sec) & (p.node_times_sec <= end_sec)
+    return int(np.unique(p.runner_ids[mask]).size)
+
+
+def _crosstab(
+    a: StreamPresence,
+    b: StreamPresence,
+    start_sec: float,
+    end_sec: float,
+    dwell_sec: float = 30.0,
+) -> List[Dict[str, Any]]:
+    """
+    Concurrent-participation crosstab by quintile:
+    count unique A runners whose node time overlaps (±dwell/2) with some B runner,
+    bucketed by (A quintile, B quintile of a concurrent partner).
+    Simplified: for each A in window, find if any B within dwell of A's time;
+    use nearest B's quintile.
+    """
+    a_mask = (a.node_times_sec >= start_sec) & (a.node_times_sec <= end_sec)
+    b_mask = (b.node_times_sec >= start_sec) & (b.node_times_sec <= end_sec)
+    a_t = a.node_times_sec[a_mask]
+    a_q = a.quintiles[a_mask]
+    a_id = a.runner_ids[a_mask]
+    b_t = b.node_times_sec[b_mask]
+    b_q = b.quintiles[b_mask]
+    if a_t.size == 0 or b_t.size == 0:
+        return []
+    order = np.argsort(b_t)
+    b_t_s = b_t[order]
+    b_q_s = b_q[order]
+    counts: Dict[Tuple[int, int], set] = {}
+    seen_a: set = set()
+    for i in range(a_t.size):
+        rid = str(a_id[i])
+        if rid in seen_a:
+            continue
+        # searchsorted nearest
+        idx = int(np.searchsorted(b_t_s, a_t[i], side="left"))
+        candidates = []
+        if idx < b_t_s.size:
+            candidates.append(idx)
+        if idx > 0:
+            candidates.append(idx - 1)
+        best = None
+        best_dt = None
+        for j in candidates:
+            dt = abs(float(b_t_s[j] - a_t[i]))
+            if best_dt is None or dt < best_dt:
+                best_dt = dt
+                best = j
+        if best is None or best_dt is None or best_dt > dwell_sec:
+            continue
+        seen_a.add(rid)
+        key = (int(a_q[i]), int(b_q_s[best]))
+        counts.setdefault(key, set()).add(rid)
+    rows = []
+    for (qa, qb), ids in sorted(counts.items()):
+        rows.append(
+            {
+                "crossing_or_joining_quintile": qa,
+                "crossed_or_through_quintile": qb,
+                "unique_crossing_or_joining_runners": len(ids),
+            }
+        )
+    return rows
+
+
+def _analyze_pair(
+    *,
+    ix: Dict[str, Any],
+    primary: StreamPresence,
+    secondary: StreamPresence,
+    primary_label: str,
+    secondary_label: str,
+    notes: List[str],
+) -> InteractionResult:
+    if primary.node_times_sec.size == 0 or secondary.node_times_sec.size == 0:
+        return InteractionResult(
+            interaction_id=str(ix.get("id") or ""),
+            type=str(ix.get("type") or ""),
+            side=str(ix.get("side") or ""),
+            label=f"{primary_label} vs {secondary_label}",
+            events=list(ix.get("events") or []),
+            window_start_hhmm="—",
+            window_end_hhmm="—",
+            window_minutes=0.0,
+            unique_by_role_event={},
+            peak_concurrent={},
+            field_crosstab=[],
+            minute_rows=[],
+            notes=notes + ["No runners on one or both streams for scoped events."],
+        )
+
+    t0 = float(min(primary.node_times_sec.min(), secondary.node_times_sec.min()))
+    t1 = float(max(primary.node_times_sec.max(), secondary.node_times_sec.max()))
+    m_pri, met_pri = _minute_metrics(primary.node_times_sec, t0, t1)
+    m_sec, met_sec = _minute_metrics(secondary.node_times_sec, t0, t1)
+    # Align on primary minutes (same grid)
+    concurrent_both = []
+    minute_rows = []
+    for i, ms in enumerate(m_pri):
+        ca = met_pri[i]["concurrent"]
+        cb = met_sec[i]["concurrent"] if i < len(met_sec) else 0
+        concurrent_both.append(ca > 0 and cb > 0)
+        minute_rows.append(
+            {
+                "minute_start": _hhmm(ms),
+                "minute_end": _hhmm(ms + 60),
+                f"{primary_label}_count": ca,
+                f"{primary_label}_entries": met_pri[i]["entries"],
+                f"{primary_label}_exits": met_pri[i]["exits"],
+                f"{secondary_label}_count": cb,
+                f"{secondary_label}_entries": met_sec[i]["entries"] if i < len(met_sec) else 0,
+                f"{secondary_label}_exits": met_sec[i]["exits"] if i < len(met_sec) else 0,
+                "both_present": bool(ca > 0 and cb > 0),
+            }
+        )
+
+    if any(concurrent_both):
+        idxs = [i for i, v in enumerate(concurrent_both) if v]
+        w0 = m_pri[idxs[0]]
+        w1 = m_pri[idxs[-1]] + 60
+    else:
+        w0, w1 = t0, t1
+        notes.append("No minute with both streams concurrent; window falls back to full span.")
+
+    # Unique by role × event
+    unique: Dict[str, Dict[str, int]] = {primary_label: {}, secondary_label: {}}
+    for p, label in ((primary, primary_label), (secondary, secondary_label)):
+        # split combined events if needed
+        mask = (p.node_times_sec >= w0) & (p.node_times_sec <= w1)
+        # event field may be comma-joined when combined; regroup via runner list sizes per building
+        unique[label]["all"] = int(np.unique(p.runner_ids[mask]).size)
+
+    # Per-event unique: recompute from parts stored in notes? Simpler: parse from building below in caller.
+    peak = {
+        primary_label: max(
+            (r[f"{primary_label}_count"] for r in minute_rows if r["both_present"]),
+            default=0,
+        ),
+        secondary_label: max(
+            (r[f"{secondary_label}_count"] for r in minute_rows if r["both_present"]),
+            default=0,
+        ),
+    }
+
+    return InteractionResult(
+        interaction_id=str(ix.get("id") or ""),
+        type=str(ix.get("type") or ""),
+        side=str(ix.get("side") or ""),
+        label=f"{primary_label} vs {secondary_label}",
+        events=list(ix.get("events") or []),
+        window_start_hhmm=_hhmm(w0),
+        window_end_hhmm=_hhmm(w1),
+        window_minutes=max(0.0, (w1 - w0) / 60.0),
+        unique_by_role_event=unique,
+        peak_concurrent=peak,
+        field_crosstab=_crosstab(primary, secondary, w0, w1),
+        minute_rows=minute_rows,
+        notes=notes,
+    )
+
+
+def build_stream_parts(
+    *,
+    seg_id: str,
+    role: str,
+    events: Sequence[str],
+    nearby_by_id: Dict[str, Dict[str, Any]],
+    runners_by_event: Dict[str, pd.DataFrame],
+    gun_by_event: Dict[str, float],
+) -> Tuple[List[StreamPresence], List[str]]:
+    parts: List[StreamPresence] = []
+    notes: List[str] = []
+    for event in events:
+        if event not in runners_by_event:
+            notes.append(f"No runners file for event={event}")
+            continue
+        node_km = _node_km_for_segment(nearby_by_id, seg_id, event)
+        if node_km is None:
+            notes.append(f"No node km for {seg_id}/{event}")
+            continue
+        # Only include runners whose event uses this segment (event_kms present)
+        row = nearby_by_id.get(seg_id) or {}
+        if event not in (row.get("event_kms") or {}):
+            notes.append(f"{seg_id} not on event={event}; skipped")
+            continue
+        parts.append(
+            _presence_at_node(
+                runners_by_event[event],
+                gun_by_event[event],
+                node_km,
+                role,
+                seg_id,
+                event,
+            )
+        )
+    return parts, notes
+
+
+def analyze_interaction(
+    ix: Dict[str, Any],
+    nearby_by_id: Dict[str, Dict[str, Any]],
+    runners_by_event: Dict[str, pd.DataFrame],
+    gun_by_event: Dict[str, float],
+) -> InteractionResult:
+    events = [str(e).lower() for e in (ix.get("events") or [])]
+    itype = str(ix.get("type") or "").lower()
+    notes: List[str] = []
+
+    if itype == "cross":
+        from_seg = str(ix.get("from_seg_id") or "")
+        to_seg = (ix.get("to_seg_ids") or [None])[0]
+        conflicts = str(ix.get("conflicts_with_seg_id") or "")
+        # Crossing stream: runners who use From (at node). Path To is used to
+        # identify the turning stream events (intersection with To's events).
+        crossing_events = []
+        for e in events:
+            from_km = _node_km_for_segment(nearby_by_id, from_seg, e)
+            to_km = _node_km_for_segment(nearby_by_id, str(to_seg), e)
+            if from_km is not None and to_km is not None:
+                crossing_events.append(e)
+        if not crossing_events:
+            crossing_events = events
+            notes.append("Could not refine crossing events via From∩To; using interaction events.")
+
+        crossed_events = []
+        for e in events:
+            if _node_km_for_segment(nearby_by_id, conflicts, e) is not None:
+                crossed_events.append(e)
+        if not crossed_events:
+            crossed_events = events
+            notes.append("Conflicts stream missing for some events; using interaction events.")
+
+        pri_parts, n1 = build_stream_parts(
+            seg_id=from_seg,
+            role="crossing",
+            events=crossing_events,
+            nearby_by_id=nearby_by_id,
+            runners_by_event=runners_by_event,
+            gun_by_event=gun_by_event,
+        )
+        sec_parts, n2 = build_stream_parts(
+            seg_id=conflicts,
+            role="crossed",
+            events=crossed_events,
+            nearby_by_id=nearby_by_id,
+            runners_by_event=runners_by_event,
+            gun_by_event=gun_by_event,
+        )
+        notes.extend(n1 + n2)
+        # Annotate To for mapping
+        notes.append(f"Cross path {from_seg}→{to_seg} conflicts {conflicts}; side={ix.get('side')}")
+        for e in crossing_events:
+            notes.append(
+                f"map crossing {e}: {from_seg}@{_node_km_for_segment(nearby_by_id, from_seg, e)}km "
+                f"→ {to_seg}@{_node_km_for_segment(nearby_by_id, str(to_seg), e)}km"
+            )
+        for e in crossed_events:
+            notes.append(
+                f"map crossed {e}: {conflicts}@{_node_km_for_segment(nearby_by_id, conflicts, e)}km"
+            )
+
+        if not pri_parts or not sec_parts:
+            return InteractionResult(
+                interaction_id=str(ix.get("id") or ""),
+                type="cross",
+                side=str(ix.get("side") or ""),
+                label=f"{from_seg}→{to_seg} vs {conflicts}",
+                events=events,
+                window_start_hhmm="—",
+                window_end_hhmm="—",
+                window_minutes=0.0,
+                unique_by_role_event={},
+                peak_concurrent={},
+                field_crosstab=[],
+                minute_rows=[],
+                notes=notes,
+            )
+
+        primary = _combine_presences(pri_parts)
+        secondary = _combine_presences(sec_parts)
+        result = _analyze_pair(
+            ix=ix,
+            primary=primary,
+            secondary=secondary,
+            primary_label="crossing",
+            secondary_label="crossed",
+            notes=notes,
+        )
+
+        def _parse_hhmm(s: str) -> float:
+            if not s or s == "—":
+                return 0.0
+            hh, mm = s.split(":")
+            return int(hh) * 3600 + int(mm) * 60
+
+        w0 = _parse_hhmm(result.window_start_hhmm)
+        w1 = _parse_hhmm(result.window_end_hhmm)
+        result.unique_by_role_event = {
+            "crossing": {p.event: _unique_in_window(p, w0, w1) for p in pri_parts},
+            "crossed": {p.event: _unique_in_window(p, w0, w1) for p in sec_parts},
+        }
+        result.label = f"{from_seg}→{to_seg} vs {conflicts}"
+        return result
+
+    # merge
+    from_seg = str(ix.get("from_seg_id") or "")
+    to_segs = [str(s) for s in (ix.get("to_seg_ids") or [])]
+    join_parts, n1 = build_stream_parts(
+        seg_id=from_seg,
+        role="joining",
+        events=events,
+        nearby_by_id=nearby_by_id,
+        runners_by_event=runners_by_event,
+        gun_by_event=gun_by_event,
+    )
+    through_parts: List[StreamPresence] = []
+    notes.extend(n1)
+    notes.append(
+        "Merge is junction-level: through stream unions all To segments; "
+        "each To keeps event km/time for map/context."
+    )
+    for to_seg in to_segs:
+        parts, n = build_stream_parts(
+            seg_id=to_seg,
+            role="through",
+            events=events,
+            nearby_by_id=nearby_by_id,
+            runners_by_event=runners_by_event,
+            gun_by_event=gun_by_event,
+        )
+        notes.extend(n)
+        through_parts.extend(parts)
+        for e in events:
+            km = _node_km_for_segment(nearby_by_id, to_seg, e)
+            if km is not None:
+                notes.append(f"map through {to_seg}/{e} @ {km} km")
+
+    if not join_parts or not through_parts:
+        return InteractionResult(
+            interaction_id=str(ix.get("id") or ""),
+            type="merge",
+            side=str(ix.get("side") or ""),
+            label=f"{from_seg}→{','.join(to_segs)}",
+            events=events,
+            window_start_hhmm="—",
+            window_end_hhmm="—",
+            window_minutes=0.0,
+            unique_by_role_event={},
+            peak_concurrent={},
+            field_crosstab=[],
+            minute_rows=[],
+            notes=notes,
+        )
+
+    primary = _combine_presences(join_parts)
+    secondary = _combine_presences(through_parts)
+    result = _analyze_pair(
+        ix=ix,
+        primary=primary,
+        secondary=secondary,
+        primary_label="joining",
+        secondary_label="through",
+        notes=notes,
+    )
+
+    def _parse_hhmm(s: str) -> float:
+        if not s or s == "—":
+            return 0.0
+        hh, mm = s.split(":")
+        return int(hh) * 3600 + int(mm) * 60
+
+    w0 = _parse_hhmm(result.window_start_hhmm)
+    w1 = _parse_hhmm(result.window_end_hhmm)
+    # Through uniques: de-dupe runner_id across To segments
+    through_ids = set()
+    through_by_event: Dict[str, set] = {}
+    for p in through_parts:
+        mask = (p.node_times_sec >= w0) & (p.node_times_sec <= w1)
+        ids = set(p.runner_ids[mask].astype(str))
+        through_ids |= ids
+        through_by_event.setdefault(p.event, set()).update(ids)
+    result.unique_by_role_event = {
+        "joining": {p.event: _unique_in_window(p, w0, w1) for p in join_parts},
+        "through": {e: len(ids) for e, ids in through_by_event.items()},
+        "through_all_deduped": {"all": len(through_ids)},
+    }
+    result.label = f"{from_seg}→{','.join(to_segs)}"
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--package-id", required=True)
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--junction-label", default="Trail at George")
+    parser.add_argument("--runflow-root", type=Path, default=DEFAULT_RUNFLOW)
+    parser.add_argument(
+        "--out-dir",
+        type=Path,
+        default=None,
+        help="Default: <run>/<day>/reports/junctions_prototype",
+    )
+    args = parser.parse_args()
+
+    package_dir = args.runflow_root / "config" / args.package_id
+    run_dir = args.runflow_root / "analysis" / args.run_id
+    analysis = json.loads((run_dir / "analysis.json").read_text(encoding="utf-8"))
+    day = (analysis.get("event_days") or ["sun"])[0]
+    gun_by_event = {
+        str(e["name"]).lower(): float(e["start_time"])
+        for e in analysis.get("events") or []
+    }
+
+    junctions_doc = json.loads((package_dir / "junctions.json").read_text(encoding="utf-8"))
+    junction = next(
+        (
+            j
+            for j in junctions_doc.get("junctions") or []
+            if str(j.get("label") or "") == args.junction_label
+        ),
+        None,
+    )
+    if not junction:
+        raise SystemExit(f"Junction not found: {args.junction_label}")
+
+    nearby_by_id = {
+        str(s["seg_id"]): s for s in (junction.get("nearby_segments") or []) if s.get("seg_id")
+    }
+    events_needed = set()
+    for ix in junction.get("interactions") or []:
+        events_needed.update(str(e).lower() for e in (ix.get("events") or []))
+    runners_by_event = {e: _load_runners(package_dir, e) for e in sorted(events_needed)}
+
+    out_dir = args.out_dir or (run_dir / day / "reports" / "junctions_prototype")
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    summary: Dict[str, Any] = {
+        "run_id": args.run_id,
+        "package_id": args.package_id,
+        "junction_id": junction.get("id"),
+        "junction_label": junction.get("label"),
+        "method": {
+            "participation": "concurrent_stream_at_node",
+            "field_bands": "event_relative_pace_quintiles_Q1_lead_Q5_rear",
+            "timing_model": "gun + start_offset + pace*node_km (Flow-overlap equivalent)",
+            "node_dwell_sec": 30,
+        },
+        "interactions": [],
+    }
+
+    for ix in junction.get("interactions") or []:
+        result = analyze_interaction(ix, nearby_by_id, runners_by_event, gun_by_event)
+        ix_out = {
+            "id": result.interaction_id,
+            "type": result.type,
+            "side": result.side,
+            "label": result.label,
+            "events": result.events,
+            "window_start": result.window_start_hhmm,
+            "window_end": result.window_end_hhmm,
+            "window_minutes": round(result.window_minutes, 2),
+            "unique_by_role_event": result.unique_by_role_event,
+            "peak_concurrent": result.peak_concurrent,
+            "field_crosstab_top": result.field_crosstab[:15],
+            "notes": result.notes,
+        }
+        summary["interactions"].append(ix_out)
+
+        # minute CSV
+        if result.minute_rows:
+            csv_name = f"{result.interaction_id}_{result.type}_per_minute.csv"
+            csv_path = out_dir / csv_name
+            with csv_path.open("w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=list(result.minute_rows[0].keys()))
+                writer.writeheader()
+                writer.writerows(result.minute_rows)
+            ix_out["minute_csv"] = csv_name
+
+        # crosstab CSV
+        if result.field_crosstab:
+            ct_name = f"{result.interaction_id}_{result.type}_field_crosstab.csv"
+            ct_path = out_dir / ct_name
+            with ct_path.open("w", encoding="utf-8", newline="") as f:
+                writer = csv.DictWriter(f, fieldnames=list(result.field_crosstab[0].keys()))
+                writer.writeheader()
+                writer.writerows(result.field_crosstab)
+            ix_out["field_crosstab_csv"] = ct_name
+
+    summary_path = out_dir / "junction_summary.json"
+    summary_path.write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(summary, indent=2))
+    print(f"\nWrote {summary_path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_junction_flow_compute.py
+++ b/tests/unit/test_junction_flow_compute.py
@@ -1,0 +1,105 @@
+"""Unit tests for Junction Flow compute (Issue #818)."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from app.core.junction_flow.compute import (
+    MERGE_PARTNER_EVENTS,
+    NODE_DWELL_SEC,
+    StreamPresence,
+    _unique_with_copresence,
+    analyze_interaction,
+    analyze_junctions_doc,
+    prepare_runners_by_event,
+)
+import numpy as np
+
+
+def test_constants():
+    assert NODE_DWELL_SEC == 30.0
+    assert MERGE_PARTNER_EVENTS == ("full", "half")
+
+
+def test_prepare_runners_quintiles():
+    df = pd.DataFrame(
+        {
+            "runner_id": [f"r{i}" for i in range(10)],
+            "event": ["10k"] * 10,
+            "pace": [4.0 + 0.2 * i for i in range(10)],
+            "start_offset": [0] * 10,
+            "distance": [10] * 10,
+        }
+    )
+    by_event = prepare_runners_by_event(df)
+    assert "10k" in by_event
+    assert set(by_event["10k"]["quintile"].unique()) <= {1, 2, 3, 4, 5}
+
+
+def test_copresence_requires_partner_within_dwell():
+    primary = StreamPresence(
+        role="joining",
+        seg_id="S26",
+        event="10k",
+        runner_ids=np.array(["a", "b"]),
+        node_times_sec=np.array([1000.0, 2000.0]),
+        paces=np.array([5.0, 5.0]),
+        quintiles=np.array([3, 3]),
+    )
+    partner = StreamPresence(
+        role="through",
+        seg_id="S9",
+        event="full",
+        runner_ids=np.array(["f1"]),
+        node_times_sec=np.array([1010.0]),  # within 30s of a, not of b
+        paces=np.array([5.0]),
+        quintiles=np.array([1]),
+    )
+    stats = _unique_with_copresence(primary, partner, 0.0, 3000.0, dwell_sec=30.0)
+    assert stats["with_partner"] == 1
+    assert stats["without_partner"] == 1
+
+
+def test_merge_empty_without_full_half_partners():
+    runners = {
+        "10k": pd.DataFrame(
+            {
+                "runner_id": ["r1"],
+                "event": ["10k"],
+                "pace": [5.0],
+                "start_offset": [0.0],
+                "quintile": [3],
+            }
+        )
+    }
+    nearby = {
+        "S26": {
+            "seg_id": "S26",
+            "near_endpoint": "end",
+            "event_kms": {"10k": {"from_km": 8.0, "to_km": 9.0}},
+        },
+        "S9": {
+            "seg_id": "S9",
+            "near_endpoint": "start",
+            "event_kms": {"10k": {"from_km": 9.0, "to_km": 9.4}},
+        },
+    }
+    ix = {
+        "id": "m1",
+        "type": "merge",
+        "from_seg_id": "S26",
+        "to_seg_ids": ["S9"],
+        "events": ["10k"],
+    }
+    # Monkeypatch analyze path via analyze_interaction with empty full/half
+    # build nearby without full/half event_kms — partner_parts empty
+    result = analyze_interaction(ix, nearby, runners, {"10k": 480.0})
+    assert result.type == "merge"
+    assert "No full/half" in " ".join(result.notes) or result.unique_by_role_event == {}
+
+
+def test_analyze_junctions_doc_empty():
+    out = analyze_junctions_doc({"junctions": []}, {}, {})
+    assert out["ok"] is True
+    assert out["junctions"] == []
+    assert out["method"]["node_dwell_sec"] == NODE_DWELL_SEC


### PR DESCRIPTION
## Summary
- Adds Junction Flow compute to the **core analysis path** (Phase 4.3 / 6.4): dwell co-presence at the node; merge partners = full/half only.
- Persists `junction_flow_results.json`, UI metrics, and `reports/junctions/` artifacts per day.
- New Results peer **Junctions** (`/junctions` + `GET /api/junctions`) with concurrent charts, quintile crosstabs, and a Junction Reference section.

## Test plan
- [ ] Unit: `pytest tests/unit/test_junction_flow_compute.py`
- [ ] Run package analysis with authored junctions; confirm artifacts under `{day}/ui/metrics/junctions.json` and `reports/junctions/`
- [ ] Open `/junctions` for that run: headline co-presence stats, circle legends, column totals, reference card
- [ ] Package without `junctions.json` still completes analysis (empty junctions artifact)

Closes #818

Made with [Cursor](https://cursor.com)