### PR TITLE
Locations: first/peak/last timings by event (#828)

### DIFF
--- a/app/core/locations/pairing.py
+++ b/app/core/locations/pairing.py
@@ -21,6 +21,13 @@ from app.core.locations.identity import effective_pass_key
 logger = logging.getLogger(__name__)
 
 
+def _merge_by_event_from_passes(passes: Sequence[Dict[str, Any]]) -> Dict[str, Dict[str, Any]]:
+    """Issue #828: Location-level by_event = merge of pass-level maps."""
+    from app.location_report import merge_by_event_timings
+
+    return merge_by_event_timings([p.get("by_event") for p in passes])
+
+
 def effective_location_key(row: MutableMapping[str, Any]) -> str:
     """Alias for effective_pass_key (legacy name)."""
     return effective_pass_key(row)
@@ -217,6 +224,7 @@ def consolidate_location_rows(
             "loc_end": g.get("loc_end"),
             "peak_start": g.get("peak_start"),
             "peak_end": g.get("peak_end"),
+            "by_event": g.get("by_event") or _merge_by_event_from_passes(passes),
             "flag": g.get("flag"),
             "onepage": g.get("onepage"),
             "notes": g.get("notes"),
@@ -272,6 +280,7 @@ def _singleton_group(
         "loc_end": row.get("loc_end"),
         "peak_start": row.get("peak_start"),
         "peak_end": row.get("peak_end"),
+        "by_event": _merge_by_event_from_passes([row]),
         "flag": row.get("flag"),
         "onepage": row.get("onepage"),
         "notes": row.get("notes"),
@@ -336,6 +345,7 @@ def _paired_group(key: str, group: List[Dict[str, Any]]) -> Dict[str, Any]:
         "loc_end": max_time_str(r.get("loc_end") for r in ordered),
         "peak_start": min_time_str(r.get("peak_start") for r in ordered),
         "peak_end": max_time_str(r.get("peak_end") for r in ordered),
+        "by_event": _merge_by_event_from_passes(ordered),
         "flag": any(
             r.get("flag") in (True, "true", "True", "Y", "y", 1, "1") for r in ordered
         ),

--- a/app/location_report.py
+++ b/app/location_report.py
@@ -11,6 +11,7 @@ Epic: Issue #277
 """
 
 from __future__ import annotations
+import json
 import logging
 from typing import Dict, List, Any, Optional, Tuple
 from datetime import datetime, timedelta
@@ -78,6 +79,137 @@ def format_time_hhmmss(seconds: float) -> str:
     secs = total_seconds % 60
     
     return f"{hours:02d}:{minutes:02d}:{secs:02d}"
+
+
+def compute_timing_window(arrival_times: List[float]) -> Dict[str, Optional[str]]:
+    """
+    First / peak (p25–p75) / last from arrival seconds.
+
+    Issue #828: Shared helper so aggregate and per-event windows use the
+    same percentile rules.
+    """
+    empty = {
+        "first_runner": None,
+        "peak_start": None,
+        "peak_end": None,
+        "last_runner": None,
+    }
+    if not arrival_times:
+        return empty
+    sorted_times = sorted(arrival_times)
+    first = format_time_hhmmss(sorted_times[0])
+    last = format_time_hhmmss(sorted_times[-1])
+    if len(sorted_times) > 1:
+        p25_idx = int(len(sorted_times) * 0.25)
+        p75_idx = int(len(sorted_times) * 0.75)
+        peak_start = format_time_hhmmss(sorted_times[p25_idx])
+        peak_end = format_time_hhmmss(sorted_times[p75_idx])
+    else:
+        peak_start = first
+        peak_end = last
+    return {
+        "first_runner": first,
+        "peak_start": peak_start,
+        "peak_end": peak_end,
+        "last_runner": last,
+    }
+
+
+def build_by_event_timings(
+    arrivals_by_event: Dict[str, List[float]],
+) -> Dict[str, Dict[str, Optional[str]]]:
+    """Per-event first/peak/last windows (Issue #828)."""
+    out: Dict[str, Dict[str, Optional[str]]] = {}
+    for event, times in arrivals_by_event.items():
+        if not times:
+            continue
+        out[str(event)] = compute_timing_window(times)
+    return out
+
+
+def serialize_by_event(by_event: Any) -> str:
+    """JSON-encode by_event for CSV cells."""
+    if not by_event:
+        return ""
+    if isinstance(by_event, str):
+        return by_event
+    return json.dumps(by_event, ensure_ascii=False, sort_keys=True)
+
+
+def parse_by_event(value: Any) -> Dict[str, Dict[str, Any]]:
+    """Parse by_event from a dict or JSON CSV cell."""
+    if value is None or (isinstance(value, float) and pd.isna(value)):
+        return {}
+    if isinstance(value, dict):
+        return {str(k): v for k, v in value.items() if isinstance(v, dict)}
+    text = str(value).strip()
+    if not text or text.lower() in ("nan", "none", "null"):
+        return {}
+    try:
+        data = json.loads(text)
+    except (TypeError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    return {str(k): v for k, v in data.items() if isinstance(v, dict)}
+
+
+def _time_to_seconds_loose(value: Any) -> Optional[float]:
+    if value is None or value == "" or value == "NA":
+        return None
+    if isinstance(value, (int, float)) and not pd.isna(value):
+        return float(value)
+    text = str(value).strip()
+    parts = text.split(":")
+    if len(parts) < 2:
+        return None
+    try:
+        hours = int(parts[0])
+        minutes = int(parts[1])
+        secs = int(parts[2]) if len(parts) >= 3 else 0
+    except (TypeError, ValueError):
+        return None
+    return hours * 3600 + minutes * 60 + secs
+
+
+def merge_by_event_timings(
+    maps: List[Any],
+) -> Dict[str, Dict[str, Optional[str]]]:
+    """
+    Merge per-pass by_event maps for a Location row.
+
+    For each event: earliest first/peak_start, latest peak_end/last across passes.
+    """
+    merged: Dict[str, Dict[str, Optional[str]]] = {}
+    for raw in maps:
+        for event, window in parse_by_event(raw).items():
+            cur = merged.get(event)
+            if cur is None:
+                merged[event] = {
+                    "first_runner": window.get("first_runner"),
+                    "peak_start": window.get("peak_start"),
+                    "peak_end": window.get("peak_end"),
+                    "last_runner": window.get("last_runner"),
+                }
+                continue
+            for field, picker in (
+                ("first_runner", min),
+                ("peak_start", min),
+                ("peak_end", max),
+                ("last_runner", max),
+            ):
+                a = _time_to_seconds_loose(cur.get(field))
+                b = _time_to_seconds_loose(window.get(field))
+                if a is None and b is None:
+                    continue
+                if a is None:
+                    cur[field] = window.get(field)
+                elif b is None:
+                    continue
+                else:
+                    chosen = picker(a, b)
+                    cur[field] = format_time_hhmmss(chosen)
+    return merged
 
 
 def parse_segment_ids(seg_id_value: Any) -> List[str]:
@@ -452,13 +584,15 @@ def calculate_arrival_times_for_location(
     segments_df: pd.DataFrame,
     courses: Dict[str, GPXCourse],
     start_times: Dict[str, float]
-) -> List[float]:
+) -> Dict[str, List[float]]:
     """
-    Calculate arrival times for all eligible runners at a location.
-    
+    Calculate arrival times for all eligible runners at a location, keyed by event.
+
     Issue #277: Supports multiple crossings (e.g., A1 and G1 for loc_id=8).
     Issue #480: Processes ALL listed segments independently to capture all crossings
                 (e.g., B1 outbound, B3 return, D1 outbound, D2 return).
+    Issue #828: Returns per-event buckets so callers can compute aggregate and
+                by-event first/peak/last without changing arrival math.
     
     Args:
         location: Location row from locations.csv
@@ -468,10 +602,11 @@ def calculate_arrival_times_for_location(
         start_times: Dictionary of event start times in minutes
         
     Returns:
-        List of arrival times in seconds (may include duplicates for multiple crossings).
-        Same runner may appear multiple times (once per segment crossing).
+        Mapping of event id → list of arrival times in seconds (may include
+        duplicates for multiple crossings). Same runner may appear multiple
+        times (once per segment crossing).
     """
-    arrival_times = []
+    arrivals_by_event: Dict[str, List[float]] = {}
     
     # Eligible events: product vocabulary ∩ (courses present or all COURSE_EVENT_IDS),
     # discovered dynamically from location flags (#701 / #531 elite+open).
@@ -485,7 +620,7 @@ def calculate_arrival_times_for_location(
         logger.warning(
             f"Location {location.get('loc_id')}: No eligible events among {candidate_events}"
         )
-        return arrival_times
+        return arrivals_by_event
     
     logger.debug(f"Location {location.get('loc_id')}: Processing {len(eligible_events)} eligible events: {eligible_events}")
     
@@ -494,7 +629,7 @@ def calculate_arrival_times_for_location(
     lon = location.get("lon")
     if pd.isna(lat) or pd.isna(lon):
         logger.warning(f"Location {location.get('loc_id')} has invalid coordinates")
-        return arrival_times
+        return arrivals_by_event
     
     location_point_utm = Point(WGS84_TO_UTM.transform(lon, lat))
     
@@ -553,6 +688,7 @@ def calculate_arrival_times_for_location(
             # Issue #480: Process ALL listed segments independently
             # This ensures we capture all crossings (e.g., B1 outbound, B3 return, D1 outbound, D2 return)
             processed_segments = []
+            event_arrivals = arrivals_by_event.setdefault(event, [])
             
             for seg_id, from_km, to_km in segment_ranges:
                 logger.debug(f"Location {location.get('loc_id')} ({event}): Processing segment {seg_id} [{from_km:.3f}, {to_km:.3f}]km")
@@ -673,7 +809,7 @@ def calculate_arrival_times_for_location(
                     
                     # Arrival time = start_time + offset (seconds) + pace * distance
                     arrival_time = event_start_sec + start_offset + pace_sec_per_km * seg_distance_km
-                    arrival_times.append(arrival_time)
+                    event_arrivals.append(arrival_time)
                 
                 processed_segments.append(seg_id)
             
@@ -704,6 +840,7 @@ def calculate_arrival_times_for_location(
         
         # Calculate arrival times
         event_start_sec = start_times.get(event, 0) * SECONDS_PER_MINUTE
+        event_arrivals = arrivals_by_event.setdefault(event, [])
         
         for _, runner in event_runners.iterrows():
             start_offset = runner.get("start_offset", 0)
@@ -719,11 +856,14 @@ def calculate_arrival_times_for_location(
             
             # Arrival time = start_time + offset (seconds) + pace * distance
             arrival_time = event_start_sec + start_offset + pace_sec_per_km * distance_km
-            arrival_times.append(arrival_time)
+            event_arrivals.append(arrival_time)
         
-        logger.debug(f"Location {location.get('loc_id')} ({event}): Calculated {len(arrival_times)} arrival times for {len(event_runners)} runners at distance {distance_km:.3f}km")
+        logger.debug(
+            f"Location {location.get('loc_id')} ({event}): Calculated {len(event_arrivals)} "
+            f"arrival times for {len(event_runners)} runners at distance {distance_km:.3f}km"
+        )
     
-    return arrival_times
+    return arrivals_by_event
 
 
 def generate_location_report(
@@ -1000,10 +1140,13 @@ def generate_location_report(
             locations_by_id[loc_id] = report_row
             continue
         
-        # Calculate arrival times
-        arrival_times = calculate_arrival_times_for_location(
+        # Calculate arrival times (per-event buckets — Issue #828)
+        arrivals_by_event = calculate_arrival_times_for_location(
             location, runners_df, segments_df, courses, start_times
         )
+        arrival_times: List[float] = []
+        for times in arrivals_by_event.values():
+            arrival_times.extend(times)
         
         if not arrival_times:
             loc_row = locations_df[locations_df['pass_id' if 'pass_id' in locations_df.columns else 'loc_id'] == loc_id]
@@ -1020,23 +1163,17 @@ def generate_location_report(
             locations_by_id[loc_id] = report_row
             continue
         
-        # Calculate statistics
-        arrival_times_sorted = sorted(arrival_times)
-        report_row["first_runner"] = format_time_hhmmss(arrival_times_sorted[0])
-        report_row["last_runner"] = format_time_hhmmss(arrival_times_sorted[-1])
-        
-        # Percentiles
-        if len(arrival_times_sorted) > 1:
-            p25_idx = int(len(arrival_times_sorted) * 0.25)
-            p75_idx = int(len(arrival_times_sorted) * 0.75)
-            report_row["peak_start"] = format_time_hhmmss(arrival_times_sorted[p25_idx])
-            report_row["peak_end"] = format_time_hhmmss(arrival_times_sorted[p75_idx])
-        else:
-            report_row["peak_start"] = report_row["first_runner"]
-            report_row["peak_end"] = report_row["last_runner"]
+        # Aggregate statistics (union of all events — unchanged semantics)
+        timing = compute_timing_window(arrival_times)
+        report_row["first_runner"] = timing["first_runner"]
+        report_row["peak_start"] = timing["peak_start"]
+        report_row["peak_end"] = timing["peak_end"]
+        report_row["last_runner"] = timing["last_runner"]
+        report_row["by_event"] = build_by_event_timings(arrivals_by_event)
         
         # Calculate loc_end (last_runner + buffer, rounded to interval)
         if report_row["last_runner"] != "NA":
+            arrival_times_sorted = sorted(arrival_times)
             last_runner_sec = arrival_times_sorted[-1]
             buffer_minutes = location.get("buffer", 0)
             if pd.isna(buffer_minutes):
@@ -1268,6 +1405,7 @@ def generate_location_report(
         "lat", "lon", "zone",
         "buffer", "interval",
         "first_runner", "peak_start", "peak_end", "last_runner",
+        "by_event",
         "loc_start", "loc_end", "duration",
         "timing_source",
         # legacy aliases kept at end of base for importers mid-cutover
@@ -1286,6 +1424,8 @@ def generate_location_report(
     final_columns = final_columns + remaining_cols
 
     report_df = report_df[final_columns]
+    if "by_event" in report_df.columns:
+        report_df["by_event"] = report_df["by_event"].map(serialize_by_event)
 
     # Passes.csv — bottom-up timed instances (agencies / YSSR)
     passes_full, passes_rel = get_report_paths("Passes", "csv", output_dir)
@@ -1294,13 +1434,19 @@ def generate_location_report(
     logger.info(f"Passes report saved to: {passes_full}")
 
     # Locations.csv — consolidated Location view (UI mirror)
-    location_rows = consolidate_location_rows(report_df.to_dict(orient="records"))
+    # Re-read pass dicts with parsed by_event for merge
+    pass_records = report_df.to_dict(orient="records")
+    for rec in pass_records:
+        rec["by_event"] = parse_by_event(rec.get("by_event"))
+    location_rows = consolidate_location_rows(pass_records)
+    for rec in location_rows:
+        rec["by_event"] = serialize_by_event(rec.get("by_event"))
     locations_df_out = pd.DataFrame(location_rows)
     loc_base = [
         "loc_id", "pass_key", "pass_ids", "pass_count", "loc_label", "day",
         "loc_type", "lat", "lon", "zone",
         "first_runner", "last_runner", "loc_start", "loc_end",
-        "peak_start", "peak_end", "flag", "onepage", "notes",
+        "peak_start", "peak_end", "by_event", "flag", "onepage", "notes",
     ]
     loc_counts = sorted([c for c in locations_df_out.columns if c.endswith("_count") or c.endswith("_mins")])
     loc_cols = [c for c in loc_base + loc_counts if c in locations_df_out.columns]

--- a/app/one_pager.py
+++ b/app/one_pager.py
@@ -271,6 +271,8 @@ def _load_locations_results(path: Path) -> List[Dict[str, Any]]:
 
 def _load_pass_timings_report(path: Path) -> Dict[int, Dict[str, Any]]:
     """Prefer Passes.csv (keyed by pass_id); fall back to Locations.csv / legacy loc_id."""
+    from app.location_report import parse_by_event
+
     candidates = []
     if path.name.lower() == "locations.csv":
         candidates.append(path.parent / "Passes.csv")
@@ -296,8 +298,38 @@ def _load_pass_timings_report(path: Path) -> Dict[int, Dict[str, Any]]:
         df[id_col] = pd.to_numeric(df[id_col], errors="coerce")
         df = df.dropna(subset=[id_col])
         df[id_col] = df[id_col].astype(int)
-        return df.set_index(id_col).to_dict("index")
+        records = df.set_index(id_col).to_dict("index")
+        for row in records.values():
+            if "by_event" in row:
+                row["by_event"] = parse_by_event(row.get("by_event"))
+        return records
     return {}
+
+
+def _by_event_timing_lines(report_row: Dict[str, Any]) -> List[str]:
+    """Issue #828: lines for per-event first/peak/last under aggregate timings."""
+    from app.location_report import parse_by_event
+
+    by_event = parse_by_event(report_row.get("by_event"))
+    if not by_event:
+        return []
+    lines: List[str] = []
+    for event in sorted(by_event.keys(), key=lambda e: str(e).lower()):
+        w = by_event[event] or {}
+        lines.append(
+            f"{event}: First {_format_time(w.get('first_runner'))} · "
+            f"Peak {_format_time(w.get('peak_start'))}–{_format_time(w.get('peak_end'))} · "
+            f"Last {_format_time(w.get('last_runner'))}"
+        )
+    return lines
+
+
+def _by_event_timing_html(report_row: Dict[str, Any]) -> str:
+    lines = _by_event_timing_lines(report_row)
+    if not lines:
+        return ""
+    items = "".join(f"<li>{html.escape(line)}</li>" for line in lines)
+    return f"<p><strong>By event</strong></p><ul>{items}</ul>"
 
 
 def _load_locations_report(path: Path) -> Dict[int, Dict[str, Any]]:
@@ -561,6 +593,15 @@ def _render_onepager_pdf(
                     y = _draw_text_block(
                         c, f"- {line}", font_body, 12, _MARGIN + 28, y - 2, page_w - 2 * _MARGIN
                     )
+                by_lines = _by_event_timing_lines(prow)
+                if by_lines:
+                    y = _draw_text_block(
+                        c, "By event:", font_bold, 11, _MARGIN + 28, y - 2, page_w - 2 * _MARGIN
+                    )
+                    for line in by_lines:
+                        y = _draw_text_block(
+                            c, f"- {line}", font_body, 11, _MARGIN + 40, y - 2, page_w - 2 * _MARGIN
+                        )
         else:
             timings_lines = [
                 f"First: {_format_time(report_row.get('first_runner'))}",
@@ -570,6 +611,15 @@ def _render_onepager_pdf(
             ]
             for line in timings_lines:
                 y = _draw_text_block(c, f"- {line}", font_body, 12, _MARGIN + 16, y - 2, page_w - 2 * _MARGIN)
+            by_lines = _by_event_timing_lines(report_row)
+            if by_lines:
+                y = _draw_text_block(
+                    c, "By event:", font_bold, 12, _MARGIN + 16, y - 4, page_w - 2 * _MARGIN
+                )
+                for line in by_lines:
+                    y = _draw_text_block(
+                        c, f"- {line}", font_body, 11, _MARGIN + 28, y - 2, page_w - 2 * _MARGIN
+                    )
 
     y = _draw_text_block(c, "EVENTS:", font_bold, 14, _MARGIN, y - _SECTION_GAP, page_w - 2 * _MARGIN)
     if is_proxy:
@@ -688,6 +738,7 @@ def _render_onepager_html(
                 f"<li>Last: {html.escape(_format_time(prow.get('last_runner')))}</li>"
                 "</ul>"
             )
+            blocks.append(_by_event_timing_html(prow))
         runner_timings_html = "\n".join(blocks)
     else:
         runner_timings_html = """
@@ -698,7 +749,7 @@ def _render_onepager_html(
             <li>Peak Start: """ + html.escape(_format_time(report_row.get("peak_start"))) + """</li>
             <li>Peak End: """ + html.escape(_format_time(report_row.get("peak_end"))) + """</li>
             <li>Last: """ + html.escape(_format_time(report_row.get("last_runner"))) + """</li>
-        </ul>"""
+        </ul>""" + _by_event_timing_html(report_row)
 
     events_list = ", ".join(events) if events else "NA"
 

--- a/app/routes/api_locations.py
+++ b/app/routes/api_locations.py
@@ -132,6 +132,12 @@ async def get_locations_report(
                 # Convert flag column: handle both boolean and string representations
                 df['flag'] = df['flag'].apply(lambda x: True if (x is True or str(x).lower() in ['true', '1', 'y', 'yes']) else False)
             report_data = df.to_dict('records')
+            # Issue #828: parse by_event JSON column into objects for the UI
+            from app.location_report import parse_by_event
+
+            for row in report_data:
+                if "by_event" in row:
+                    row["by_event"] = parse_by_event(row.get("by_event"))
             _merge_onepage_into_report_rows(report_data, locations_results, selected_day)
         elif generate:
             # Generate new report

--- a/frontend/static/js/map/location_pairing.js
+++ b/frontend/static/js/map/location_pairing.js
@@ -45,6 +45,35 @@
         return best;
     }
 
+    function mergeByEventMaps(maps) {
+        const merged = {};
+        (maps || []).forEach((raw) => {
+            let map = raw;
+            if (typeof map === 'string') {
+                try { map = JSON.parse(map); } catch (e) { map = null; }
+            }
+            if (!map || typeof map !== 'object') return;
+            Object.keys(map).forEach((ev) => {
+                const w = map[ev] || {};
+                if (!merged[ev]) {
+                    merged[ev] = {
+                        first_runner: w.first_runner,
+                        peak_start: w.peak_start,
+                        peak_end: w.peak_end,
+                        last_runner: w.last_runner,
+                    };
+                    return;
+                }
+                const cur = merged[ev];
+                cur.first_runner = pickMinTime([cur.first_runner, w.first_runner]);
+                cur.peak_start = pickMinTime([cur.peak_start, w.peak_start]);
+                cur.peak_end = pickMaxTime([cur.peak_end, w.peak_end]);
+                cur.last_runner = pickMaxTime([cur.last_runner, w.last_runner]);
+            });
+        });
+        return Object.keys(merged).length ? merged : null;
+    }
+
     function effectiveKey(loc) {
         const key = loc && (loc.pass_key != null ? loc.pass_key : loc.location_key);
         const text = key != null ? String(key).trim() : '';
@@ -133,6 +162,7 @@
                 loc_end: pickMaxTime(passes.map((p) => p.loc_end)),
                 peak_start: pickMinTime(passes.map((p) => p.peak_start)),
                 peak_end: pickMaxTime(passes.map((p) => p.peak_end)),
+                by_event: mergeByEventMaps(passes.map((p) => p.by_event)),
                 flag: passes.some((p) => p.flag === true || p.flag === 'true' || p.flag === 'Y'),
                 onepage: passes.some((p) => String(p.onepage || '').toLowerCase() === 'y')
                     ? 'y'

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -95,6 +95,7 @@ function convertToGeoJSON(locations) {
                 notes: loc.notes,
                 first_runner: loc.first_runner,
                 last_runner: loc.last_runner,
+                by_event: loc.by_event || null,
                 flag: loc.flag,
                 flagged_seg_id: loc.flagged_seg_id,
                 flag_severity: loc.flag_severity,

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -44,6 +44,24 @@
     #locations-table a.loc-sheet-link:hover {
         color: #0a58ca;
     }
+    #locations-table .loc-by-event-details {
+        margin-top: 0.35rem;
+        font-size: 0.8rem;
+        line-height: 1.35;
+    }
+    #locations-table .loc-by-event-details summary {
+        cursor: pointer;
+        color: #6c757d;
+        user-select: none;
+    }
+    #locations-table .loc-by-event-row {
+        margin-top: 0.2rem;
+    }
+    #locations-table .loc-by-event-name {
+        font-weight: 600;
+        text-transform: uppercase;
+        margin-right: 0.25rem;
+    }
 </style>
 {% endblock %}
 
@@ -361,6 +379,7 @@
                 timing_source: p.timing_source,
                 first_runner: p.first_runner,
                 last_runner: p.last_runner,
+                by_event: p.by_event || null,
                 onepage: p.onepage
             };
             Object.keys(p).forEach(key => {
@@ -419,6 +438,7 @@
                 timing_source: p.timing_source,
                 first_runner: p.first_runner,
                 last_runner: p.last_runner,
+                by_event: p.by_event || null,
                 onepage: p.onepage
             };
             Object.keys(p).forEach(key => {
@@ -1127,6 +1147,36 @@
         }
         return `<a href="${path}" target="_blank" rel="noopener" class="loc-sheet-link" onclick="event.stopPropagation()">${escaped}</a>`;
     }
+
+    /**
+     * Issue #828: compact per-event first/peak/last under the aggregate window.
+     */
+    function formatByEventTimingsHtml(location) {
+        let byEvent = location && location.by_event;
+        if (typeof byEvent === 'string') {
+            try {
+                byEvent = JSON.parse(byEvent);
+            } catch (e) {
+                byEvent = null;
+            }
+        }
+        if (!byEvent || typeof byEvent !== 'object') {
+            return '';
+        }
+        const events = Object.keys(byEvent).sort((a, b) => a.localeCompare(b));
+        if (!events.length) {
+            return '';
+        }
+        const lines = events.map((ev) => {
+            const w = byEvent[ev] || {};
+            const first = formatTimeToHHMM(w.first_runner) || '—';
+            const last = formatTimeToHHMM(w.last_runner) || '—';
+            const peakStart = formatTimeToHHMM(w.peak_start) || '—';
+            const peakEnd = formatTimeToHHMM(w.peak_end) || '—';
+            return `<div class="loc-by-event-row"><span class="loc-by-event-name">${escapeHtml(ev)}</span> ${escapeHtml(first)} → ${escapeHtml(last)} <span class="text-secondary">(peak ${escapeHtml(peakStart)}–${escapeHtml(peakEnd)})</span></div>`;
+        });
+        return `<details class="loc-by-event-details"><summary>By event</summary>${lines.join('')}</details>`;
+    }
     
     function renderLocationsTable(locations) {
         const tbody = document.getElementById('locations-tbody');
@@ -1190,6 +1240,12 @@
                 firstLastRunner = (firstRunnerFormatted !== "—" && lastRunnerFormatted !== "—")
                     ? `${firstRunnerFormatted} → ${lastRunnerFormatted}`
                     : "—";
+            }
+
+            // Issue #828: per-event timings under aggregate First/Last
+            const byEventHtml = formatByEventTimingsHtml(location);
+            if (byEventHtml) {
+                firstLastRunner = `${firstLastRunner}<div class="loc-by-event">${byEventHtml}</div>`;
             }
             
             // Issue #598: Format flag value

--- a/tests/unit/test_location_report_location_key.py
+++ b/tests/unit/test_location_report_location_key.py
@@ -73,7 +73,7 @@ def test_generate_location_report_writes_passes_and_locations(tmp_path, monkeypa
     monkeypatch.setattr(
         location_report,
         "calculate_arrival_times_for_location",
-        lambda *a, **k: [],
+        lambda *a, **k: {},
     )
     monkeypatch.setattr(location_report, "load_flagged_segments", lambda **k: {})
 

--- a/tests/unit/test_location_timings_by_event.py
+++ b/tests/unit/test_location_timings_by_event.py
@@ -1,0 +1,106 @@
+"""Issue #828: per-event location timing windows."""
+
+from __future__ import annotations
+
+import json
+
+from app.location_report import (
+    build_by_event_timings,
+    compute_timing_window,
+    merge_by_event_timings,
+    parse_by_event,
+    serialize_by_event,
+)
+from app.one_pager import _by_event_timing_html, _by_event_timing_lines
+
+
+def test_compute_timing_window_percentiles():
+    # 4 arrivals → p25 idx=1, p75 idx=3
+    times = [100.0, 200.0, 300.0, 400.0]
+    window = compute_timing_window(times)
+    assert window["first_runner"] == "00:01:40"
+    assert window["last_runner"] == "00:06:40"
+    assert window["peak_start"] == "00:03:20"
+    assert window["peak_end"] == "00:06:40"
+
+
+def test_build_by_event_and_aggregate_union():
+    arrivals = {
+        "10k": [100.0, 120.0],
+        "half": [500.0, 700.0],
+    }
+    by_event = build_by_event_timings(arrivals)
+    assert set(by_event) == {"10k", "half"}
+    assert by_event["10k"]["first_runner"] == "00:01:40"
+    assert by_event["half"]["last_runner"] == "00:11:40"
+
+    flat = []
+    for times in arrivals.values():
+        flat.extend(times)
+    aggregate = compute_timing_window(flat)
+    assert aggregate["first_runner"] == "00:01:40"
+    assert aggregate["last_runner"] == "00:11:40"
+
+
+def test_serialize_parse_roundtrip():
+    payload = {
+        "full": {
+            "first_runner": "07:00:00",
+            "peak_start": "07:10:00",
+            "peak_end": "07:40:00",
+            "last_runner": "08:00:00",
+        }
+    }
+    text = serialize_by_event(payload)
+    assert json.loads(text)["full"]["first_runner"] == "07:00:00"
+    assert parse_by_event(text)["full"]["last_runner"] == "08:00:00"
+
+
+def test_merge_by_event_across_passes():
+    outbound = {
+        "full": {
+            "first_runner": "07:00:00",
+            "peak_start": "07:10:00",
+            "peak_end": "07:20:00",
+            "last_runner": "07:30:00",
+        }
+    }
+    ret = {
+        "full": {
+            "first_runner": "08:00:00",
+            "peak_start": "08:10:00",
+            "peak_end": "08:40:00",
+            "last_runner": "09:00:00",
+        },
+        "half": {
+            "first_runner": "07:45:00",
+            "peak_start": "08:00:00",
+            "peak_end": "08:15:00",
+            "last_runner": "08:30:00",
+        },
+    }
+    merged = merge_by_event_timings([outbound, ret])
+    assert merged["full"]["first_runner"] == "07:00:00"
+    assert merged["full"]["last_runner"] == "09:00:00"
+    assert merged["full"]["peak_start"] == "07:10:00"
+    assert merged["full"]["peak_end"] == "08:40:00"
+    assert "half" in merged
+
+
+def test_one_pager_by_event_lines_and_html():
+    row = {
+        "by_event": {
+            "10k": {
+                "first_runner": "09:00:00",
+                "peak_start": "09:10:00",
+                "peak_end": "09:20:00",
+                "last_runner": "09:30:00",
+            }
+        }
+    }
+    lines = _by_event_timing_lines(row)
+    assert len(lines) == 1
+    assert lines[0].startswith("10k:")
+    html = _by_event_timing_html(row)
+    assert "By event" in html
+    assert "10k:" in html


### PR DESCRIPTION
## Summary
- Compute per-event `first_runner` / `peak_*` / `last_runner` from the existing arrival model without changing aggregate semantics.
- Persist `by_event` (JSON) on **Passes.csv** and consolidated **Locations.csv**.
- Show expandable “By event” detail in the Locations UI; include the same timings on one-pager **HTML** and **PDF**.

## Test plan
- [ ] `pytest tests/unit/test_location_timings_by_event.py tests/unit/test_location_report_location_key.py tests/unit/test_location_pairing.py`
- [ ] Re-run a multi-event package analysis
- [ ] Confirm Locations table aggregate First/Last unchanged; expand “By event”
- [ ] Confirm Passes.csv / Locations.csv include `by_event`
- [ ] Open a one-pager HTML and PDF and verify per-event timings under Runner Timings

Closes #828

Made with [Cursor](https://cursor.com)