### PR TITLE
Fix Locations zone map filter + unique loc_id (#838)

### DIFF
--- a/app/core/locations/identity.py
+++ b/app/core/locations/identity.py
@@ -148,14 +148,16 @@ def _assign_human_loc_ids(locs: Sequence[Dict[str, Any]]) -> None:
         if len(group) >= 2 and len(unique) == 1:
             # Paired passes already share a human loc_id
             shared = next(iter(unique))
-            key_to_loc_id[key] = shared
-            used_loc_ids.add(shared)
+            if shared not in used_loc_ids:
+                key_to_loc_id[key] = shared
+                used_loc_ids.add(shared)
             continue
         if len(group) == 1 and loc_ids[0] is not None:
             lid = loc_ids[0]
             pid = get_pass_id(group[0])
             # Legacy CSV: loc_id was the pass instance — treat as unset
-            if lid != pid:
+            # Also skip if another pass_key already claimed this human id (#838).
+            if lid != pid and lid not in used_loc_ids:
                 key_to_loc_id[key] = lid
                 used_loc_ids.add(lid)
 

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -516,8 +516,7 @@
         }
         
         // Update map markers (without fitting bounds - preserve user zoom)
-        const visibleIds = filtered.flatMap(loc => loc.loc_ids || [loc.loc_id]);
-        filterMapToLocations(visibleIds, false);
+        filterMapToLocations(filtered, false);
         
         // Render filtered and sorted data
         renderLocationsTable(filtered);
@@ -808,38 +807,63 @@
         }
         
         // Update map to show only filtered locations (only fit bounds if requested)
-        const visibleIds = filtered.flatMap(loc => loc.loc_ids || [loc.loc_id]);
-        filterMapToLocations(visibleIds, fitBounds);
+        filterMapToLocations(filtered, fitBounds);
         
         // Render filtered and sorted data
         renderLocationsTable(filtered);
     }
     
     /**
-     * Filter map markers to show only specified location IDs
-     * @param {Array<number|string>} visibleLocIds - Array of location IDs to show
+     * Filter map markers to the current table filter result.
+     * Prefer pass_key / location_key so colliding human loc_ids do not leak pins (#838).
+     * @param {Array<Object>|Array<number|string>} visibleLocationsOrIds - Filtered location rows, or legacy id list
      * @param {boolean} fitBounds - Whether to fit map bounds to visible markers (default: true)
      */
-    function filterMapToLocations(visibleLocIds, fitBounds = true) {
+    function filterMapToLocations(visibleLocationsOrIds, fitBounds = true) {
         if (!window.locationsLayer || !window.locationsMarkersByLocId) {
             return; // Map not initialized yet
         }
-        
-        const visibleSet = new Set(visibleLocIds.map(id => String(id)));
+
+        const rows = Array.isArray(visibleLocationsOrIds) ? visibleLocationsOrIds : [];
+        const useKeys = rows.length > 0 && typeof rows[0] === 'object' && rows[0] !== null;
+        const visibleKeySet = new Set();
+        const visibleIdSet = new Set();
+        if (useKeys) {
+            rows.forEach(function (loc) {
+                const key = String(loc.pass_key || loc.location_key || '').trim();
+                if (key) visibleKeySet.add(key);
+                const ids = loc.loc_ids || [loc.loc_id];
+                (Array.isArray(ids) ? ids : [ids]).forEach(function (id) {
+                    if (id != null && id !== '') visibleIdSet.add(String(id));
+                });
+            });
+        } else {
+            rows.forEach(function (id) {
+                if (id != null && id !== '') visibleIdSet.add(String(id));
+            });
+        }
+
         let hasVisibleMarkers = false;
-        
+        const visibleMarkers = [];
+
         // Show/hide markers based on filter
         window.locationsLayer.eachLayer(function(marker) {
-            const locId = String(marker.feature?.properties?.loc_id);
-            const isVisible = visibleSet.has(locId);
-            
+            const props = marker.feature?.properties || {};
+            const key = String(props.pass_key || props.location_key || '').trim();
+            let isVisible = false;
+            if (useKeys && visibleKeySet.size > 0) {
+                isVisible = key !== '' && visibleKeySet.has(key);
+            } else {
+                const locId = String(props.loc_id);
+                isVisible = visibleIdSet.has(locId);
+            }
+
             if (isVisible) {
                 hasVisibleMarkers = true;
-                // Show marker with original styling
-                const props = marker.feature?.properties || {};
+                visibleMarkers.push(marker);
                 const locType = props.loc_type?.toLowerCase() || 'unknown';
                 const color = getLocationMarkerColor(locType);
-                
+
                 marker.setStyle({
                     radius: 8,
                     fillColor: color,
@@ -848,50 +872,39 @@
                     opacity: 1,
                     fillOpacity: 0.8
                 });
-                
-                // Re-enable pointer events so tooltips/popups work
+
                 if (marker.options) {
                     marker.options.interactive = true;
                 }
                 marker._path && (marker._path.style.pointerEvents = 'auto');
             } else {
-                // Hide marker by making it transparent and disabling pointer events
                 marker.setStyle({
                     opacity: 0,
                     fillOpacity: 0
                 });
-                
-                // Disable pointer events to prevent tooltip/popup on hidden markers
+
                 if (marker.options) {
                     marker.options.interactive = false;
                 }
                 marker._path && (marker._path.style.pointerEvents = 'none');
             }
         });
-        
+
         // Fit map bounds to visible markers if requested and if any visible
-        if (fitBounds && hasVisibleMarkers && visibleLocIds.length > 0) {
-            const visibleMarkers = visibleLocIds
-                .map(id => window.locationsMarkersByLocId[String(id)])
-                .filter(m => m != null);
-            
-            if (visibleMarkers.length > 0) {
-                const group = L.featureGroup(visibleMarkers);
-                if (window.map && group.getBounds().isValid()) {
-                    // Temporarily disable bounds filtering to allow programmatic fit
-                    const wasProgrammatic = window.isProgrammaticMapMove;
-                    window.isProgrammaticMapMove = true;
-                    
-                    window.map.fitBounds(group.getBounds(), {
-                        padding: [20, 20],
-                        maxZoom: 16
-                    });
-                    
-                    // Re-enable bounds filtering after animation
-                    setTimeout(() => {
-                        window.isProgrammaticMapMove = wasProgrammatic;
-                    }, 600);
-                }
+        if (fitBounds && hasVisibleMarkers && visibleMarkers.length > 0) {
+            const group = L.featureGroup(visibleMarkers);
+            if (window.map && group.getBounds().isValid()) {
+                const wasProgrammatic = window.isProgrammaticMapMove;
+                window.isProgrammaticMapMove = true;
+
+                window.map.fitBounds(group.getBounds(), {
+                    padding: [20, 20],
+                    maxZoom: 16
+                });
+
+                setTimeout(() => {
+                    window.isProgrammaticMapMove = wasProgrammatic;
+                }, 600);
             }
         }
     }

--- a/tests/unit/test_location_identity.py
+++ b/tests/unit/test_location_identity.py
@@ -34,3 +34,26 @@ def test_stamp_pass_identity_preserves_existing_shared_loc_id():
     assert get_loc_id(locs[1]) == 7
     assert get_pass_id(locs[0]) == 10
     assert get_pass_id(locs[1]) == 20
+
+
+def test_stamp_pass_identity_rejects_duplicate_loc_id_across_keys():
+    """Two different pass_keys must not keep the same human loc_id (#838)."""
+    locs = [
+        {
+            "id": 79,
+            "pass_key": "CKTV6",
+            "loc_id": 1,
+            "loc_label": "St John at Charlotte",
+        },
+        {
+            "id": 114,
+            "pass_key": "24NXJ",
+            "loc_id": 1,
+            "loc_label": "Aberdeen at Church",
+        },
+    ]
+    stamp_pass_identity(locs)
+    assert get_pass_id(locs[0]) == 79
+    assert get_pass_id(locs[1]) == 114
+    assert get_loc_id(locs[0]) != get_loc_id(locs[1])
+    assert {get_loc_id(locs[0]), get_loc_id(locs[1])} == {1, 2}


### PR DESCRIPTION
## Summary
- **Map filter:** Locations Report map show/hide uses `pass_key` (not lone `loc_id`), so Zone 9 no longer leaves a Zone 1 pin visible when ids collide.
- **Identity:** `_assign_human_loc_ids` will not preserve a human `loc_id` already claimed by another `pass_key` (paired shares within one key still OK).

Closes #838.

## Test plan
- [ ] Locations Report → Zone 9: St John at Charlotte (zone 1) pin hidden; Aberdeen / Trail at Charlotte (zone 9) visible
- [ ] Build race exports (or any path that stamps identity) then re-check package `course.json` — St John and Aberdeen no longer share `loc_id: 1`
- [ ] Unit: `tests/unit/test_location_identity.py`


Made with [Cursor](https://cursor.com)