### PR TITLE
Build > Legs: unify filters + move location between legs (#834)

### DIFF
--- a/app/core/config_package/org_leg_library.py
+++ b/app/core/config_package/org_leg_library.py
@@ -556,6 +556,92 @@ def copy_org_leg_locations(
     }
 
 
+def move_org_leg_location(
+    source_leg_id: str,
+    loc_index: int,
+    target_leg_id: str,
+) -> Dict[str, Any]:
+    """
+    Move one location pin from ``source_leg_id`` onto ``target_leg_id``.
+
+    Preserves ``location_key`` and operational fields; drops leg-scoped keys so
+    the target gets a fresh ``leg_loc_key`` on course merge. Blocks when the
+    target already has a pin with the same ``location_key``.
+    """
+    import copy
+
+    from app.core.config_package.legs import _find_leg_index, _normalize_locations
+    from app.core.config_package.location_keys import is_valid_location_key
+
+    source_leg_id = str(source_leg_id).strip()
+    target_leg_id = str(target_leg_id).strip()
+    if not source_leg_id or not target_leg_id:
+        raise ValueError("Source and target leg ids are required")
+    if source_leg_id == target_leg_id:
+        raise ValueError("Source and target leg must differ")
+    try:
+        loc_index = int(loc_index)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("Invalid location index") from exc
+    if loc_index < 0:
+        raise ValueError("Invalid location index")
+
+    manifest = load_org_leg_manifest()
+    legs: List[Dict[str, Any]] = list(manifest_legs(manifest))
+    source_idx = _find_leg_index(legs, source_leg_id)
+    target_idx = _find_leg_index(legs, target_leg_id)
+    if source_idx < 0:
+        raise ValueError(f"Leg not found: {source_leg_id}")
+    if target_idx < 0:
+        raise ValueError(f"Leg not found: {target_leg_id}")
+
+    source_entry = dict(legs[source_idx])
+    source_locs = list(source_entry.get("locations") or [])
+    if loc_index >= len(source_locs):
+        raise ValueError(
+            f"Location index {loc_index} out of range on leg {source_leg_id}"
+        )
+
+    moving = copy.deepcopy(source_locs[loc_index])
+    if not isinstance(moving, dict):
+        raise ValueError("Invalid location")
+
+    moving_key = str(moving.get("location_key") or "").strip()
+    target_entry = dict(legs[target_idx])
+    target_locs = list(target_entry.get("locations") or [])
+    if is_valid_location_key(moving_key):
+        for existing in target_locs:
+            if not isinstance(existing, dict):
+                continue
+            if str(existing.get("location_key") or "").strip() == moving_key:
+                raise ValueError(
+                    f"Target leg {target_leg_id} already has a location "
+                    f"with key {moving_key}"
+                )
+
+    moving.pop("leg_loc_key", None)
+    moving.pop("id", None)
+    moving.pop("loc_id", None)
+
+    source_locs.pop(loc_index)
+    source_entry["locations"] = _normalize_locations(source_locs)
+    target_entry["locations"] = _normalize_locations(target_locs + [moving])
+    legs[source_idx] = source_entry
+    legs[target_idx] = target_entry
+    set_manifest_legs(manifest, legs)
+    save_org_leg_manifest(manifest)
+    sync_org_leg_changes_into_packages()
+
+    new_loc_index = len(target_entry["locations"]) - 1
+    return {
+        **get_org_leg_library_state(),
+        "source_leg_id": source_leg_id,
+        "target_leg_id": target_leg_id,
+        "loc_index": loc_index,
+        "new_loc_index": new_loc_index,
+    }
+
+
 def get_org_leg_library_state() -> Dict[str, Any]:
     """API state for org leg library management UI."""
     legs = list_org_legs()

--- a/app/routes/api_config_packages.py
+++ b/app/routes/api_config_packages.py
@@ -55,6 +55,7 @@ from app.core.config_package.org_leg_library import (
     import_gpx_files_to_org_library,
     import_org_leg_to_package,
     list_org_legs,
+    move_org_leg_location,
     publish_package_leg_to_org_library,
     update_org_leg,
     update_org_leg_geometry,
@@ -1092,6 +1093,12 @@ class CopyOrgLegLocationsRequest(BaseModel):
     replace: bool = True
 
 
+class MoveOrgLegLocationRequest(BaseModel):
+    """Move one location pin onto another org leg."""
+
+    target_leg_id: str
+
+
 @router.post("/api/org/legs/{leg_id}/copy")
 async def api_copy_org_leg(
     request: Request,
@@ -1124,6 +1131,22 @@ async def api_copy_org_leg_locations(
             body.source_leg_id,
             replace=body.replace,
         )
+        return JSONResponse(content={"ok": True, **state})
+    except ValueError as e:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))
+
+
+@router.post("/api/org/legs/{leg_id}/locations/{loc_index}/move")
+async def api_move_org_leg_location(
+    request: Request,
+    leg_id: str,
+    loc_index: int,
+    body: MoveOrgLegLocationRequest,
+) -> JSONResponse:
+    """Move one location pin from this org leg onto another org leg."""
+    require_auth(request)
+    try:
+        state = move_org_leg_location(leg_id, loc_index, body.target_leg_id)
         return JSONResponse(content={"ok": True, **state})
     except ValueError as e:
         raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail=str(e))

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -612,7 +612,7 @@
         var row = document.getElementById('leg-locations-browser-thead-row');
         if (!row) return;
         row.innerHTML = '';
-        ['Leg #', 'ID', 'Label', 'Type', 'Proxy'].forEach(function (text) {
+        ['Leg #', 'ID', 'Label', 'Type', 'Zone', 'Proxy'].forEach(function (text) {
             var th = document.createElement('th');
             th.textContent = text;
             row.appendChild(th);
@@ -852,6 +852,9 @@
                 String(row.locIndex),
                 (row.loc.loc_label || '').slice(0, 48),
                 row.loc.loc_type || 'course',
+                row.loc.zone != null && String(row.loc.zone).trim() !== ''
+                    ? String(row.loc.zone).trim()
+                    : '—',
                 formatLegLocationProxyDisplay(row.loc),
             ].forEach(function (text) {
                 var td = document.createElement('td');

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -646,8 +646,6 @@
         if (isNaN(idx) || idx < 0) return;
         pendingLocationFocus = { legId: legId, locIndex: idx };
         legLocationsBrowserHighlightKey = legLocKey(legId, idx);
-        var legSel = document.getElementById('leg-locations-filter-leg');
-        if (legSel) legSel.value = legId;
         if (!isOrgLegsHubMode()) {
             var url = new URL(window.location.href);
             url.searchParams.delete('id');
@@ -666,11 +664,12 @@
     }
 
     function getLegLocationsBrowserFilters() {
-        var legSel = document.getElementById('leg-locations-filter-leg');
+        var zoneSel = document.getElementById('leg-locations-filter-zone');
         var typeSel = document.getElementById('leg-locations-filter-type');
         var searchInp = document.getElementById('leg-locations-filter-search');
         return {
-            legId: legSel ? String(legSel.value || '').trim() : '',
+            legId: selectedLegId ? String(selectedLegId).trim() : '',
+            zone: zoneSel ? String(zoneSel.value || '').trim() : '',
             type: typeSel ? String(typeSel.value || '').trim().toLowerCase() : '',
             query: searchInp ? String(searchInp.value || '').trim().toLowerCase() : ''
         };
@@ -679,6 +678,10 @@
     function legLocationRowMatchesFilters(row, filters) {
         if (!row || !row.loc) return false;
         if (filters.legId && row.legId !== filters.legId) return false;
+        if (filters.zone) {
+            var zone = String(row.loc.zone != null ? row.loc.zone : '').trim();
+            if (zone.toLowerCase() !== filters.zone.toLowerCase()) return false;
+        }
         var locType = String(row.loc.loc_type || 'course').toLowerCase();
         if (filters.type && locType !== filters.type) return false;
         if (filters.query) {
@@ -766,24 +769,32 @@
     }
 
     function populateLegLocationsBrowserFilters() {
-        var legSel = document.getElementById('leg-locations-filter-leg');
+        var zoneSel = document.getElementById('leg-locations-filter-zone');
         var typeSel = document.getElementById('leg-locations-filter-type');
-        if (!legSel || !typeSel) return;
-        var prevLeg = legSel.value;
+        if (!zoneSel || !typeSel) return;
+        var prevZone = zoneSel.value;
         var prevType = typeSel.value;
-        legSel.innerHTML = '';
-        var allLeg = document.createElement('option');
-        allLeg.value = '';
-        allLeg.textContent = 'All legs';
-        legSel.appendChild(allLeg);
-        (libraryState && libraryState.legs || []).forEach(function (leg) {
-            var opt = document.createElement('option');
-            opt.value = leg.id;
-            opt.textContent = leg.id + ' — ' + ((leg.leg_label || '').slice(0, 36) || leg.id);
-            legSel.appendChild(opt);
+        var zoneSet = {};
+        collectAllLegLocationRows().forEach(function (row) {
+            var zone = String(row.loc && row.loc.zone != null ? row.loc.zone : '').trim();
+            if (zone) zoneSet[zone] = true;
         });
-        if (prevLeg && legSel.querySelector('option[value="' + prevLeg + '"]')) {
-            legSel.value = prevLeg;
+        var zones = Object.keys(zoneSet).sort(function (a, b) {
+            return a.localeCompare(b, undefined, { numeric: true, sensitivity: 'base' });
+        });
+        zoneSel.innerHTML = '';
+        var allZone = document.createElement('option');
+        allZone.value = '';
+        allZone.textContent = 'All zones';
+        zoneSel.appendChild(allZone);
+        zones.forEach(function (zone) {
+            var opt = document.createElement('option');
+            opt.value = zone;
+            opt.textContent = zone;
+            zoneSel.appendChild(opt);
+        });
+        if (prevZone && zoneSel.querySelector('option[value="' + prevZone + '"]')) {
+            zoneSel.value = prevZone;
         }
         typeSel.innerHTML = '';
         var allType = document.createElement('option');
@@ -820,13 +831,19 @@
             return legLocationRowMatchesFilters(row, filters);
         });
         if (statusEl) {
+            var scope = filters.legId
+                ? 'on leg ' + filters.legId
+                : 'across all legs (no leg selected)';
+            if (filters.zone) scope += ' × zone ' + filters.zone;
             statusEl.textContent =
                 rows.length +
                 ' of ' +
                 allRows.length +
                 ' location' +
                 (allRows.length === 1 ? '' : 's') +
-                ' shown. Use the view action to edit on the map.';
+                ' shown ' +
+                scope +
+                '. Use the view action to edit on the map.';
         }
         renderLegLocationsBrowserHeader();
         tbody.innerHTML = '';
@@ -929,7 +946,7 @@
                 renderAllLegLocationsMapLayer();
             });
         }
-        ['leg-locations-filter-leg', 'leg-locations-filter-type'].forEach(function (id) {
+        ['leg-locations-filter-zone', 'leg-locations-filter-type'].forEach(function (id) {
             var el = document.getElementById(id);
             if (el) {
                 el.addEventListener('change', function () {
@@ -3555,6 +3572,27 @@
         });
         appendLegPopupField(content, 'Type', sel);
 
+        var sourceLegIdForEdit =
+            mode === 'edit-saved' && selectedLegId ? String(selectedLegId) : '';
+        var legMoveSel = null;
+        if (
+            mode === 'edit-saved' &&
+            sourceLegIdForEdit &&
+            usesOrgLegLibrary() &&
+            isOrgLegsHubMode()
+        ) {
+            legMoveSel = document.createElement('select');
+            (libraryState && libraryState.legs || []).forEach(function (leg) {
+                var opt = document.createElement('option');
+                opt.value = leg.id;
+                opt.textContent =
+                    leg.id + ' — ' + ((leg.leg_label || '').slice(0, 40) || leg.id);
+                if (leg.id === sourceLegIdForEdit) opt.selected = true;
+                legMoveSel.appendChild(opt);
+            });
+            appendLegPopupField(content, 'Leg', legMoveSel);
+        }
+
         var excludeProxyKey =
             mode === 'edit-saved' && selectedLegId && opts.locIndex != null
                 ? legLocKey(selectedLegId, opts.locIndex)
@@ -3775,6 +3813,60 @@
                 var locIndex = opts.locIndex;
                 var leg = getSelectedLeg();
                 if (!leg || locIndex == null || !selectedLegId) return;
+                var targetLegId = legMoveSel
+                    ? String(legMoveSel.value || '').trim()
+                    : selectedLegId;
+                if (targetLegId && targetLegId !== selectedLegId) {
+                    if (
+                        !window.confirm(
+                            'Move "' +
+                                locLabel +
+                                '" from leg ' +
+                                selectedLegId +
+                                ' to leg ' +
+                                targetLegId +
+                                '?'
+                        )
+                    ) {
+                        return;
+                    }
+                    var locationsForMove = (leg.locations || []).slice();
+                    if (locIndex < 0 || locIndex >= locationsForMove.length) return;
+                    var movedLoc = applyLegLocationLabelType(
+                        locationsForMove[locIndex],
+                        locLabel,
+                        locType
+                    );
+                    applyOpsFields(movedLoc);
+                    locationsForMove[locIndex] = movedLoc;
+                    map.closePopup();
+                    setLegStatus('Moving location…');
+                    saveLegLocations(selectedLegId, locationsForMove)
+                        .then(function () {
+                            return moveOrgLegLocation(selectedLegId, locIndex, targetLegId);
+                        })
+                        .then(function (data) {
+                            var newIdx =
+                                data && data.new_loc_index != null
+                                    ? data.new_loc_index
+                                    : null;
+                            setLegStatus(
+                                'Location moved to leg ' + targetLegId + '.'
+                            );
+                            if (newIdx != null) {
+                                navigateToLegLocation(targetLegId, newIdx, {
+                                    scroll: false,
+                                });
+                            } else {
+                                selectLegById(targetLegId, { preserveZoom: true });
+                            }
+                        })
+                        .catch(function (err) {
+                            redrawLegLocationMarkers(getSelectedLeg());
+                            setLegStatus(err.message || String(err), true);
+                        });
+                    return;
+                }
                 var locations = (leg.locations || []).slice();
                 if (locIndex < 0 || locIndex >= locations.length) return;
                 var savedLoc = applyLegLocationLabelType(
@@ -3993,7 +4085,11 @@
         invalidateLegGeometryRequests();
         clearLegMapLayers();
         selectedLegId = null;
+        document.querySelectorAll('#course-legs-tbody tr').forEach(function (tr) {
+            tr.classList.remove('selected');
+        });
         updateLegActionButtons();
+        renderLegLocationsBrowser();
     }
 
     function saveLegEndpoints(legId, startLabel, endLabel) {
@@ -4063,6 +4159,7 @@
         document.querySelectorAll('#course-legs-tbody tr').forEach(function (tr) {
             tr.classList.toggle('selected', tr.dataset.legId === legId);
         });
+        renderLegLocationsBrowser();
         if (!options.keepPinMode) {
             stopLegLocationPinMode();
         }
@@ -4125,6 +4222,10 @@
 
     function selectLeg(leg) {
         if (!leg) return;
+        if (selectedLegId === leg.id) {
+            clearLegMap();
+            return;
+        }
         selectLegById(leg.id);
     }
 
@@ -4394,6 +4495,33 @@
             .then(function (payload) {
                 if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
                 return afterLegLibraryMutation(payload.data);
+            });
+    }
+
+    function moveOrgLegLocation(sourceLegId, locIndex, targetLegId) {
+        return fetch(
+            '/api/org/legs/' +
+                encodeURIComponent(sourceLegId) +
+                '/locations/' +
+                encodeURIComponent(String(locIndex)) +
+                '/move',
+            {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ target_leg_id: targetLegId }),
+            }
+        )
+            .then(function (r) {
+                return r.json().then(function (d) {
+                    return { res: r, data: d };
+                });
+            })
+            .then(function (payload) {
+                if (!payload.res.ok) throw new Error(formatApiError(payload.res, payload.data));
+                return afterLegLibraryMutation(payload.data).then(function () {
+                    return payload.data;
+                });
             });
     }
 

--- a/frontend/static/js/map/segment_recipes.js
+++ b/frontend/static/js/map/segment_recipes.js
@@ -48,11 +48,17 @@
     /** Background layer showing every leg route on the legs map. */
     var allLegRoutesLayer = null;
     var allLegRoutesFetchSeq = 0;
+    /** Last GeoJSON features from org/package leg geometries (for restyling). */
+    var allLegRoutesFeatures = null;
     var ALL_LEG_ROUTES_PANE = 'all-leg-routes';
     var allLegLocationsLayer = null;
     var ALL_LEG_LOCATIONS_PANE = 'all-leg-locations';
     var legLocationsBrowserShowAllPins = false;
     var legLocationsBrowserHighlightKey = '';
+    /** Last zone-audit fit key so we only re-zoom when the scope changes. */
+    var legLocationsZoneAuditFitKey = '';
+    /** True when a zone-audit fit is waiting on leg geometries. */
+    var legLocationsZoneAuditFitPending = false;
     var pendingLocationFocus = null;
     var legLocationsBrowserFiltersBound = false;
     /** Draw-a-leg mode state (Issue #789 Create Leg). */
@@ -329,13 +335,84 @@
         return (res && res.status ? 'HTTP ' + res.status + ': ' : '') + 'Request failed';
     }
 
+    var legActionToastTimer = null;
+
+    function clearLegActionToastTimer() {
+        if (legActionToastTimer) {
+            clearTimeout(legActionToastTimer);
+            legActionToastTimer = null;
+        }
+    }
+
+    function hideLegActionToast() {
+        clearLegActionToastTimer();
+        var toast = document.getElementById('leg-action-toast');
+        if (!toast) return;
+        toast.hidden = true;
+        toast.textContent = '';
+        toast.classList.remove('is-busy', 'is-error');
+    }
+
+    /**
+     * Prominent map-overlay feedback for location save / move / remove.
+     * Non-blocking toast (not a modal) so rapid pin edits stay fluid.
+     */
+    function showLegActionToast(msg, kind) {
+        var toast = document.getElementById('leg-action-toast');
+        if (!toast || !msg) return;
+        clearLegActionToastTimer();
+        toast.textContent = msg;
+        toast.classList.remove('is-busy', 'is-error');
+        if (kind === 'error') toast.classList.add('is-error');
+        else if (kind === 'busy') toast.classList.add('is-busy');
+        toast.hidden = false;
+        if (kind === 'busy') return;
+        var ms = kind === 'error' ? 4500 : 2800;
+        legActionToastTimer = setTimeout(function () {
+            legActionToastTimer = null;
+            hideLegActionToast();
+        }, ms);
+    }
+
+    function legStatusToastKind(msg, isError) {
+        if (!msg) return null;
+        if (isError) return 'error';
+        if (/^(Saving|Moving|Removing)\b/i.test(msg)) return 'busy';
+        if (
+            /^(Location (updated|removed|position saved|moved)\b|Locations saved\b)/i.test(
+                msg
+            )
+        ) {
+            return 'ok';
+        }
+        return null;
+    }
+
     function setLegStatus(msg, isError) {
         var el = document.getElementById('course-legs-status');
-        if (!el) return;
-        if (!msg) { el.style.display = 'none'; el.textContent = ''; return; }
-        el.style.display = 'block';
-        el.style.color = isError ? '#c0392b' : '#27ae60';
-        el.textContent = msg;
+        if (!msg) {
+            if (el) {
+                el.style.display = 'none';
+                el.textContent = '';
+            }
+            hideLegActionToast();
+            return;
+        }
+        var kind = legStatusToastKind(msg, isError);
+        if (kind) {
+            // Toast covers save/move/remove feedback — skip the inline duplicate under Org leg library.
+            if (el) {
+                el.style.display = 'none';
+                el.textContent = '';
+            }
+            showLegActionToast(msg, kind);
+            return;
+        }
+        if (el) {
+            el.style.display = 'block';
+            el.style.color = isError ? '#c0392b' : '#27ae60';
+            el.textContent = msg;
+        }
     }
 
     function setRecipeStatus(msg, isError) {
@@ -713,9 +790,75 @@
         btn.textContent = legLocationsBrowserShowAllPins ? 'Hide all pins' : 'Show all pins';
     }
 
+    /** No leg selected + a Zone filter: map focuses that zone across the library. */
+    function isZoneAuditMapMode() {
+        if (!isOrgLegsHubMode() || selectedLegId) return false;
+        var filters = getLegLocationsBrowserFilters();
+        return !!(filters && filters.zone);
+    }
+
+    function shouldShowBrowserLocationsOnMap() {
+        return !!legLocationsBrowserShowAllPins || isZoneAuditMapMode();
+    }
+
+    /** Leg ids that have at least one location matching current browser filters. */
+    function getFilteredBrowserLegIdSet() {
+        var filters = getLegLocationsBrowserFilters();
+        var ids = {};
+        collectAllLegLocationRows().forEach(function (row) {
+            if (!legLocationRowMatchesFilters(row, filters)) return;
+            if (row.legId) ids[row.legId] = true;
+        });
+        return ids;
+    }
+
+    function allLegRouteStyle(legId, auditLegIds) {
+        if (auditLegIds) {
+            if (legId && auditLegIds[legId]) {
+                return { color: '#5b4db8', weight: 5, opacity: 0.95 };
+            }
+            return { color: '#9b8ec4', weight: 2, opacity: 0.22 };
+        }
+        return { color: '#9b8ec4', weight: 3, opacity: 0.7 };
+    }
+
+    function fitZoneAuditMapBounds(rows, legIds) {
+        var map = window.courseMappingMap;
+        if (!map || typeof L === 'undefined') return;
+        var points = [];
+        (rows || []).forEach(function (row) {
+            if (row.loc && row.loc.lat != null && row.loc.lon != null) {
+                points.push([row.loc.lat, row.loc.lon]);
+            }
+        });
+        Object.keys(legIds || {}).forEach(function (legId) {
+            var bounds = legBoundsCache[legId];
+            if (!bounds) return;
+            try {
+                points.push(bounds.getSouthWest());
+                points.push(bounds.getNorthEast());
+            } catch (e) { /* ignore */ }
+        });
+        if (!points.length) return;
+        function doFit() {
+            if (points.length === 1) {
+                map.setView(points[0], Math.max(map.getZoom(), 14));
+                return;
+            }
+            try {
+                map.fitBounds(L.latLngBounds(points), { padding: [48, 48], maxZoom: 15 });
+            } catch (e) { /* empty */ }
+        }
+        if (legsTableBoundsFilter) {
+            legsTableBoundsFilter.runProgrammatic(doFit);
+        } else {
+            doFit();
+        }
+    }
+
     function renderAllLegLocationsMapLayer() {
         var map = window.courseMappingMap;
-        if (!map || !legLocationsBrowserShowAllPins || !isOrgLegsHubMode()) {
+        if (!map || !shouldShowBrowserLocationsOnMap() || !isOrgLegsHubMode()) {
             removeAllLegLocationsLayer();
             return;
         }
@@ -851,6 +994,9 @@
             if (wrap) wrap.style.display = 'none';
             if (empty) empty.style.display = 'block';
             renderAllLegLocationsMapLayer();
+            syncAllLegRoutesHighlight();
+            legLocationsZoneAuditFitKey = '';
+            legLocationsZoneAuditFitPending = false;
             return;
         }
         if (empty) empty.style.display = 'none';
@@ -902,6 +1048,29 @@
             tbody.appendChild(tr);
         });
         renderAllLegLocationsMapLayer();
+        syncAllLegRoutesHighlight();
+        if (isZoneAuditMapMode()) {
+            var auditLegIds = getFilteredBrowserLegIdSet();
+            var fitKey =
+                (filters.zone || '') +
+                '|' +
+                Object.keys(auditLegIds).sort().join(',') +
+                '|' +
+                rows.length;
+            if (fitKey !== legLocationsZoneAuditFitKey) {
+                legLocationsZoneAuditFitKey = fitKey;
+                if (allLegRoutesFeatures && allLegRoutesFeatures.length) {
+                    legLocationsZoneAuditFitPending = false;
+                    fitZoneAuditMapBounds(rows, auditLegIds);
+                } else {
+                    legLocationsZoneAuditFitPending = true;
+                    fitZoneAuditMapBounds(rows, auditLegIds);
+                }
+            }
+        } else {
+            legLocationsZoneAuditFitKey = '';
+            legLocationsZoneAuditFitPending = false;
+        }
     }
 
     function tryOpenPendingLocationFocus() {
@@ -1624,6 +1793,66 @@
         }
     }
 
+    function paintAllLegRoutesFromFeatures(features) {
+        var mapNow = window.courseMappingMap;
+        if (!mapNow || typeof L === 'undefined') return;
+        ensureAllLegRoutesPane(mapNow);
+        removeAllLegRoutesLayer();
+        features = features || [];
+        if (!features.length) return;
+        var auditLegIds = isZoneAuditMapMode() ? getFilteredBrowserLegIdSet() : null;
+        var group = L.layerGroup();
+        features.forEach(function (feature) {
+            var geom = feature.geometry || {};
+            var coords = geom.coordinates || [];
+            if (geom.type !== 'LineString' || coords.length < 2) return;
+            var latlngs = coords.map(function (c) { return [c[1], c[0]]; });
+            var props = feature.properties || {};
+            var legId = props.leg_id;
+            if (legId) {
+                try {
+                    legBoundsCache[legId] = L.latLngBounds(latlngs);
+                } catch (e) { /* ignore */ }
+            }
+            var style = allLegRouteStyle(legId, auditLegIds);
+            var line = L.polyline(latlngs, {
+                pane: ALL_LEG_ROUTES_PANE,
+                color: style.color,
+                weight: style.weight,
+                opacity: style.opacity
+            });
+            var label = String(props.leg_label || legId || '');
+            if (label) {
+                line.bindTooltip(label, { sticky: true });
+            }
+            if (legId) {
+                line.on('click', function () {
+                    if (legDrawActive || legExtendActive) return;
+                    selectLegById(legId);
+                });
+            }
+            group.addLayer(line);
+        });
+        allLegRoutesLayer = group.addTo(mapNow);
+        if (legLocationsZoneAuditFitPending && isZoneAuditMapMode()) {
+            legLocationsZoneAuditFitPending = false;
+            var filters = getLegLocationsBrowserFilters();
+            var rows = collectAllLegLocationRows().filter(function (row) {
+                return legLocationRowMatchesFilters(row, filters);
+            });
+            fitZoneAuditMapBounds(rows, getFilteredBrowserLegIdSet());
+        }
+    }
+
+    function syncAllLegRoutesHighlight() {
+        if (!allLegRoutesFeatures || !allLegRoutesFeatures.length) {
+            if (isZoneAuditMapMode()) renderAllLegRoutes();
+            return;
+        }
+        if (!shouldShowLegRoutesWhileDrawing()) return;
+        paintAllLegRoutesFromFeatures(allLegRoutesFeatures);
+    }
+
     /** Draw every leg route as a muted background line so the full network is visible without a selection. */
     function renderAllLegRoutes() {
         var map = window.courseMappingMap;
@@ -1636,6 +1865,7 @@
         var legs = (libraryState && libraryState.legs) || [];
         if (!legs.length) {
             removeAllLegRoutesLayer();
+            allLegRoutesFeatures = null;
             return;
         }
         allLegRoutesFetchSeq += 1;
@@ -1649,44 +1879,8 @@
             .then(function (data) {
                 if (seq !== allLegRoutesFetchSeq || !data) return;
                 if (!shouldShowLegRoutesWhileDrawing()) return;
-                var mapNow = window.courseMappingMap;
-                if (!mapNow) return;
-                ensureAllLegRoutesPane(mapNow);
-                removeAllLegRoutesLayer();
-                var features = data.features || [];
-                if (!features.length) return;
-                var group = L.layerGroup();
-                features.forEach(function (feature) {
-                    var geom = feature.geometry || {};
-                    var coords = geom.coordinates || [];
-                    if (geom.type !== 'LineString' || coords.length < 2) return;
-                    var latlngs = coords.map(function (c) { return [c[1], c[0]]; });
-                    var props = feature.properties || {};
-                    var legId = props.leg_id;
-                    if (legId) {
-                        try {
-                            legBoundsCache[legId] = L.latLngBounds(latlngs);
-                        } catch (e) { /* ignore */ }
-                    }
-                    var line = L.polyline(latlngs, {
-                        pane: ALL_LEG_ROUTES_PANE,
-                        color: '#9b8ec4',
-                        weight: 3,
-                        opacity: 0.7
-                    });
-                    var label = String(props.leg_label || legId || '');
-                    if (label) {
-                        line.bindTooltip(label, { sticky: true });
-                    }
-                    if (legId) {
-                        line.on('click', function () {
-                            if (legDrawActive || legExtendActive) return;
-                            selectLegById(legId);
-                        });
-                    }
-                    group.addLayer(line);
-                });
-                allLegRoutesLayer = group.addTo(mapNow);
+                allLegRoutesFeatures = data.features || [];
+                paintAllLegRoutesFromFeatures(allLegRoutesFeatures);
             })
             .catch(function () { /* background layer is best-effort */ });
     }

--- a/frontend/templates/partials/course_mapping_styles.html
+++ b/frontend/templates/partials/course_mapping_styles.html
@@ -141,6 +141,38 @@
         line-height: 1.35;
         pointer-events: none;
     }
+    .leg-action-toast {
+        position: absolute;
+        top: 12px;
+        left: 50%;
+        transform: translateX(-50%);
+        z-index: 1200;
+        max-width: min(420px, calc(100% - 2rem));
+        padding: 0.65rem 1.1rem;
+        border-radius: 6px;
+        border: 1px solid #27ae60;
+        background: #edf9f1;
+        box-shadow: 0 4px 16px rgba(0, 0, 0, 0.18);
+        font-size: 0.95rem;
+        font-weight: 600;
+        color: #1e7e34;
+        line-height: 1.35;
+        text-align: center;
+        pointer-events: none;
+    }
+    .leg-action-toast[hidden] {
+        display: none !important;
+    }
+    .leg-action-toast.is-busy {
+        border-color: #2980b9;
+        background: #eaf4fb;
+        color: #1a5276;
+    }
+    .leg-action-toast.is-error {
+        border-color: #c0392b;
+        background: #fdecea;
+        color: #922b21;
+    }
     #config-package-legs-panel .config-legs-map-lead {
         margin: 0 0 0.65rem 0;
         font-size: 0.875rem;

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -158,7 +158,7 @@
             </div>
             <p class="card-help course-derived-empty">
                 Every location across the org leg library. Use the view action to select the leg on the map and open the location editor.
-                Zone is set on the package <strong>Courses</strong> tab after build.
+                Zone on the leg is the default for new packages; package Course edits can still override per package.
             </p>
             <div class="leg-locations-browser-filters">
                 <label>
@@ -183,6 +183,7 @@
                             <th>ID</th>
                             <th>Label</th>
                             <th>Type</th>
+                            <th>Zone</th>
                             <th>Proxy</th>
                         </tr>
                     </thead>

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -55,6 +55,7 @@
                 <div id="course-mapping-map" aria-label="Leg and course map">
                     <div class="map-loading">Loading map...</div>
                     <div id="leg-map-bounds-status" class="config-map-bounds-status" aria-live="polite"></div>
+                    <div id="leg-action-toast" class="leg-action-toast" hidden role="status" aria-live="polite"></div>
                     <div id="leg-map-toolbar" class="leg-map-toolbar">
                         <button type="button" id="btn-leg-draw" class="course-btn" title="Draw a new leg by clicking along roads and trails (snap to route)">Draw leg</button>
                         <span id="leg-draw-actions" class="leg-route-edit-actions" style="display: none;">
@@ -158,7 +159,8 @@
             </div>
             <p class="card-help course-derived-empty">
                 Scoped by the <strong>Organization leg library</strong> selection (click the selected leg again to clear and browse all legs).
-                Zone intersects with that scope; Type and Search apply on top. Use view to open the location editor on the map.
+                With no leg selected, choosing a <strong>Zone</strong> shows matching pins and highlights their legs on the map.
+                Type and Search apply on top. Use view to open the location editor.
                 Zone on the leg is the default for new packages; package Course edits can still override per package.
             </p>
             <div class="leg-locations-browser-filters">

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -157,13 +157,14 @@
                 </div>
             </div>
             <p class="card-help course-derived-empty">
-                Every location across the org leg library. Use the view action to select the leg on the map and open the location editor.
+                Scoped by the <strong>Organization leg library</strong> selection (click the selected leg again to clear and browse all legs).
+                Zone intersects with that scope; Type and Search apply on top. Use view to open the location editor on the map.
                 Zone on the leg is the default for new packages; package Course edits can still override per package.
             </p>
             <div class="leg-locations-browser-filters">
                 <label>
-                    <span class="course-label">Leg</span>
-                    <select id="leg-locations-filter-leg" class="course-btn leg-locations-filter-control"></select>
+                    <span class="course-label">Zone</span>
+                    <select id="leg-locations-filter-zone" class="course-btn leg-locations-filter-control"></select>
                 </label>
                 <label>
                     <span class="course-label">Type</span>

--- a/tests/unit/test_org_leg_library.py
+++ b/tests/unit/test_org_leg_library.py
@@ -5,6 +5,7 @@ import yaml
 from app.core.config_package.org_leg_library import (
     import_org_leg_to_package,
     list_org_legs,
+    move_org_leg_location,
     publish_package_leg_to_org_library,
     update_org_leg,
     update_org_leg_geometry,
@@ -380,6 +381,126 @@ def test_copy_org_leg_locations_from_paired_leg(tmp_path, monkeypatch):
     assert copied["locations"][0]["loc_label"] == "Trail at Charlotte"
     assert copied["locations"][0]["resources"]["yssr"] == 2
     assert len(list(get_org_legs_dir().glob("*.gpx"))) == 2
+
+
+def test_move_org_leg_location_happy_path(tmp_path, monkeypatch):
+    """Move one pin from source leg onto target; preserve location_key."""
+    monkeypatch.setattr(
+        "app.core.config_package.org_leg_library.get_runflow_root",
+        lambda: tmp_path,
+    )
+    org_dir = tmp_path / "org" / "legs"
+    org_dir.mkdir(parents=True)
+    (org_dir / "05_trail.gpx").write_text(_GPX, encoding="utf-8")
+    (org_dir / "12_trail.gpx").write_text(_GPX, encoding="utf-8")
+    (org_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "05",
+                        "file": "05_trail.gpx",
+                        "seg_label": "Source corridor",
+                        "locations": [
+                            {
+                                "loc_label": "Keep on source",
+                                "loc_type": "course",
+                                "lat": 45.961,
+                                "lon": -66.641,
+                                "location_key": "KEEP1",
+                            },
+                            {
+                                "loc_label": "St John at Aberdeen",
+                                "loc_type": "traffic",
+                                "lat": 45.96,
+                                "lon": -66.64,
+                                "zone": "A",
+                                "resources": {"yssr": 1},
+                                "location_key": "ABCDE",
+                            },
+                        ],
+                    },
+                    {
+                        "id": "12",
+                        "file": "12_trail.gpx",
+                        "seg_label": "Target corridor",
+                        "locations": [],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    state = move_org_leg_location("05", 1, "12")
+    assert state["source_leg_id"] == "05"
+    assert state["target_leg_id"] == "12"
+    assert state["new_loc_index"] == 0
+    source = next(l for l in state["legs"] if l["id"] == "05")
+    target = next(l for l in state["legs"] if l["id"] == "12")
+    assert len(source.get("locations") or []) == 1
+    assert source["locations"][0]["loc_label"] == "Keep on source"
+    assert len(target.get("locations") or []) == 1
+    moved = target["locations"][0]
+    assert moved["loc_label"] == "St John at Aberdeen"
+    assert moved["location_key"] == "ABCDE"
+    assert moved["zone"] == "A"
+    assert moved["resources"]["yssr"] == 1
+
+
+def test_move_org_leg_location_blocks_duplicate_key(tmp_path, monkeypatch):
+    """Refuse move when target already has the same location_key."""
+    monkeypatch.setattr(
+        "app.core.config_package.org_leg_library.get_runflow_root",
+        lambda: tmp_path,
+    )
+    org_dir = tmp_path / "org" / "legs"
+    org_dir.mkdir(parents=True)
+    (org_dir / "05_trail.gpx").write_text(_GPX, encoding="utf-8")
+    (org_dir / "12_trail.gpx").write_text(_GPX, encoding="utf-8")
+    (org_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "05",
+                        "file": "05_trail.gpx",
+                        "seg_label": "Source",
+                        "locations": [
+                            {
+                                "loc_label": "Shared pin",
+                                "loc_type": "traffic",
+                                "lat": 45.96,
+                                "lon": -66.64,
+                                "location_key": "SAME2",
+                            }
+                        ],
+                    },
+                    {
+                        "id": "12",
+                        "file": "12_trail.gpx",
+                        "seg_label": "Target",
+                        "locations": [
+                            {
+                                "loc_label": "Already here",
+                                "loc_type": "traffic",
+                                "lat": 45.961,
+                                "lon": -66.641,
+                                "location_key": "SAME2",
+                            }
+                        ],
+                    },
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    try:
+        move_org_leg_location("05", 0, "12")
+        assert False, "expected ValueError for duplicate location_key"
+    except ValueError as exc:
+        assert "SAME2" in str(exc)
 
 
 def test_update_org_leg_geometry(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- **Milestone 1:** All leg locations is scoped by Organization leg library selection (click selected leg again to clear). Removes the Leg dropdown; adds Zone filter. With no leg selected + a Zone chosen, the map shows matching pins and highlights associated legs.
- **Milestone 2:** Location popup Leg dropdown moves a pin between org legs (confirm, preserve `location_key`, block duplicate key on target). `POST /api/org/legs/{id}/locations/{index}/move`.
- **UX:** Map toast for location save/move/remove (no duplicate status under Org leg library).

Closes #834.

## Test plan
- [x] Select a leg → All leg locations shows only that leg
- [x] Deselect leg + choose Zone → pins + highlighted legs on map
- [x] Type/Search still apply on top of leg × zone
- [x] Edit location → change Leg → confirm → pin moves
- [x] Save feedback appears as map toast (not under Org leg library)
- [x] Unit: `test_move_org_leg_location_*`