### PR TITLE
Keep Overview progress responsive during analysis

### DIFF
--- a/app/core/v2/analysis_submit.py
+++ b/app/core/v2/analysis_submit.py
@@ -6,9 +6,9 @@ from __future__ import annotations
 
 import json
 import logging
-import os
+import threading
 from pathlib import Path
-from typing import Any, Dict, List, Union
+from typing import Any, Dict, List, Optional, Union
 
 from fastapi import BackgroundTasks, status
 from fastapi.responses import JSONResponse
@@ -21,6 +21,10 @@ from app.core.v2.validation import ValidationError, validate_api_payload
 from app.utils.run_id import generate_run_id, get_run_directory
 
 logger = logging.getLogger(__name__)
+
+# Keep a strong reference so GC does not collect live analysis threads.
+_ACTIVE_ANALYSIS_THREADS: Dict[str, threading.Thread] = {}
+_ACTIVE_ANALYSIS_LOCK = threading.Lock()
 
 
 def map_data_dir_for_runtime(data_dir: str) -> str:
@@ -106,11 +110,59 @@ def run_analysis_background(
             mark_run_failed(run_id, str(e))
         except Exception:
             pass
+    finally:
+        with _ACTIVE_ANALYSIS_LOCK:
+            _ACTIVE_ANALYSIS_THREADS.pop(run_id, None)
+
+
+def enqueue_analysis_run(
+    *,
+    events,
+    segments_file: str,
+    locations_file: str,
+    flow_file: str,
+    data_dir: str,
+    run_id: str,
+    request_payload: Dict[str, Any],
+) -> threading.Thread:
+    """
+    Start analysis on a dedicated daemon thread.
+
+    FastAPI BackgroundTasks share the server threadpool and can starve HTTP
+    (including /progress polling) under CPU-heavy phases. A dedicated thread
+    keeps request handling responsive enough for Overview progress updates.
+    """
+    thread = threading.Thread(
+        target=run_analysis_background,
+        kwargs={
+            "events": events,
+            "segments_file": segments_file,
+            "locations_file": locations_file,
+            "flow_file": flow_file,
+            "data_dir": data_dir,
+            "run_id": run_id,
+            "request_payload": request_payload,
+        },
+        name=f"runflow-analysis-{run_id}",
+        daemon=True,
+    )
+    with _ACTIVE_ANALYSIS_LOCK:
+        existing = _ACTIVE_ANALYSIS_THREADS.get(run_id)
+        if existing is not None and existing.is_alive():
+            logger.warning(
+                "Analysis thread already running for run_id=%s; not starting another",
+                run_id,
+            )
+            return existing
+        _ACTIVE_ANALYSIS_THREADS[run_id] = thread
+    thread.start()
+    logger.info("Started analysis thread %s for run_id=%s", thread.name, run_id)
+    return thread
 
 
 def submit_v2_analysis(
     payload_dict: Dict[str, Any],
-    background_tasks: BackgroundTasks,
+    background_tasks: Optional[BackgroundTasks] = None,
 ) -> Union[V2AnalyzeResponse, JSONResponse]:
     """Validate payload, write analysis.json, and queue the background pipeline."""
     data_dir = payload_dict.get("data_dir") or get_data_directory()
@@ -209,8 +261,10 @@ def submit_v2_analysis(
             metadata=f"runflow/analysis/{run_id}/{day_code}/metadata.json",
         )
 
-    background_tasks.add_task(
-        run_analysis_background,
+    # Prefer a dedicated thread over FastAPI BackgroundTasks so long CPU-bound
+    # phases do not contend with the shared ASGI threadpool used for HTTP.
+    _ = background_tasks  # kept for call-site compatibility
+    enqueue_analysis_run(
         events=events,
         segments_file=segments_file,
         locations_file=locations_file,

--- a/app/core/v2/run_progress.py
+++ b/app/core/v2/run_progress.py
@@ -71,6 +71,18 @@ def _empty_stage_states() -> List[Dict[str, Any]]:
     ]
 
 
+def normalize_phase_name(phase_name: Optional[str]) -> Optional[str]:
+    """Map day-suffixed phase ids (e.g. phase_5_1_bin_generation_sun) to catalog keys."""
+    if not phase_name:
+        return None
+    if phase_name in PHASE_TO_USER_STAGE:
+        return phase_name
+    for catalog_name in PHASE_TO_USER_STAGE:
+        if phase_name.startswith(catalog_name + "_"):
+            return catalog_name
+    return phase_name
+
+
 def build_progress_payload(
     *,
     run_id: str,
@@ -83,8 +95,13 @@ def build_progress_payload(
     junctions_note: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Build a progress.json document from completed pipeline phase names."""
-    completed = list(completed_phases or [])
+    completed = []
+    for phase in completed_phases or []:
+        normalized = normalize_phase_name(phase) or phase
+        if normalized not in completed:
+            completed.append(normalized)
     completed_set = set(completed)
+    current_phase = normalize_phase_name(current_phase) or current_phase
 
     stages = _empty_stage_states()
     stage_by_id = {s["id"]: s for s in stages}
@@ -219,6 +236,7 @@ def _merge_from_disk(run_id: str) -> Dict[str, Any]:
 
 
 def mark_phase_started(run_id: Optional[str], phase_name: str) -> None:
+    phase_name = normalize_phase_name(phase_name) or phase_name
     if not run_id or phase_name not in PHASE_TO_USER_STAGE:
         return
     try:
@@ -236,6 +254,7 @@ def mark_phase_started(run_id: Optional[str], phase_name: str) -> None:
 
 
 def mark_phase_complete(run_id: Optional[str], phase_name: str) -> None:
+    phase_name = normalize_phase_name(phase_name) or phase_name
     if not run_id or phase_name not in PHASE_TO_USER_STAGE:
         return
     try:

--- a/app/routes/api_dashboard.py
+++ b/app/routes/api_dashboard.py
@@ -468,6 +468,8 @@ async def get_run_progress(run_id: str):
     Returns progress.json (or a synthetic fallback from metadata / analysis.json).
     """
     try:
+        import asyncio
+
         from app.core.v2.run_progress import resolve_progress_for_api
         from app.utils.run_id import get_run_directory
 
@@ -476,7 +478,9 @@ async def get_run_progress(run_id: str):
             raise HTTPException(status_code=400, detail="Invalid run_id")
         # Ensure directory naming is consistent
         _ = get_run_directory(run_id)
-        payload = resolve_progress_for_api(run_id)
+        # Offload sync filesystem work so the event loop stays free while
+        # analysis runs on a sibling thread.
+        payload = await asyncio.to_thread(resolve_progress_for_api, run_id)
         return JSONResponse(
             content=payload,
             headers={"Cache-Control": "no-store"},

--- a/frontend/static/js/run_overview_progress.js
+++ b/frontend/static/js/run_overview_progress.js
@@ -4,6 +4,9 @@
 (function (global) {
     'use strict';
 
+    var elapsedTimer = null;
+    var lastProgressData = null;
+
     function escapeHtml(s) {
         return String(s == null ? '' : s)
             .replace(/&/g, '&amp;')
@@ -28,12 +31,33 @@
         return '○';
     }
 
+    function stopElapsedTicker() {
+        if (elapsedTimer) {
+            clearInterval(elapsedTimer);
+            elapsedTimer = null;
+        }
+    }
+
+    function startElapsedTicker() {
+        stopElapsedTicker();
+        elapsedTimer = setInterval(function () {
+            var el = document.querySelector('#rf-overview-progress .rf-progress-elapsed');
+            if (!el || !lastProgressData || lastProgressData.status !== 'running') {
+                return;
+            }
+            var elapsed = formatElapsed(lastProgressData.started_at);
+            if (elapsed) el.textContent = '· Running ' + elapsed;
+        }, 1000);
+    }
+
     function renderProgressCard(data) {
         var card = document.getElementById('rf-overview-progress');
         if (!card) return;
+        lastProgressData = data || null;
 
         var status = (data && data.status) || '';
         if (status === 'PASS') {
+            stopElapsedTicker();
             card.style.display = 'block';
             card.className = 'card rf-overview-progress rf-overview-progress--done';
             card.innerHTML =
@@ -42,6 +66,7 @@
             return;
         }
         if (status === 'FAIL') {
+            stopElapsedTicker();
             card.style.display = 'block';
             card.className = 'card rf-overview-progress rf-overview-progress--fail';
             card.innerHTML =
@@ -53,6 +78,7 @@
             return;
         }
         if (status !== 'running') {
+            stopElapsedTicker();
             card.style.display = 'none';
             card.innerHTML = '';
             return;
@@ -65,6 +91,15 @@
             if (percent < 8) percent = 8;
         }
         var elapsed = formatElapsed(data.started_at);
+        var stageSeconds = 0;
+        if (data.updated_at) {
+            var u = Date.parse(data.updated_at);
+            if (isFinite(u)) stageSeconds = Math.max(0, Math.floor((Date.now() - u) / 1000));
+        }
+        var longHint =
+            stageSeconds >= 45
+                ? '<p class="text-secondary small" style="margin:0 0 0.75rem;">Still working on this step — larger races can take a couple of minutes here.</p>'
+                : '';
         var stages = data.user_stages || [];
         var listHtml = stages
             .map(function (st) {
@@ -89,10 +124,13 @@
         card.className = 'card rf-overview-progress';
         card.innerHTML =
             '<h3 style="margin-bottom:0.35rem;">Preparing your results</h3>' +
-            '<p class="text-secondary" style="margin-bottom:0.75rem;">' +
+            '<p class="text-secondary" style="margin-bottom:0.35rem;">' +
             escapeHtml(data.message || 'Working…') +
-            (elapsed ? ' <span class="rf-progress-elapsed">· Running ' + escapeHtml(elapsed) + '</span>' : '') +
+            (elapsed
+                ? ' <span class="rf-progress-elapsed">· Running ' + escapeHtml(elapsed) + '</span>'
+                : '') +
             '</p>' +
+            longHint +
             '<div class="rf-progress-bar" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="' +
             percent +
             '"><div class="rf-progress-bar-fill" style="width:' +
@@ -102,9 +140,12 @@
             listHtml +
             '</ul>' +
             '<p class="text-secondary small mb-0">This usually takes a few minutes. You can leave this page open.</p>';
+        startElapsedTicker();
     }
 
     function hideProgressCard() {
+        stopElapsedTicker();
+        lastProgressData = null;
         var card = document.getElementById('rf-overview-progress');
         if (!card) return;
         card.style.display = 'none';
@@ -160,9 +201,10 @@
                 })
                 .catch(function () {
                     if (stopped) return;
-                    // Run may not exist yet; retry a few times
-                    if (Date.now() - started < 30000) {
-                        timer = setTimeout(tick, delayMs());
+                    // Keep elapsed alive; retry while run may still be starting or busy.
+                    // Aborted/timeout fetches land here so the card keeps ticking.
+                    if (Date.now() - started < 600000) {
+                        timer = setTimeout(tick, Math.min(delayMs(), 2500));
                     }
                 });
         }
@@ -171,6 +213,7 @@
         return function stop() {
             stopped = true;
             if (timer) clearTimeout(timer);
+            stopElapsedTicker();
         };
     }
 

--- a/frontend/templates/pages/overview.html
+++ b/frontend/templates/pages/overview.html
@@ -92,22 +92,31 @@
 {% endblock %}
 
 {% block extra_scripts %}
-<script src="/static/js/run_overview.js?v=825a"></script>
-<script src="/static/js/run_overview_progress.js?v=825a"></script>
+<script src="/static/js/run_overview.js?v=825c"></script>
+<script src="/static/js/run_overview_progress.js?v=825c"></script>
 <script>
 (function () {
     var tabler = document.documentElement.classList.contains('rf-tabler');
     var stopProgressWatch = null;
 
-    function fetchJson(url) {
-        return fetch(url, { credentials: 'same-origin' }).then(function (r) {
-            if (r.status === 401) {
-                window.location.href = '/';
-                return Promise.reject(new Error('unauthorized'));
-            }
-            if (!r.ok) return Promise.reject(new Error('HTTP ' + r.status));
-            return r.json();
-        });
+    function fetchJson(url, timeoutMs) {
+        timeoutMs = timeoutMs == null ? 8000 : timeoutMs;
+        var controller = new AbortController();
+        var timer = setTimeout(function () {
+            controller.abort();
+        }, timeoutMs);
+        return fetch(url, { credentials: 'same-origin', signal: controller.signal })
+            .then(function (r) {
+                if (r.status === 401) {
+                    window.location.href = '/';
+                    return Promise.reject(new Error('unauthorized'));
+                }
+                if (!r.ok) return Promise.reject(new Error('HTTP ' + r.status));
+                return r.json();
+            })
+            .finally(function () {
+                clearTimeout(timer);
+            });
     }
 
     function withUi(path) {

--- a/tests/unit/test_analysis_submit_enqueue.py
+++ b/tests/unit/test_analysis_submit_enqueue.py
@@ -1,0 +1,33 @@
+"""Unit tests for analysis enqueue threading (#825 follow-up)."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from app.core.v2 import analysis_submit
+
+
+def test_enqueue_analysis_run_starts_daemon_thread(monkeypatch):
+    started = threading.Event()
+
+    def fake_run(**kwargs):
+        assert kwargs["run_id"] == "enqueue-test"
+        started.set()
+        time.sleep(0.05)
+
+    monkeypatch.setattr(analysis_submit, "run_analysis_background", fake_run)
+
+    thread = analysis_submit.enqueue_analysis_run(
+        events=[],
+        segments_file="segments.csv",
+        locations_file="locations.csv",
+        flow_file="flow.csv",
+        data_dir="/tmp",
+        run_id="enqueue-test",
+        request_payload={},
+    )
+    assert thread.daemon is True
+    assert started.wait(timeout=2.0)
+    thread.join(timeout=2.0)
+    assert not thread.is_alive()

--- a/tests/unit/test_run_progress.py
+++ b/tests/unit/test_run_progress.py
@@ -27,6 +27,13 @@ def test_user_stages_order():
     ]
 
 
+def test_normalize_day_suffixed_phase():
+    from app.core.v2.run_progress import normalize_phase_name
+
+    assert normalize_phase_name("phase_5_1_bin_generation_sun") == "phase_5_1_bin_generation"
+    assert normalize_phase_name("phase_3_2_density_compute") == "phase_3_2_density_compute"
+
+
 def test_phase_mapping_covers_catalog():
     assert PHASE_TO_USER_STAGE["phase_3_2_density_compute"] == "density"
     assert PHASE_TO_USER_STAGE["phase_4_3_junction_flow"] == "junctions"


### PR DESCRIPTION
## Summary
- Run v2 analysis on a dedicated daemon thread instead of FastAPI `BackgroundTasks`, so CPU-heavy phases are less likely to starve Overview `/progress` polling.
- Serve progress via `asyncio.to_thread`, add an 8s abort on Overview progress fetches, and keep the elapsed ticker / “Still working…” hint during long silent steps.
- Normalize day-suffixed pipeline phase names in progress mapping; add enqueue + normalize unit tests.

## Test plan
- [ ] `pytest tests/unit/test_run_progress.py tests/unit/test_analysis_submit_enqueue.py`
- [ ] Start River Trail (or similar) package analysis from Build
- [ ] Confirm Overview progress advances past density/flow without appearing frozen
- [ ] Confirm elapsed time keeps updating during long steps and recovers if a poll times out
- [ ] Confirm Overview loads results after PASS


Made with [Cursor](https://cursor.com)