### PR TITLE
Build race exports: org-level zone from Legs/Courses (#836)

### DIFF
--- a/app/core/config_package/legs.py
+++ b/app/core/config_package/legs.py
@@ -68,7 +68,6 @@ _LEG_LOC_PRESERVE_FIELDS = (
     "notes",
     "buffer",
     "interval",
-    "zone",
     "equipment",
     "contact",
     "proxy_pass_id",
@@ -84,13 +83,21 @@ _LEG_LOC_PRESERVE_FIELDS = (
 # silently ignored otherwise).
 _LEG_OWNED_PLACEMENT_FIELDS = ("lat", "lon", "placement")
 
+# Zone is org-level (Build → Legs), snapshotted into Courses. Do not preserve
+# stale package course.json zone on merge / race export (Issue #836).
+_LEG_OWNED_ZONE_FIELD = "zone"
+
+# Fields persisted on org/package leg location rows (includes zone; zone is not
+# package-preserved on merge — see _LEG_OWNED_ZONE_FIELD).
+_LEG_LOC_EXPORT_FIELDS = _LEG_LOC_PRESERVE_FIELDS + (_LEG_OWNED_ZONE_FIELD,)
+
 # Assigned-course race builds use saved course leg snapshots as source of truth
-# for labels/types/placement; only operational fields stay on the package row.
+# for labels/types/placement/zone; only remaining operational fields stay on the
+# package row.
 _RACE_EXPORT_PRESERVE_FIELDS = (
     "notes",
     "buffer",
     "interval",
-    "zone",
     "equipment",
     "contact",
     "proxy_pass_id",
@@ -101,8 +108,6 @@ _RACE_EXPORT_PRESERVE_FIELDS = (
     "onepage",
     "resources",
 )
-
-_LEG_LOC_EXPORT_FIELDS = _LEG_LOC_PRESERVE_FIELDS
 
 _BLANK_LOCATION_DAYS = frozenset({"", "nan", "none", "null"})
 
@@ -1190,7 +1195,8 @@ def merge_leg_locations_into_course(
     ``leg_manifest`` overrides the org/package library (e.g. merged saved-course
     snapshots during Build race exports). ``preserve_from_course`` controls which
     fields are kept from existing course rows; race builds use
-    ``_RACE_EXPORT_PRESERVE_FIELDS`` so saved course snapshots win for type/label.
+    ``_RACE_EXPORT_PRESERVE_FIELDS`` so saved course snapshots win for
+    type/label/zone.
     """
     from app.core.config_package.leg_library_resolver import (
         recipe_leg_ids_from_package,
@@ -1287,6 +1293,9 @@ def merge_leg_locations_into_course(
                 "source": "leg",
                 "seg_id": seg_id if on_course else "",
             }
+            zone_val = loc.get(_LEG_OWNED_ZONE_FIELD)
+            if zone_val not in (None, ""):
+                row[_LEG_OWNED_ZONE_FIELD] = zone_val
             if not row["pass_key"]:
                 ensure_location_key(row, used_loc_keys)
                 row["pass_key"] = row.get("location_key") or ""
@@ -1324,6 +1333,8 @@ def merge_leg_locations_into_course(
                     row["pass_id"] = new_id
                 for field in preserve_fields:
                     if field in _LEG_OWNED_PLACEMENT_FIELDS:
+                        continue
+                    if field == _LEG_OWNED_ZONE_FIELD:
                         continue
                     if on_course and field in (
                         "proxy_loc_id",

--- a/app/core/config_package/saved_courses.py
+++ b/app/core/config_package/saved_courses.py
@@ -934,9 +934,10 @@ def build_package_race_exports(config_id: str) -> Dict[str, Any]:
     pkg_seg["leg_source"] = "org"
     save_package_segment_manifest(cid, pkg_seg)
 
-    # Merge locations from assigned-course snapshots (not live org legs). Package
-    # course.json may still have stale traffic types; do not preserve those over
-    # the saved course leg snapshot.
+    # Merge locations from assigned-course snapshots (not live org legs).
+    # Zone comes from the snapshot (org Legs); do not keep stale package zone.
+    # Package course.json may still have stale traffic types; do not preserve
+    # those over the saved course leg snapshot.
     try:
         from app.core.config_package.legs import (
             _RACE_EXPORT_PRESERVE_FIELDS,

--- a/frontend/templates/partials/course_mapping_workspace.html
+++ b/frontend/templates/partials/course_mapping_workspace.html
@@ -161,7 +161,9 @@
                 Scoped by the <strong>Organization leg library</strong> selection (click the selected leg again to clear and browse all legs).
                 With no leg selected, choosing a <strong>Zone</strong> shows matching pins and highlights their legs on the map.
                 Type and Search apply on top. Use view to open the location editor.
-                Zone on the leg is the default for new packages; package Course edits can still override per package.
+                Zone is authored on the org leg and snapshotted into Courses; Build race
+                exports republishes that zone into the package (package Course edits do not
+                win on export).
             </p>
             <div class="leg-locations-browser-filters">
                 <label>

--- a/tests/unit/test_saved_courses.py
+++ b/tests/unit/test_saved_courses.py
@@ -396,8 +396,89 @@ def test_build_race_exports_uses_saved_course_location_types(tmp_path, monkeypat
 
     build_package_race_exports(config_id)
 
-    rows = list(csv.DictReader((package_path / "locations.csv").open(encoding="utf-8")))
+    rows = list(csv.DictReader((package_path / "passes.csv").open(encoding="utf-8")))
     george = [r for r in rows if r.get("loc_label") == "University at George"]
     assert len(george) == 1
     assert george[0].get("loc_type") == "course"
     assert george[0].get("seg_id")
+
+
+def test_build_race_exports_uses_saved_course_zone(tmp_path, monkeypatch):
+    """Stale package zone must not override org/course-snapshot zone (#836)."""
+    import csv
+
+    _patch_roots(tmp_path, monkeypatch)
+    org_dir = tmp_path / "org" / "legs"
+    org_dir.mkdir(parents=True)
+    gpx_name = "36_trail.gpx"
+    (org_dir / gpx_name).write_text(_GPX, encoding="utf-8")
+    (org_dir / "manifest.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "legs": [
+                    {
+                        "id": "36",
+                        "file": gpx_name,
+                        "seg_label": "Trail",
+                        "start_label": "Start",
+                        "end_label": "End",
+                        "locations": [
+                            {
+                                "loc_label": "Trail at Charlotte",
+                                "loc_type": "course",
+                                "lat": 45.954885,
+                                "lon": -66.636135,
+                                "placement": "along",
+                                "zone": "9",
+                                "location_key": "N2RKT",
+                            }
+                        ],
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    save_org_course(
+        name="Full Trail",
+        distance="full",
+        recipe=["36"],
+        course_id="04",
+    )
+
+    result = create_config_package(
+        "Race build zones",
+        "",
+        event_day="sun",
+        package_events=["full"],
+    )
+    config_id = result["config_id"]
+    save_package_segment_manifest(
+        config_id,
+        {
+            "version": 1,
+            "leg_source": "org",
+            "legs": [],
+            "recipes": {"full": []},
+            "flow_overrides": [],
+        },
+    )
+    set_package_course_assignments(config_id, {"full": "04"})
+    build_package_race_exports(config_id)
+
+    package_path = resolve_config_package_path(config_id)
+    course_path = package_path / "course.json"
+    course = json.loads(course_path.read_text(encoding="utf-8"))
+    stale = course["locations"][0]
+    stale["zone"] = "2"
+    course_path.write_text(json.dumps(course, indent=2), encoding="utf-8")
+
+    build_package_race_exports(config_id)
+
+    rows = list(csv.DictReader((package_path / "passes.csv").open(encoding="utf-8")))
+    charlotte = [r for r in rows if r.get("loc_label") == "Trail at Charlotte"]
+    assert len(charlotte) == 1
+    assert charlotte[0].get("zone") == "9"
+    course_after = json.loads(course_path.read_text(encoding="utf-8"))
+    assert course_after["locations"][0].get("zone") == "9"


### PR DESCRIPTION
## Summary
- Zone is org-level (Build → Legs), snapshotted into Courses.
- Build race exports no longer preserves stale package `course.json` zone over the assigned course snapshot.
- Help text updated; unit test covers stale package zone → snapshot zone 9.

Closes #836.

## Test plan
- [ ] On a package with stale zones (e.g. FM2027 Trail at Charlotte zone 2 vs Legs zone 9): refresh named courses if needed, Build race exports, confirm package `course.json` / `passes.csv` show zone 9
- [ ] Re-run analysis and confirm Locations report zone matches Legs
- [ ] Unit: `test_build_race_exports_uses_saved_course_zone`


Made with [Cursor](https://cursor.com)