### PR TITLE
Overview analysis progress for in-flight runs (#825)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Issue #825 — Overview analysis progress
+- Race-director **Preparing your results** card on Overview while a run is in flight
+- Coarse user stages mapped from pipeline phases (no Phase 3.2 / log console in the default UI)
+- `progress.json` + `GET /api/runs/{run_id}/progress` polled from Overview
+
 ### Issue #819 — Junctions authoring UX
 - Draggable junction pins; segment start/end markers (green within proximity)
 - Stream interaction map annotations, connector arcs, editable descriptions

--- a/app/core/v2/analysis_submit.py
+++ b/app/core/v2/analysis_submit.py
@@ -90,9 +90,22 @@ def run_analysis_background(
                 with open(day_metadata_path, "w", encoding="utf-8") as fh:
                     json.dump(day_metadata, fh, indent=2, ensure_ascii=False)
 
+        try:
+            from app.core.v2.run_progress import mark_run_complete
+
+            mark_run_complete(run_id)
+        except Exception:
+            pass
+
         logger.info("Background analysis completed for run_id: %s", run_id)
     except Exception as e:
         logger.error("Error in background analysis for run_id %s: %s", run_id, e, exc_info=True)
+        try:
+            from app.core.v2.run_progress import mark_run_failed
+
+            mark_run_failed(run_id, str(e))
+        except Exception:
+            pass
 
 
 def submit_v2_analysis(
@@ -136,6 +149,13 @@ def submit_v2_analysis(
     run_id = generate_run_id()
     run_path = get_run_directory(run_id)
     run_path.mkdir(parents=True, exist_ok=True)
+
+    try:
+        from app.core.v2.run_progress import init_run_progress
+
+        init_run_progress(run_id)
+    except Exception as e:
+        logger.warning("Failed to init progress.json for %s: %s", run_id, e)
 
     try:
         analysis_config = generate_analysis_json(

--- a/app/core/v2/performance.py
+++ b/app/core/v2/performance.py
@@ -92,7 +92,15 @@ class PerformanceMonitor:
             logger.info(f"[{phase_number}] ⏱️  Starting: {phase_description}")
         else:
             logger.info(f"⏱️  Starting phase: {phase_name}")
-        
+
+        # Issue #825: Overview progress
+        try:
+            from app.core.v2.run_progress import mark_phase_started
+
+            mark_phase_started(self.run_id, phase_name)
+        except Exception:
+            pass
+
         return metrics
     
     def get_total_elapsed(self) -> float:
@@ -145,6 +153,14 @@ class PerformanceMonitor:
             logger.info("═" * 65)
         else:
             logger.info(f"✅ Phase complete: {metrics.phase_name} {elapsed_str}")
+
+        # Issue #825: Overview progress
+        try:
+            from app.core.v2.run_progress import mark_phase_complete
+
+            mark_phase_complete(self.run_id, metrics.phase_name)
+        except Exception:
+            pass
     
     def check_guardrails(self, metrics: PerformanceMetrics) -> Dict[str, Any]:
         """

--- a/app/core/v2/run_progress.py
+++ b/app/core/v2/run_progress.py
@@ -1,0 +1,349 @@
+"""
+Run analysis progress for Overview (#825).
+
+Maps engineer pipeline phases to race-director user stages and persists
+runflow/analysis/{run_id}/progress.json for lightweight polling.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from app.utils.run_id import get_run_directory
+
+logger = logging.getLogger(__name__)
+
+PROGRESS_FILENAME = "progress.json"
+
+# Ordered user-facing stages (product copy).
+USER_STAGES: List[Dict[str, str]] = [
+    {"id": "inputs", "label": "Checking inputs"},
+    {"id": "density", "label": "Calculating density"},
+    {"id": "flow", "label": "Analyzing flow"},
+    {"id": "junctions", "label": "Analyzing junctions"},
+    {"id": "artifacts", "label": "Building maps and reports"},
+    {"id": "finish", "label": "Finishing up"},
+]
+
+# Pipeline phase_name → user stage id.
+PHASE_TO_USER_STAGE: Dict[str, str] = {
+    "phase_1_pre_analysis": "inputs",
+    "phase_2_data_loading": "inputs",
+    "phase_3_1_density_setup": "density",
+    "phase_3_2_density_compute": "density",
+    "phase_4_1_flow_build_segments": "flow",
+    "phase_4_2_flow_compute": "flow",
+    "phase_4_3_junction_flow": "junctions",
+    "phase_5_1_bin_generation": "artifacts",
+    "phase_5_2_bin_validation": "artifacts",
+    "phase_6_1_persist_density": "artifacts",
+    "phase_6_2_persist_flow": "artifacts",
+    "phase_6_3_persist_locations": "artifacts",
+    "phase_6_4_persist_junction_flow": "junctions",
+    "phase_7_ui_artifacts": "artifacts",
+    "phase_8_derived_metrics": "artifacts",
+    "phase_9_map_data": "artifacts",
+    "phase_10_reports": "artifacts",
+    "phase_11_metadata": "finish",
+}
+
+STAGE_PHASES: Dict[str, List[str]] = {}
+for _phase, _stage in PHASE_TO_USER_STAGE.items():
+    STAGE_PHASES.setdefault(_stage, []).append(_phase)
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def progress_path(run_id: str) -> Path:
+    return get_run_directory(run_id) / PROGRESS_FILENAME
+
+
+def _empty_stage_states() -> List[Dict[str, Any]]:
+    return [
+        {"id": s["id"], "label": s["label"], "state": "pending"}
+        for s in USER_STAGES
+    ]
+
+
+def build_progress_payload(
+    *,
+    run_id: str,
+    status: str,
+    completed_phases: Optional[List[str]] = None,
+    current_phase: Optional[str] = None,
+    message: Optional[str] = None,
+    error: Optional[str] = None,
+    started_at: Optional[str] = None,
+    junctions_note: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build a progress.json document from completed pipeline phase names."""
+    completed = list(completed_phases or [])
+    completed_set = set(completed)
+
+    stages = _empty_stage_states()
+    stage_by_id = {s["id"]: s for s in stages}
+
+    # Mark stages fully done when all of their phases are complete
+    # (or when a later stage has already started/completed — resilient to
+    # phases that log without going through PerformanceMonitor).
+    stage_order = [s["id"] for s in USER_STAGES]
+    highest_touched = -1
+    for phase in completed:
+        sid = PHASE_TO_USER_STAGE.get(phase)
+        if sid in stage_order:
+            highest_touched = max(highest_touched, stage_order.index(sid))
+    if current_phase and current_phase in PHASE_TO_USER_STAGE:
+        highest_touched = max(
+            highest_touched, stage_order.index(PHASE_TO_USER_STAGE[current_phase])
+        )
+
+    for idx, sid in enumerate(stage_order):
+        phases = STAGE_PHASES.get(sid, [])
+        if phases and all(p in completed_set for p in phases):
+            stage_by_id[sid]["state"] = "done"
+        elif idx < highest_touched:
+            # Earlier stage implied complete if we've moved past it
+            stage_by_id[sid]["state"] = "done"
+
+    current_stage_id = None
+    if status == "running":
+        if current_phase and current_phase in PHASE_TO_USER_STAGE:
+            current_stage_id = PHASE_TO_USER_STAGE[current_phase]
+        else:
+            for sid in stage_order:
+                if stage_by_id[sid]["state"] != "done":
+                    current_stage_id = sid
+                    break
+        if current_stage_id:
+            stage_by_id[current_stage_id]["state"] = "current"
+    elif status == "PASS":
+        for s in stages:
+            s["state"] = "done"
+        current_stage_id = "finish"
+    elif status == "FAIL":
+        # Leave completed stages; mark current as failed via message
+        if current_phase and current_phase in PHASE_TO_USER_STAGE:
+            current_stage_id = PHASE_TO_USER_STAGE[current_phase]
+            stage_by_id[current_stage_id]["state"] = "current"
+
+    if junctions_note and stage_by_id.get("junctions", {}).get("state") == "done":
+        stage_by_id["junctions"]["note"] = junctions_note
+
+    done_count = sum(1 for s in stages if s["state"] == "done")
+    total = len(stages)
+    step_index = min(done_count + (1 if status == "running" else 0), total)
+    if status == "PASS":
+        step_index = total
+
+    user_stage_label = None
+    if current_stage_id:
+        user_stage_label = stage_by_id[current_stage_id]["label"]
+
+    if message is None:
+        if status == "running" and user_stage_label:
+            message = f"Step {step_index} of {total} — {user_stage_label}"
+        elif status == "PASS":
+            message = "Analysis complete"
+        elif status == "FAIL":
+            message = "Analysis could not finish"
+        else:
+            message = "Preparing your results"
+
+    return {
+        "run_id": run_id,
+        "status": status,
+        "started_at": started_at or _utc_now_iso(),
+        "updated_at": _utc_now_iso(),
+        "current_phase": current_phase,
+        "completed_phases": completed,
+        "user_stage": current_stage_id,
+        "user_stage_label": user_stage_label,
+        "user_stages": stages,
+        "step_index": step_index,
+        "step_total": total,
+        "percent": int(round(100.0 * done_count / total)) if total else 0,
+        "message": message,
+        "error": error,
+    }
+
+
+def write_progress(run_id: str, payload: Dict[str, Any]) -> Path:
+    path = progress_path(run_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".json.tmp")
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(payload, fh, indent=2, ensure_ascii=False)
+    tmp.replace(path)
+    return path
+
+
+def read_progress(run_id: str) -> Optional[Dict[str, Any]]:
+    path = progress_path(run_id)
+    if not path.is_file():
+        return None
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else None
+    except (OSError, json.JSONDecodeError) as e:
+        logger.warning("Failed to read progress for %s: %s", run_id, e)
+        return None
+
+
+def init_run_progress(run_id: str) -> Dict[str, Any]:
+    """Create initial running progress.json when analysis is accepted."""
+    payload = build_progress_payload(
+        run_id=run_id,
+        status="running",
+        completed_phases=[],
+        current_phase="phase_1_pre_analysis",
+        message="Step 1 of 6 — Checking inputs",
+    )
+    write_progress(run_id, payload)
+    return payload
+
+
+def _merge_from_disk(run_id: str) -> Dict[str, Any]:
+    existing = read_progress(run_id) or {}
+    return {
+        "completed_phases": list(existing.get("completed_phases") or []),
+        "started_at": existing.get("started_at"),
+        "junctions_note": None,
+    }
+
+
+def mark_phase_started(run_id: Optional[str], phase_name: str) -> None:
+    if not run_id or phase_name not in PHASE_TO_USER_STAGE:
+        return
+    try:
+        base = _merge_from_disk(run_id)
+        payload = build_progress_payload(
+            run_id=run_id,
+            status="running",
+            completed_phases=base["completed_phases"],
+            current_phase=phase_name,
+            started_at=base["started_at"],
+        )
+        write_progress(run_id, payload)
+    except Exception as e:
+        logger.warning("progress mark_phase_started failed for %s: %s", run_id, e)
+
+
+def mark_phase_complete(run_id: Optional[str], phase_name: str) -> None:
+    if not run_id or phase_name not in PHASE_TO_USER_STAGE:
+        return
+    try:
+        base = _merge_from_disk(run_id)
+        completed = base["completed_phases"]
+        if phase_name not in completed:
+            completed.append(phase_name)
+        payload = build_progress_payload(
+            run_id=run_id,
+            status="running",
+            completed_phases=completed,
+            current_phase=phase_name,
+            started_at=base["started_at"],
+        )
+        write_progress(run_id, payload)
+    except Exception as e:
+        logger.warning("progress mark_phase_complete failed for %s: %s", run_id, e)
+
+
+def mark_run_complete(run_id: Optional[str]) -> None:
+    if not run_id:
+        return
+    try:
+        base = _merge_from_disk(run_id)
+        # Ensure all known phases appear complete for UI
+        all_phases = list(PHASE_TO_USER_STAGE.keys())
+        completed = list(dict.fromkeys(base["completed_phases"] + all_phases))
+        payload = build_progress_payload(
+            run_id=run_id,
+            status="PASS",
+            completed_phases=completed,
+            current_phase="phase_11_metadata",
+            started_at=base["started_at"],
+            message="Analysis complete",
+        )
+        write_progress(run_id, payload)
+    except Exception as e:
+        logger.warning("progress mark_run_complete failed for %s: %s", run_id, e)
+
+
+def mark_run_failed(run_id: Optional[str], error: str) -> None:
+    if not run_id:
+        return
+    try:
+        base = _merge_from_disk(run_id)
+        payload = build_progress_payload(
+            run_id=run_id,
+            status="FAIL",
+            completed_phases=base["completed_phases"],
+            current_phase=None,
+            started_at=base["started_at"],
+            message="Analysis could not finish",
+            error=(error or "Unknown error")[:500],
+        )
+        write_progress(run_id, payload)
+    except Exception as e:
+        logger.warning("progress mark_run_failed failed for %s: %s", run_id, e)
+
+
+def resolve_progress_for_api(run_id: str) -> Dict[str, Any]:
+    """
+    Return progress for GET /api/runs/{run_id}/progress.
+
+    Fallbacks when progress.json is missing:
+    - metadata.json status PASS → synthetic complete
+    - analysis.json present, no metadata → running at stage 1
+    - else 404-shaped None (caller raises)
+    """
+    existing = read_progress(run_id)
+    if existing:
+        return existing
+
+    run_path = get_run_directory(run_id)
+    if not run_path.is_dir():
+        raise FileNotFoundError(f"Run {run_id} not found")
+
+    meta_path = run_path / "metadata.json"
+    if meta_path.is_file():
+        try:
+            with open(meta_path, "r", encoding="utf-8") as fh:
+                meta = json.load(fh)
+            status = str(meta.get("status") or "PASS").upper()
+            if status in ("PASS", "PARTIAL"):
+                return build_progress_payload(
+                    run_id=run_id,
+                    status="PASS",
+                    completed_phases=list(PHASE_TO_USER_STAGE.keys()),
+                    message="Analysis complete",
+                    started_at=meta.get("created_at"),
+                )
+            if status == "FAIL":
+                return build_progress_payload(
+                    run_id=run_id,
+                    status="FAIL",
+                    completed_phases=[],
+                    error="Analysis failed",
+                    started_at=meta.get("created_at"),
+                )
+        except (OSError, json.JSONDecodeError):
+            pass
+
+    if (run_path / "analysis.json").is_file():
+        return build_progress_payload(
+            run_id=run_id,
+            status="running",
+            completed_phases=[],
+            current_phase="phase_1_pre_analysis",
+            message="Step 1 of 6 — Checking inputs",
+        )
+
+    raise FileNotFoundError(f"Run {run_id} not found")

--- a/app/routes/api_dashboard.py
+++ b/app/routes/api_dashboard.py
@@ -460,6 +460,36 @@ async def get_runs_list():
         )
 
 
+@router.get("/api/runs/{run_id}/progress")
+async def get_run_progress(run_id: str):
+    """
+    Issue #825: Race-director analysis progress for Overview polling.
+
+    Returns progress.json (or a synthetic fallback from metadata / analysis.json).
+    """
+    try:
+        from app.core.v2.run_progress import resolve_progress_for_api
+        from app.utils.run_id import get_run_directory
+
+        # Light validation: reject path traversal style ids
+        if not run_id or "/" in run_id or ".." in run_id:
+            raise HTTPException(status_code=400, detail="Invalid run_id")
+        # Ensure directory naming is consistent
+        _ = get_run_directory(run_id)
+        payload = resolve_progress_for_api(run_id)
+        return JSONResponse(
+            content=payload,
+            headers={"Cache-Control": "no-store"},
+        )
+    except FileNotFoundError:
+        raise HTTPException(status_code=404, detail=f"Run {run_id} not found")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Error getting run progress for %s: %s", run_id, e)
+        raise HTTPException(status_code=500, detail="Failed to load run progress")
+
+
 @router.get("/api/runs/{run_id}/summary")
 async def get_run_summary(run_id: str):
     """

--- a/frontend/static/js/run_overview_progress.js
+++ b/frontend/static/js/run_overview_progress.js
@@ -1,0 +1,182 @@
+/**
+ * Issue #825: Overview analysis progress card (race-director facing).
+ */
+(function (global) {
+    'use strict';
+
+    function escapeHtml(s) {
+        return String(s == null ? '' : s)
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
+    }
+
+    function formatElapsed(startedAt) {
+        if (!startedAt) return '';
+        var start = Date.parse(startedAt);
+        if (!isFinite(start)) return '';
+        var sec = Math.max(0, Math.floor((Date.now() - start) / 1000));
+        var m = Math.floor(sec / 60);
+        var s = sec % 60;
+        return m + ':' + String(s).padStart(2, '0');
+    }
+
+    function stageIcon(state) {
+        if (state === 'done') return '✓';
+        if (state === 'current') return '…';
+        return '○';
+    }
+
+    function renderProgressCard(data) {
+        var card = document.getElementById('rf-overview-progress');
+        if (!card) return;
+
+        var status = (data && data.status) || '';
+        if (status === 'PASS') {
+            card.style.display = 'block';
+            card.className = 'card rf-overview-progress rf-overview-progress--done';
+            card.innerHTML =
+                '<h3 style="margin-bottom:0.35rem;">Analysis complete</h3>' +
+                '<p class="text-secondary mb-0">Results are ready below.</p>';
+            return;
+        }
+        if (status === 'FAIL') {
+            card.style.display = 'block';
+            card.className = 'card rf-overview-progress rf-overview-progress--fail';
+            card.innerHTML =
+                '<h3 style="margin-bottom:0.35rem;">Analysis could not finish</h3>' +
+                '<p class="text-secondary">' +
+                escapeHtml((data && data.error) || 'Something went wrong while preparing results.') +
+                '</p>' +
+                '<p class="mb-0"><a href="/config">Open Build</a> to adjust the package and try again.</p>';
+            return;
+        }
+        if (status !== 'running') {
+            card.style.display = 'none';
+            card.innerHTML = '';
+            return;
+        }
+
+        var percent = Math.max(0, Math.min(100, Number(data.percent) || 0));
+        if (data.step_index && data.step_total) {
+            percent = Math.round((100 * (Number(data.step_index) - 1)) / Number(data.step_total));
+            // Show some fill while on step 1
+            if (percent < 8) percent = 8;
+        }
+        var elapsed = formatElapsed(data.started_at);
+        var stages = data.user_stages || [];
+        var listHtml = stages
+            .map(function (st) {
+                var cls = 'rf-progress-stage rf-progress-stage--' + (st.state || 'pending');
+                var note = st.note
+                    ? ' <span class="text-secondary">(' + escapeHtml(st.note) + ')</span>'
+                    : '';
+                return (
+                    '<li class="' +
+                    cls +
+                    '"><span class="rf-progress-stage-icon" aria-hidden="true">' +
+                    stageIcon(st.state) +
+                    '</span> ' +
+                    escapeHtml(st.label) +
+                    note +
+                    '</li>'
+                );
+            })
+            .join('');
+
+        card.style.display = 'block';
+        card.className = 'card rf-overview-progress';
+        card.innerHTML =
+            '<h3 style="margin-bottom:0.35rem;">Preparing your results</h3>' +
+            '<p class="text-secondary" style="margin-bottom:0.75rem;">' +
+            escapeHtml(data.message || 'Working…') +
+            (elapsed ? ' <span class="rf-progress-elapsed">· Running ' + escapeHtml(elapsed) + '</span>' : '') +
+            '</p>' +
+            '<div class="rf-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' +
+            percent +
+            '"><div class="rf-progress-bar-fill" style="width:' +
+            percent +
+            '%;"></div></div>' +
+            '<ul class="rf-progress-stages">' +
+            listHtml +
+            '</ul>' +
+            '<p class="text-secondary small mb-0">This usually takes a few minutes. You can leave this page open.</p>';
+    }
+
+    function hideProgressCard() {
+        var card = document.getElementById('rf-overview-progress');
+        if (!card) return;
+        card.style.display = 'none';
+        card.innerHTML = '';
+    }
+
+    /**
+     * Poll progress until PASS/FAIL. onComplete(status) when terminal.
+     * Returns a stop() function.
+     */
+    function watchRunProgress(runId, fetchJson, onComplete) {
+        var stopped = false;
+        var started = Date.now();
+        var timer = null;
+        var seenRunning = false;
+
+        function delayMs() {
+            return Date.now() - started > 120000 ? 4000 : 2000;
+        }
+
+        function tick() {
+            if (stopped || !runId) return;
+            fetchJson('/api/runs/' + encodeURIComponent(runId) + '/progress')
+                .then(function (data) {
+                    if (stopped) return;
+                    renderProgressCard(data);
+                    var status = data && data.status;
+                    if (status === 'running') {
+                        seenRunning = true;
+                        timer = setTimeout(tick, delayMs());
+                        return;
+                    }
+                    if (status === 'PASS' || status === 'FAIL') {
+                        if (status === 'PASS' && !seenRunning) {
+                            hideProgressCard();
+                            if (typeof onComplete === 'function') onComplete(status, data);
+                            return;
+                        }
+                        if (typeof onComplete === 'function') onComplete(status, data);
+                        if (status === 'PASS') {
+                            setTimeout(function () {
+                                if (!stopped) hideProgressCard();
+                            }, 3000);
+                        }
+                        return;
+                    }
+                    // Unknown — keep polling briefly if we never saw running
+                    if (!seenRunning && Date.now() - started < 15000) {
+                        timer = setTimeout(tick, delayMs());
+                    } else {
+                        hideProgressCard();
+                    }
+                })
+                .catch(function () {
+                    if (stopped) return;
+                    // Run may not exist yet; retry a few times
+                    if (Date.now() - started < 30000) {
+                        timer = setTimeout(tick, delayMs());
+                    }
+                });
+        }
+
+        tick();
+        return function stop() {
+            stopped = true;
+            if (timer) clearTimeout(timer);
+        };
+    }
+
+    global.RunOverviewProgress = {
+        watchRunProgress: watchRunProgress,
+        renderProgressCard: renderProgressCard,
+        hideProgressCard: hideProgressCard,
+    };
+})(window);

--- a/frontend/templates/pages/overview.html
+++ b/frontend/templates/pages/overview.html
@@ -21,6 +21,8 @@
 </div>
 
 <div id="rf-overview-body" style="display: none;">
+    <div id="rf-overview-progress" class="card rf-overview-progress" style="display: none; margin-bottom: 1.25rem;" aria-live="polite"></div>
+
     <div id="analysis-inputs-section" class="card" style="display: none; margin-bottom: 1.25rem;">
         <h3 style="margin-bottom: 1rem;">Analysis Inputs</h3>
         <div id="analysis-inputs-content"></div>
@@ -52,14 +54,50 @@
 .rf-overview-lead { margin: 0.35rem 0 0; color: #667382; font-size: 0.9rem; max-width: 40rem; }
 .rf-overview-meta { margin-bottom: 1rem; }
 .rf-overview-subhead { margin: 1rem 0 0.5rem; font-size: 1rem; color: #34495e; }
+.rf-overview-progress { border-left: 4px solid #206bc4; }
+.rf-overview-progress--done { border-left-color: #2fb344; }
+.rf-overview-progress--fail { border-left-color: #d63939; }
+.rf-progress-bar {
+    height: 8px;
+    background: #e6e8eb;
+    border-radius: 4px;
+    overflow: hidden;
+    margin-bottom: 0.85rem;
+}
+.rf-progress-bar-fill {
+    height: 100%;
+    background: #206bc4;
+    border-radius: 4px;
+    transition: width 0.4s ease;
+}
+.rf-progress-stages {
+    list-style: none;
+    margin: 0 0 0.75rem;
+    padding: 0;
+}
+.rf-progress-stage {
+    padding: 0.2rem 0;
+    color: #667382;
+    font-size: 0.9rem;
+}
+.rf-progress-stage--done { color: #2fb344; }
+.rf-progress-stage--current { color: #1e293b; font-weight: 600; }
+.rf-progress-stage-icon {
+    display: inline-block;
+    width: 1.1rem;
+    text-align: center;
+}
+.rf-progress-elapsed { white-space: nowrap; }
 </style>
 {% endblock %}
 
 {% block extra_scripts %}
-<script src="/static/js/run_overview.js?v=796h"></script>
+<script src="/static/js/run_overview.js?v=825a"></script>
+<script src="/static/js/run_overview_progress.js?v=825a"></script>
 <script>
 (function () {
     var tabler = document.documentElement.classList.contains('rf-tabler');
+    var stopProgressWatch = null;
 
     function fetchJson(url) {
         return fetch(url, { credentials: 'same-origin' }).then(function (r) {
@@ -105,15 +143,8 @@
         document.getElementById('rf-overview-body').style.display = 'block';
     }
 
-    function boot(runId) {
-        document.getElementById('rf-overview-body').dataset.booted = '1';
-        if (!runId) {
-            showEmpty();
-            return;
-        }
-        localStorage.setItem('selected_run_id', runId);
-        showBody();
-        window.RunOverview.loadRunSummary(runId, fetchJson)
+    function loadSummary(runId) {
+        return window.RunOverview.loadRunSummary(runId, fetchJson)
             .then(function (data) {
                 var days = data.days || [];
                 var day = resolveDay();
@@ -121,17 +152,42 @@
                 else if (!day && days.length) day = days[0];
                 if (day) localStorage.setItem('selected_day', day);
                 if (window.updateNavLinks) window.updateNavLinks(day, runId);
-            })
-            .catch(function () {
-                showBody();
+                return data;
             });
+    }
+
+    function boot(runId) {
+        document.getElementById('rf-overview-body').dataset.booted = '1';
+        if (stopProgressWatch) {
+            stopProgressWatch();
+            stopProgressWatch = null;
+        }
+        if (!runId) {
+            showEmpty();
+            return;
+        }
+        localStorage.setItem('selected_run_id', runId);
+        showBody();
+        loadSummary(runId).catch(function () {
+            showBody();
+        });
+        if (window.RunOverviewProgress) {
+            stopProgressWatch = window.RunOverviewProgress.watchRunProgress(
+                runId,
+                fetchJson,
+                function (status) {
+                    if (status === 'PASS') {
+                        loadSummary(runId).catch(function () {});
+                    }
+                }
+            );
+        }
     }
 
     function onReady() {
         boot(resolveRunId());
     }
 
-    // Prefer URL/localStorage immediately; refresh when base day/run init finishes.
     document.addEventListener('DOMContentLoaded', onReady);
     window.addEventListener('runflow:context-ready', function (ev) {
         var id = (ev.detail && ev.detail.run_id) || resolveRunId();

--- a/tests/unit/test_run_progress.py
+++ b/tests/unit/test_run_progress.py
@@ -1,0 +1,103 @@
+"""Unit tests for Overview run progress (#825)."""
+
+from __future__ import annotations
+
+from app.core.v2.run_progress import (
+    PHASE_TO_USER_STAGE,
+    USER_STAGES,
+    build_progress_payload,
+    init_run_progress,
+    mark_phase_complete,
+    mark_phase_started,
+    mark_run_complete,
+    mark_run_failed,
+    read_progress,
+    resolve_progress_for_api,
+)
+
+
+def test_user_stages_order():
+    assert [s["id"] for s in USER_STAGES] == [
+        "inputs",
+        "density",
+        "flow",
+        "junctions",
+        "artifacts",
+        "finish",
+    ]
+
+
+def test_phase_mapping_covers_catalog():
+    assert PHASE_TO_USER_STAGE["phase_3_2_density_compute"] == "density"
+    assert PHASE_TO_USER_STAGE["phase_4_3_junction_flow"] == "junctions"
+    assert PHASE_TO_USER_STAGE["phase_6_4_persist_junction_flow"] == "junctions"
+    assert PHASE_TO_USER_STAGE["phase_11_metadata"] == "finish"
+
+
+def test_build_progress_advances_stages():
+    payload = build_progress_payload(
+        run_id="abc",
+        status="running",
+        completed_phases=["phase_1_pre_analysis", "phase_2_data_loading"],
+        current_phase="phase_3_1_density_setup",
+    )
+    by_id = {s["id"]: s["state"] for s in payload["user_stages"]}
+    assert by_id["inputs"] == "done"
+    assert by_id["density"] == "current"
+    assert payload["user_stage"] == "density"
+    assert "Calculating density" in payload["message"]
+
+
+def test_progress_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.v2.run_progress.get_run_directory",
+        lambda run_id: tmp_path / run_id,
+    )
+    run_id = "testrun825"
+    (tmp_path / run_id).mkdir()
+    init_run_progress(run_id)
+    data = read_progress(run_id)
+    assert data is not None
+    assert data["status"] == "running"
+    assert data["user_stage"] == "inputs"
+
+    mark_phase_started(run_id, "phase_3_2_density_compute")
+    mark_phase_complete(run_id, "phase_1_pre_analysis")
+    mark_phase_complete(run_id, "phase_2_data_loading")
+    mark_phase_complete(run_id, "phase_3_2_density_compute")
+    data = read_progress(run_id)
+    assert "phase_3_2_density_compute" in data["completed_phases"]
+
+    mark_run_complete(run_id)
+    data = read_progress(run_id)
+    assert data["status"] == "PASS"
+    assert all(s["state"] == "done" for s in data["user_stages"])
+
+
+def test_mark_failed(tmp_path, monkeypatch):
+    monkeypatch.setattr(
+        "app.core.v2.run_progress.get_run_directory",
+        lambda run_id: tmp_path / run_id,
+    )
+    run_id = "fail825"
+    (tmp_path / run_id).mkdir()
+    init_run_progress(run_id)
+    mark_run_failed(run_id, "boom")
+    data = read_progress(run_id)
+    assert data["status"] == "FAIL"
+    assert data["error"] == "boom"
+
+
+def test_resolve_fallback_from_metadata(tmp_path, monkeypatch):
+    import json
+
+    monkeypatch.setattr(
+        "app.core.v2.run_progress.get_run_directory",
+        lambda run_id: tmp_path / run_id,
+    )
+    run_id = "old825"
+    d = tmp_path / run_id
+    d.mkdir()
+    (d / "metadata.json").write_text(json.dumps({"status": "PASS", "created_at": "t"}))
+    payload = resolve_progress_for_api(run_id)
+    assert payload["status"] == "PASS"


### PR DESCRIPTION
## Summary
- Adds a race-director **Preparing your results** card on Overview while analysis runs in the background
- Maps internal pipeline phases to 6 coarse user stages; persists `progress.json` and exposes `GET /api/runs/{run_id}/progress`
- Polls Overview (~2s) until PASS/FAIL, then refreshes Inputs/Outputs

Closes #825

## Test plan
- [x] Unit tests: `tests/unit/test_run_progress.py`
- [x] Manual: Start analysis from Build (e.g. River Trail) → Overview shows progress stages and elapsed time
- [ ] Confirm completed runs do not flash the progress card when reopening Overview
- [ ] Confirm FAIL path shows a short error and Build link if a run fails


Made with [Cursor](https://cursor.com)