### PR TITLE
One-day analysis: drop multi-day chrome; day from run (#841)

### DIFF
--- a/docs/dev-guides/frontend-ui.md
+++ b/docs/dev-guides/frontend-ui.md
@@ -70,12 +70,13 @@ Wired unconditionally from `frontend/templates/base.html` (`html.rf-tabler`).
 
 ### UX model (horizontal light shell)
 
-- Top bar: **Runflow** | **Runs ▾** | Overview · Segments · Density · Flow · Locations · Reports | **Build** | Day (multi-day) | Logout
+- Top bar: **Runflow** | **Runs ▾** | Overview · Segments · Density · Flow · Junctions · Locations · Reports | **Build** | Logout
 - **Runs ▾:** up to 10 recent runs (label primary, short id secondary) + **View all runs…** → `/dashboard`
-- Picking a run opens **`/overview?run_id=&day=`** (Analysis Inputs + Analysis Outputs)
-- Context strip: Active run · label · short id · day · **Package**
+- Picking a run opens **`/overview?run_id=`** (day is derived from the run — Issue #841; no day dropdown)
+- Context strip: Active run · label · short id · day (read-only) · **Open source package**
 - Runs catalog is history-only
 - Build hub uses Tabler **card-header-tabs** for Legs / Courses / Packages
+- Historical multi-day analysis trees are not browsed in product chrome; archive offline if needed
 
 ### Attribution & license
 

--- a/frontend/static/js/map/locations.js
+++ b/frontend/static/js/map/locations.js
@@ -367,19 +367,23 @@ function createLocationPopup(properties) {
  */
 function getRunDayParams() {
     const params = new URLSearchParams(window.location.search);
-    const dayParam = params.get('day');
     const runParam = params.get('run_id');
-    const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-    const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-    return { day, run_id, dayParam, runParam };
+    // Issue #841: prefer chrome/localStorage over possibly-stale URL day
+    const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || '').toLowerCase().trim();
+    const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || '').trim();
+    return { day, run_id, dayParam: params.get('day'), runParam };
 }
 
 async function waitForRunflowDay(maxWaitMs = 2000) {
     const start = Date.now();
     while (Date.now() - start < maxWaitMs) {
         const { day, run_id } = getRunDayParams();
-        if (day && run_id) {
+        if (run_id && day) {
             return { day, run_id };
+        }
+        if (run_id) {
+            // Day optional — API can resolve from run
+            return { day: day || null, run_id };
         }
         await new Promise(resolve => setTimeout(resolve, 50));
     }
@@ -388,9 +392,8 @@ async function waitForRunflowDay(maxWaitMs = 2000) {
 
 async function loadLocations() {
     try {
-        // Get run_id and day from URL or global state
         let { day, run_id, dayParam, runParam } = getRunDayParams();
-        if (!day || !run_id) {
+        if (!run_id) {
             const ready = await waitForRunflowDay();
             if (ready) {
                 day = ready.day;
@@ -398,8 +401,8 @@ async function loadLocations() {
             }
         }
         
-        if (!day || !run_id) {
-            console.error('❌ Refusing to fetch locations without day+run_id', {
+        if (!run_id) {
+            console.error('❌ Refusing to fetch locations without run_id', {
                 href: window.location.href,
                 dayParam, runParam,
                 runflowDay: window.runflowDay
@@ -407,7 +410,9 @@ async function loadLocations() {
             return null;
         }
         
-        const apiUrl = `/api/locations?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/locations?${qp.toString()}`;
         console.log('Loading locations via API...', { apiUrl, day, run_id });
         
         const response = await fetch(apiUrl, { cache: 'no-store' });
@@ -444,15 +449,15 @@ async function loadLocations() {
 async function loadSegmentsGeojson() {
     try {
         let { day, run_id, dayParam, runParam } = getRunDayParams();
-        if (!day || !run_id) {
+        if (!run_id) {
             const ready = await waitForRunflowDay();
             if (ready) {
                 day = ready.day;
                 run_id = ready.run_id;
             }
         }
-        if (!day || !run_id) {
-            console.error('❌ Refusing to fetch segments without day+run_id', {
+        if (!run_id) {
+            console.error('❌ Refusing to fetch segments without run_id', {
                 href: window.location.href,
                 dayParam, runParam,
                 runflowDay: window.runflowDay
@@ -460,7 +465,9 @@ async function loadSegmentsGeojson() {
             return null;
         }
         
-        const apiUrl = `/api/segments/geojson?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/segments/geojson?${qp.toString()}`;
         console.log('Loading segments overlay via API...', { apiUrl, day, run_id });
         
         const response = await fetch(apiUrl, { cache: 'no-store' });

--- a/frontend/static/js/map/segments.js
+++ b/frontend/static/js/map/segments.js
@@ -53,12 +53,10 @@ function cleanFeature(feature) {
 
 function currentDayAndRun() {
     const urlParams = new URLSearchParams(window.location.search);
-    const dayParam = urlParams.get('day');
     const runParam = urlParams.get('run_id');
-    const dayFromSelect = document.getElementById('day-selector')?.value;
 
-    // Prefer URL → selector → global → storage fallbacks
-    const day = (dayParam || dayFromSelect || (window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || '')
+    // Issue #841: prefer run-derived day from chrome; do not trust stale ?day=
+    const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || urlParams.get('day') || '')
         .toLowerCase()
         .trim();
     const run_id = runParam || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || '';
@@ -74,28 +72,19 @@ function currentDayAndRun() {
  */
 async function loadSegments() {
     try {
-        // Resolve directly from URL to avoid any timing issues
-        const urlParams = new URLSearchParams(window.location.search);
-        const dayParam = urlParams.get("day");
-        const runParam = urlParams.get("run_id");
+        let { day, run_id } = currentDayAndRun();
 
-        let day = (dayParam || '').toLowerCase().trim();
-        let run_id = (runParam || '').trim();
-
-        // Hard guard: refuse to fetch without both values to avoid silent fallbacks
-        if (!run_id || !day) {
-            console.error("❌ Refusing to fetch segments without day+run_id", {
+        // Hard guard: need run_id; day may be omitted (API resolves from run — Issue #841)
+        if (!run_id) {
+            console.error("❌ Refusing to fetch segments without run_id", {
                 href: window.location.href,
-                dayParam,
-                runParam,
-                dayFromSelect: document.getElementById("day-selector")?.value,
                 runflowDay: window.runflowDay
             });
             return null;
         }
 
         const params = new URLSearchParams();
-        if (run_id) params.set('run_id', run_id);
+        params.set('run_id', run_id);
         if (day) params.set('day', day);
         params.set('_', Date.now().toString()); // cache buster during dev
         const apiUrl = `/api/segments/geojson?${params.toString()}`;
@@ -719,14 +708,6 @@ document.addEventListener('DOMContentLoaded', async function() {
         window.map.on('moveend', debouncedFilterTableByMapBounds);
         window.map.on('zoomend', debouncedFilterTableByMapBounds);
         
-        // If day selector exists, trigger refresh on change to re-fetch correct day/run_id
-        const daySelector = document.getElementById('day-selector');
-        if (daySelector) {
-            daySelector.addEventListener('change', async () => {
-                await refreshSegmentsOnDayChange();
-            });
-        }
-        
         console.log('✅ Segments map initialized successfully with bounds filtering');
         
     } catch (error) {
@@ -740,6 +721,13 @@ document.addEventListener('DOMContentLoaded', async function() {
 
 // Handle bfcache / soft navigation cases: refresh data when page is shown
 window.addEventListener('pageshow', async () => {
+    if (window.map) {
+        await refreshSegmentsOnDayChange();
+    }
+});
+
+// Refresh after chrome resolves run-derived day (Issue #841)
+window.addEventListener('runflow:context-ready', async () => {
     if (window.map) {
         await refreshSegmentsOnDayChange();
     }

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -28,12 +28,7 @@
                     </a>
                 </h1>
                 <div class="navbar-nav flex-row order-md-last align-items-center gap-1">
-                    <div id="day-selector-wrap" class="nav-item rf-tabler-day" style="display:none;" aria-hidden="true">
-                        <label for="day-selector" class="form-label mb-0 me-1 visually-hidden">Day</label>
-                        <select id="day-selector" class="form-select form-select-sm" style="min-width:88px;">
-                            <option value="">—</option>
-                        </select>
-                    </div>
+                    {# Issue #841: day dropdown removed — day is read-only from the run #}
                     <a class="nav-link px-2 text-danger" href="/logout">Logout</a>
                 </div>
                 <div class="collapse navbar-collapse" id="rf-tabler-menu">
@@ -208,15 +203,8 @@
             return isResultsRoutePath(pathname);
         }
 
-        function setDaySelectorVisible(visible) {
-            const wrap = document.getElementById("day-selector-wrap");
-            if (!wrap) return;
-            wrap.style.display = visible ? "flex" : "none";
-            wrap.setAttribute("aria-hidden", visible ? "false" : "true");
-        }
-
         function announceRunflowContextReady(runId, day) {
-            // Issue #791: Results pages (run_context) wait for day/run init before empty CTA
+            // Issue #791 / #841: Results pages wait for run (and derived day) before empty CTA
             window.dispatchEvent(new CustomEvent("runflow:context-ready", {
                 detail: { run_id: runId || null, day: day || null },
             }));
@@ -265,9 +253,8 @@
                 idEl.title = id;
             }
             if (dayEl) {
-                const multi = window.runflowDay && Array.isArray(window.runflowDay.available)
-                    && window.runflowDay.available.length > 1;
-                if (multi && day) {
+                // Issue #841: always show day as read-only run metadata when known
+                if (day) {
                     dayEl.textContent = "· " + String(day).toUpperCase();
                     dayEl.hidden = false;
                 } else {
@@ -389,14 +376,10 @@
                 .then(function (r) { return r.ok ? r.json() : null; })
                 .then(function (data) {
                     const days = (data && data.days) || [];
-                    let day = (localStorage.getItem("selected_day") || "").trim().toLowerCase();
-                    if (day && days.length && days.indexOf(day) < 0) day = days[0];
-                    else if (!day && days.length) day = days[0];
+                    // Issue #841: day from run only — do not carry ?day= in Results nav
+                    const day = days.length ? String(days[0]).toLowerCase() : null;
                     if (day) localStorage.setItem("selected_day", day);
-                    const params = new URLSearchParams();
-                    params.set("run_id", runId);
-                    if (day) params.set("day", day);
-                    window.location.href = "/overview?" + params.toString();
+                    window.location.href = "/overview?run_id=" + encodeURIComponent(runId);
                 })
                 .catch(function () {
                     window.location.href = "/overview?run_id=" + encodeURIComponent(runId);
@@ -424,12 +407,12 @@
                     newHref = setQueryParam(newHref, "run_id", null);
                     newHref = setQueryParam(newHref, "day", null);
                 } else if (isAnalysisRoutePath(linkPath)) {
-                    if (day) newHref = setQueryParam(newHref, "day", day);
+                    // Issue #841: Results nav is run_id-primary; day comes from the run
                     if (runId) newHref = setQueryParam(newHref, "run_id", runId);
+                    newHref = setQueryParam(newHref, "day", null);
                     // Catalog page should not require a run in the URL
                     if (linkPath === "/dashboard") {
                         newHref = setQueryParam(newHref, "run_id", null);
-                        newHref = setQueryParam(newHref, "day", null);
                     }
                     newHref = setQueryParam(newHref, "config_id", null);
                 }
@@ -463,8 +446,6 @@
         }
 
         function initConfigPageNav() {
-            setDaySelectorVisible(false);
-
             const params = new URLSearchParams(window.location.search);
             let changed = false;
             if (params.has("day")) {
@@ -496,10 +477,11 @@
             updateNavLinks(storedDay, storedRun);
         }
 
-        async function initDaySelector() {
-            const select = document.getElementById("day-selector");
-            if (!select) return;
-
+        /**
+         * Issue #841: one analysis run = one event day in product chrome.
+         * Derive day from the run; never show a day dropdown; strip ?day= from Results URLs.
+         */
+        async function initRunflowContext() {
             if (isConfigRoutePath(window.location.pathname)) {
                 initConfigPageNav();
                 announceRunflowContextReady(
@@ -509,9 +491,7 @@
                 return;
             }
 
-            // Day chrome belongs on Results routes only (Issue #791 Phase 0)
             if (!isResultsRoutePath(window.location.pathname)) {
-                setDaySelectorVisible(false);
                 const day = (localStorage.getItem("selected_day") || "").toLowerCase().trim() || null;
                 const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
                 updateNavLinks(day, storedRun);
@@ -519,18 +499,13 @@
                 return;
             }
 
-            setDaySelectorVisible(false); // show only after we know multi-day
-
             const params = new URLSearchParams(window.location.search);
             const urlDayRaw = params.get("day");
             const urlRunRaw = params.get("run_id");
-            const hasUrlDay = !!urlDayRaw;
             const hasUrlRun = !!urlRunRaw;
 
-            // Start with URL as canonical, then fall back to storage
-            let selectedDay = (urlDayRaw || localStorage.getItem("selected_day") || "").toLowerCase().trim() || null;
+            let selectedDay = null;
             let runId = (urlRunRaw || localStorage.getItem("selected_run_id") || "").trim() || null;
-
             let availableDays = [];
 
             if (CLOUD_MODE) {
@@ -544,24 +519,16 @@
 
             if (!CLOUD_MODE) {
                 try {
-                    // Issue #565: If run_id is in URL, pass it to API to get correct available_days for that run
-                    // Otherwise, get latest run_id from API
+                    // Do not pass URL day — stale ?day= must not poison resolution (Issue #841)
                     let url = "/api/dashboard/summary";
-                    const qp = [];
-                    
                     if (hasUrlRun) {
-                        // URL has run_id - pass it to API to get available_days for that specific run
-                        qp.push(`run_id=${encodeURIComponent(urlRunRaw)}`);
+                        url += "?run_id=" + encodeURIComponent(urlRunRaw);
                         runId = urlRunRaw;
                     }
-                    // Only pass day if we have it
-                    if (selectedDay) qp.push(`day=${encodeURIComponent(selectedDay)}`);
-                    if (qp.length) url += `?${qp.join("&")}`;
 
                     const resp = await fetch(url, { cache: "no-store" });
                     const data = await resp.json();
 
-                    // If no run_id in URL, use latest from API
                     if (!hasUrlRun) {
                         const latestRunId = data?.run_id;
                         if (latestRunId) {
@@ -569,103 +536,62 @@
                         }
                     }
 
-                    // Fill missing day if not in URL
-                    if (!hasUrlDay && !selectedDay && data?.selected_day) selectedDay = data.selected_day.toLowerCase();
-
                     availableDays = Array.isArray(data?.available_days)
-                        ? data.available_days.map(d => d.toLowerCase())
+                        ? data.available_days.map(d => String(d).toLowerCase())
                         : [];
+                    if (data?.selected_day) {
+                        selectedDay = String(data.selected_day).toLowerCase();
+                    }
                 } catch (e) {
-                    console.warn("Day selector: failed to load dashboard summary for day metadata", e);
+                    console.warn("Runflow context: failed to load dashboard summary for day metadata", e);
                 }
             }
 
-            // Issue #565: If run_id is set, only use available_days from API (don't add invalid days)
-            // If no run_id, keep empty — do not invent fri/sat/sun/mon
-            if (!availableDays.length) {
-                if (runId && selectedDay) {
-                    availableDays = [selectedDay];
-                } else if (!runId && selectedDay) {
-                    availableDays = [selectedDay];
+            // Prefer run-derived day. Accept URL day only when it is still valid for this run.
+            const urlDay = (urlDayRaw || "").toLowerCase().trim() || null;
+            if (availableDays.length) {
+                if (urlDay && availableDays.includes(urlDay)) {
+                    selectedDay = urlDay;
                 } else {
-                    availableDays = [];
+                    selectedDay = availableDays[0];
                 }
-            } else if (selectedDay && !availableDays.includes(selectedDay)) {
-                // URL has a day that's not available for this run_id - remove it and use first available
-                selectedDay = availableDays[0] || null;
-                // Update URL to remove invalid day or set to first available
-                const params = new URLSearchParams(window.location.search);
-                if (selectedDay) {
-                    params.set("day", selectedDay);
-                } else {
-                    params.delete("day");
+            } else if (urlDay) {
+                // No available_days from API — keep storage/URL only as last resort
+                selectedDay = urlDay;
+            } else {
+                selectedDay = (localStorage.getItem("selected_day") || "").toLowerCase().trim() || null;
+            }
+
+            // Canonical Results URL is run_id-only (strip day / keep run_id)
+            {
+                const p = new URLSearchParams(window.location.search);
+                let changed = false;
+                if (p.has("day")) {
+                    p.delete("day");
+                    changed = true;
                 }
-                if (runId) params.set("run_id", runId);
-                const newUrl = window.location.pathname + (params.toString() ? "?" + params.toString() : "");
-                if (newUrl !== window.location.pathname + window.location.search) {
+                if (runId && p.get("run_id") !== runId) {
+                    p.set("run_id", runId);
+                    changed = true;
+                }
+                if (CLOUD_MODE && runId) {
+                    p.set("run_id", runId);
+                    changed = true;
+                }
+                const newUrl = window.location.pathname + (p.toString() ? "?" + p.toString() : "");
+                if (changed && newUrl !== window.location.pathname + window.location.search) {
                     window.history.replaceState({}, "", newUrl);
                 }
             }
 
-            select.innerHTML = "";
-            availableDays.forEach(day => {
-                const opt = document.createElement("option");
-                opt.value = day; // keep lowercase
-                opt.textContent = day.toUpperCase();
-                select.appendChild(opt);
-            });
-
-            // Issue #565: Only set selected day if it's in availableDays for this run_id
-            if (selectedDay && availableDays.includes(selectedDay)) {
-                select.value = selectedDay;
-            } else if (availableDays.length > 0) {
-                // If selectedDay is not available, use first available day
-                selectedDay = availableDays[0];
-                select.value = selectedDay;
-                // Update URL if day changed
-                const params = new URLSearchParams(window.location.search);
-                params.set("day", selectedDay);
-                if (runId) params.set("run_id", runId);
-                const newUrl = window.location.pathname + (params.toString() ? "?" + params.toString() : "");
-                if (newUrl !== window.location.pathname + window.location.search) {
-                    window.history.replaceState({}, "", newUrl);
-                }
-            }
-
-            // Show Day control only when the selected run has more than one day
-            setDaySelectorVisible(availableDays.length > 1);
-
-            if (CLOUD_MODE) {
-                // Force canonical run_id and day in URL for cloud mode
-                const params = new URLSearchParams(window.location.search);
-                if (runId) params.set("run_id", runId);
-                if (selectedDay) params.set("day", selectedDay);
-                const newUrl = window.location.pathname + (params.toString() ? "?" + params.toString() : "");
-                if (newUrl !== window.location.pathname + window.location.search) {
-                    window.history.replaceState({}, "", newUrl);
-                }
-            }
-
-            // Persist canonical state and update nav links
             if (selectedDay) localStorage.setItem("selected_day", selectedDay);
             if (runId) localStorage.setItem("selected_run_id", runId);
             updateNavLinks(selectedDay, runId);
             window.runflowDay = { selected: selectedDay, available: availableDays, run_id: runId };
             announceRunflowContextReady(runId, selectedDay);
-
-            select.addEventListener("change", (e) => {
-                if (isConfigRoutePath(window.location.pathname) || !isResultsRoutePath(window.location.pathname)) {
-                    return;
-                }
-                const day = (e.target.value || "").toLowerCase().trim();
-                if (!runId) return; // do not navigate without run_id
-                localStorage.setItem("selected_day", day);
-                const newUrl = setQueryParam(setQueryParam(window.location.href, "day", day), "run_id", runId);
-                window.location.href = newUrl;
-            });
         }
 
-        document.addEventListener("DOMContentLoaded", initDaySelector);
+        document.addEventListener("DOMContentLoaded", initRunflowContext);
     })();
     </script>
 </body>

--- a/frontend/templates/pages/dashboard.html
+++ b/frontend/templates/pages/dashboard.html
@@ -859,43 +859,18 @@
     }
     
     function updateDaySelector(availableDays) {
-        // Update day selector in navbar
-        const daySelector = document.getElementById('day-selector');
-        if (daySelector && availableDays && availableDays.length > 0) {
-            // Clear existing options
-            daySelector.innerHTML = '';
-            
-            // Add options for available days
-            const DAY_ORDER = ["fri", "sat", "sun", "mon"];
-            const orderedDays = availableDays.sort((a, b) => {
-                const aIdx = DAY_ORDER.indexOf(a);
-                const bIdx = DAY_ORDER.indexOf(b);
-                if (aIdx === -1 && bIdx === -1) return 0;
-                if (aIdx === -1) return 1;
-                if (bIdx === -1) return -1;
-                return aIdx - bIdx;
-            });
-            
-            orderedDays.forEach(day => {
-                const option = document.createElement('option');
-                option.value = day;
-                option.textContent = day.toUpperCase();
-                daySelector.appendChild(option);
-            });
-            
-            // Update window.runflowDay
+        // Issue #841: no day dropdown — keep runflowDay.available in sync only
+        if (availableDays && availableDays.length > 0) {
             if (window.runflowDay) {
                 window.runflowDay.available = availableDays;
             } else {
                 window.runflowDay = { available: availableDays };
             }
-            
-            // Select first day if none selected
             const currentDay = currentDaySelection();
             if (currentDay && availableDays.includes(currentDay)) {
-                daySelector.value = currentDay;
-            } else if (availableDays.length > 0) {
-                daySelector.value = availableDays[0];
+                if (window.runflowDay) window.runflowDay.selected = currentDay;
+            } else {
+                if (window.runflowDay) window.runflowDay.selected = availableDays[0];
                 localStorage.setItem('selected_day', availableDays[0]);
             }
         }
@@ -905,9 +880,6 @@
         if (window.runflowDay && window.runflowDay.selected) {
             return window.runflowDay.selected;
         }
-        const params = new URLSearchParams(window.location.search);
-        const d = params.get("day");
-        if (d) return d.toLowerCase();
         const stored = localStorage.getItem("selected_day");
         return stored ? stored.toLowerCase() : null;
     }

--- a/frontend/templates/pages/density.html
+++ b/frontend/templates/pages/density.html
@@ -289,11 +289,20 @@
     
     // Issue #652: Removed pagination - using scrollable tables instead
     
-    // Load density data on page load
+    // Load density data on page load (and after chrome derives day — Issue #841)
     document.addEventListener('DOMContentLoaded', function() {
         loadDensityData();
         setupBinDetailsEventListeners();
+        window.addEventListener('runflow:context-ready', loadDensityData);
     });
+
+    function resolveRunAndDay() {
+        // Issue #841: prefer run-derived day from chrome over stale ?day=
+        const params = new URLSearchParams(window.location.search);
+        const run_id = (params.get('run_id') || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || '').trim();
+        const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || '').toLowerCase().trim();
+        return { day, run_id };
+    }
     
     // Issue #286: Format worst bin label (segment · distance · time)
     function formatWorstBinLabel(bin) {
@@ -374,25 +383,20 @@
     }
     
     function loadDensityData() {
-        // Get run_id and day from URL or global state
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
+        const { day, run_id } = resolveRunAndDay();
         
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-        
-        if (!day || !run_id) {
-            console.error('❌ Refusing to fetch density data without day+run_id', {
+        if (!run_id) {
+            console.error('❌ Refusing to fetch density data without run_id', {
                 href: window.location.href,
-                dayParam, runParam,
                 runflowDay: window.runflowDay
             });
             showDensityError();
             return;
         }
         
-        const apiUrl = `/api/density/segments?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/density/segments?${qp.toString()}`;
         console.log('Loading density data via API...', { apiUrl, day, run_id });
         
         fetch(apiUrl, { cache: 'no-store' })
@@ -470,21 +474,16 @@
     }
     
     function showSegmentDetail(seg_id) {
-        // Get run_id and day from URL or global state
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
+        const { day, run_id } = resolveRunAndDay();
         
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-        
-        if (!day || !run_id) {
-            console.error('❌ Cannot load segment detail: missing day or run_id');
+        if (!run_id) {
+            console.error('❌ Cannot load segment detail: missing run_id');
             return;
         }
         
-        // Fetch detailed data with day/run_id params
-        const apiUrl = `/api/density/segment/${seg_id}?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/density/segment/${seg_id}?${qp.toString()}`;
         fetch(apiUrl, { cache: 'no-store' })
             .then(response => {
                 if (!response.ok) {
@@ -603,25 +602,21 @@
         if (loadingDiv) loadingDiv.style.display = 'block';
         if (contentDiv) contentDiv.style.display = 'none';
         
-        // Get run_id and day from URL or global state
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
+        const { day, run_id } = resolveRunAndDay();
         
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-        
-        if (!day || !run_id) {
-            console.error('❌ Cannot load bin details: missing day or run_id');
+        if (!run_id) {
+            console.error('❌ Cannot load bin details: missing run_id');
             if (loadingDiv) {
                 loadingDiv.style.display = 'block';
-                loadingDiv.innerHTML = `<div>Error: Missing day or run_id</div>`;
+                loadingDiv.innerHTML = `<div>Error: Missing run_id</div>`;
             }
             return;
         }
         
         try {
-            const apiUrl = `/api/bins?segment_id=${segId}&limit=50000&run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+            const qp = new URLSearchParams({ segment_id: segId, limit: '50000', run_id });
+            if (day) qp.set('day', day);
+            const apiUrl = `/api/bins?${qp.toString()}`;
             const response = await fetch(apiUrl, { cache: 'no-store' });
             if (!response.ok) {
                 throw new Error(`HTTP ${response.status}: ${response.statusText}`);

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -132,33 +132,39 @@
     let overlapSummary = null;
     let overlapChart = null;
     
-    // Load flow data on page load
+    // Load flow data on page load (and after chrome derives day — Issue #841)
     document.addEventListener('DOMContentLoaded', function() {
         initializeSorting();
         loadFlowData();
         loadOverlapData();
+        window.addEventListener('runflow:context-ready', function () {
+            loadFlowData();
+            loadOverlapData();
+        });
     });
+
+    function resolveRunAndDay() {
+        const params = new URLSearchParams(window.location.search);
+        const run_id = (params.get('run_id') || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || '').trim();
+        const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || '').toLowerCase().trim();
+        return { day, run_id };
+    }
     
     function loadFlowData() {
-        // Get run_id and day from URL or global state
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
+        const { day, run_id } = resolveRunAndDay();
         
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-        
-        if (!day || !run_id) {
-            console.error('❌ Refusing to fetch flow data without day+run_id', {
+        if (!run_id) {
+            console.error('❌ Refusing to fetch flow data without run_id', {
                 href: window.location.href,
-                dayParam, runParam,
                 runflowDay: window.runflowDay
             });
             showFlowError();
             return;
         }
         
-        const apiUrl = `/api/flow/segments?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/flow/segments?${qp.toString()}`;
         console.log('Loading flow data via API...', { apiUrl, day, run_id });
         
         fetch(apiUrl, { cache: 'no-store' })
@@ -441,19 +447,17 @@
     }
 
     function loadOverlapData() {
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
+        const { day, run_id } = resolveRunAndDay();
 
-        if (!day || !run_id) {
-            console.error('❌ Refusing to fetch overlap data without day+run_id', { day, run_id });
+        if (!run_id) {
+            console.error('❌ Refusing to fetch overlap data without run_id', { day, run_id });
             showOverlapError();
             return;
         }
 
-        const apiUrl = `/api/bidirectional/segments?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/bidirectional/segments?${qp.toString()}`;
         fetch(apiUrl, { cache: 'no-store' })
             .then(response => {
                 if (!response.ok) {
@@ -515,20 +519,20 @@
     }
 
     function loadOverlapDetail(segment) {
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-        if (!day || !run_id) {
+        const { day, run_id } = resolveRunAndDay();
+        if (!run_id) {
             showOverlapError();
             return;
         }
 
-        let apiUrl = `/api/bidirectional/segment/${encodeURIComponent(segment.seg_id)}?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}&event_a=${encodeURIComponent(segment.event_a)}&event_b=${encodeURIComponent(segment.event_b)}`;
-        if (segment.flow_id) {
-            apiUrl += `&flow_id=${encodeURIComponent(segment.flow_id)}`;
-        }
+        const qp = new URLSearchParams({
+            run_id,
+            event_a: segment.event_a,
+            event_b: segment.event_b,
+        });
+        if (day) qp.set('day', day);
+        if (segment.flow_id) qp.set('flow_id', segment.flow_id);
+        let apiUrl = `/api/bidirectional/segment/${encodeURIComponent(segment.seg_id)}?${qp.toString()}`;
         fetch(apiUrl, { cache: 'no-store' })
             .then(response => {
                 if (!response.ok) {

--- a/frontend/templates/pages/junctions.html
+++ b/frontend/templates/pages/junctions.html
@@ -90,16 +90,17 @@
     function resolveRunId() {
         const params = new URLSearchParams(window.location.search);
         return params.get("run_id")
-            || (window.runflowDay && window.runflowDay.runId)
-            || localStorage.getItem("runflow_run_id")
+            || (window.runflowDay && window.runflowDay.run_id)
+            || localStorage.getItem("selected_run_id")
             || null;
     }
 
     function resolveDay() {
-        const params = new URLSearchParams(window.location.search);
-        return params.get("day")
-            || (window.runflowDay && window.runflowDay.day)
-            || null;
+        // Issue #841: prefer run-derived day; ignore stale ?day= until chrome resolves
+        if (window.runflowDay && window.runflowDay.selected) {
+            return String(window.runflowDay.selected).toLowerCase();
+        }
+        return (localStorage.getItem("selected_day") || "").toLowerCase().trim() || null;
     }
 
     function formatEventList(events) {
@@ -428,7 +429,7 @@
     }
 
     document.addEventListener("DOMContentLoaded", load);
-    window.addEventListener("runflow-context-ready", load);
+    window.addEventListener("runflow:context-ready", load);
 })();
 </script>
 {% endblock %}

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -274,28 +274,35 @@
                 loadLocationsData();
             }
         }, 200);
+        window.addEventListener('runflow:context-ready', function () {
+            if (!tableDataLoaded) {
+                loadLocationsData();
+            }
+        });
     });
+
+    function resolveRunAndDay() {
+        const params = new URLSearchParams(window.location.search);
+        const run_id = (params.get('run_id') || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || '').trim();
+        const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || '').toLowerCase().trim();
+        return { day, run_id };
+    }
     
     function loadLocationsData() {
-        // Get run_id and day from URL or global state
-        const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
-        const runParam = params.get('run_id');
+        const { day, run_id } = resolveRunAndDay();
         
-        const day = (dayParam || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (runParam || (window.runflowDay && window.runflowDay.run_id) || '').trim();
-        
-        if (!day || !run_id) {
-            console.error('❌ Refusing to fetch locations data without day+run_id', {
+        if (!run_id) {
+            console.error('❌ Refusing to fetch locations data without run_id', {
                 href: window.location.href,
-                dayParam, runParam,
                 runflowDay: window.runflowDay
             });
-            showLocationsError('Failed to load locations data: missing day or run_id');
+            showLocationsError('Failed to load locations data: missing run_id');
             return;
         }
         
-        const apiUrl = `/api/locations?run_id=${encodeURIComponent(run_id)}&day=${encodeURIComponent(day)}`;
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        const apiUrl = `/api/locations?${qp.toString()}`;
         console.log('Loading locations data via API...', { apiUrl, day, run_id });
         
         fetch(apiUrl, { cache: 'no-store' })
@@ -1127,9 +1134,8 @@
     }
 
     function getRunDayForLocSheets() {
-        const params = new URLSearchParams(window.location.search);
-        const day = (params.get('day') || (window.runflowDay && window.runflowDay.selected) || '').toLowerCase().trim();
-        const run_id = (params.get('run_id') || (window.runflowDay && window.runflowDay.run_id) || '').trim();
+        const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || '').toLowerCase().trim();
+        const run_id = ((new URLSearchParams(window.location.search).get('run_id')) || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || '').trim();
         return { day, run_id };
     }
 

--- a/frontend/templates/pages/overview.html
+++ b/frontend/templates/pages/overview.html
@@ -129,11 +129,12 @@
     }
 
     function resolveDay() {
-        var params = new URLSearchParams(window.location.search);
-        var fromUrl = (params.get('day') || '').trim().toLowerCase();
-        if (fromUrl) return fromUrl;
+        // Issue #841: prefer run-derived day from chrome over possibly-stale ?day=
         if (window.runflowDay && window.runflowDay.selected) return String(window.runflowDay.selected).toLowerCase();
-        return (localStorage.getItem('selected_day') || '').trim().toLowerCase();
+        var stored = (localStorage.getItem('selected_day') || '').trim().toLowerCase();
+        if (stored) return stored;
+        var params = new URLSearchParams(window.location.search);
+        return (params.get('day') || '').trim().toLowerCase();
     }
 
     function wireEmptyLink() {

--- a/frontend/templates/pages/segments.html
+++ b/frontend/templates/pages/segments.html
@@ -160,10 +160,12 @@
     
     function currentDayAndRun() {
         const params = new URLSearchParams(window.location.search);
-        const dayParam = params.get('day');
         const runParam = params.get('run_id');
-        const day = dayParam ? dayParam.toLowerCase() : (window.runflowDay && window.runflowDay.selected);
-        const run_id = runParam || (window.runflowDay && window.runflowDay.run_id);
+        // Issue #841: prefer chrome/localStorage over URL day
+        const day = ((window.runflowDay && window.runflowDay.selected) || localStorage.getItem('selected_day') || params.get('day') || '')
+            .toLowerCase()
+            .trim() || null;
+        const run_id = runParam || (window.runflowDay && window.runflowDay.run_id) || localStorage.getItem('selected_run_id') || null;
         return { day, run_id };
     }
     
@@ -175,33 +177,31 @@
         return u.pathname + u.search;
     }
     
-    // Issue #565: Ensure run_id is present; respect URL run_id if explicitly set
+    // Issue #565 / #841: Ensure run_id is present; day is derived by chrome (not forced into URL)
     async function ensureRunAndDayInUrl() {
         const params = new URLSearchParams(window.location.search);
         let runId = params.get('run_id');
         const hasUrlRunId = !!runId;
-        let dayParam = params.get('day');
 
         try {
-            // Fetch latest run_id for fallback only
             const resp = await fetch('/api/dashboard/summary', { cache: 'no-store' });
             const data = await resp.json();
             const latestRunId = data.run_id;
             
-            // Issue #565: Only use latest run_id if no run_id in URL
-            // Respect URL run_id when explicitly set (don't override with latest)
             if (!hasUrlRunId && latestRunId) {
                 runId = latestRunId;
             }
-            // If URL has run_id, keep it (don't override)
+
+            if (data.selected_day) {
+                localStorage.setItem('selected_day', String(data.selected_day).toLowerCase());
+            }
             
-            const selectedDay = (dayParam || data.selected_day || '').toLowerCase();
             const p = new URLSearchParams(window.location.search);
             if (runId) p.set('run_id', runId);
-            if (selectedDay) p.set('day', selectedDay);
+            p.delete('day');
             const newUrl = window.location.pathname + (p.toString() ? '?' + p.toString() : '');
             if (newUrl !== window.location.pathname + window.location.search) {
-                window.location.replace(newUrl);
+                window.history.replaceState({}, '', newUrl);
             }
         } catch (e) {
             console.warn('Failed to resolve run_id for segments page', e);
@@ -221,21 +221,6 @@
                     focusOnSegment(focusSegmentId);
                 }
             }, 100);
-            
-            // Force reload of map data with day/run_id when day selector changes
-            const daySelector = document.getElementById('day-selector');
-            if (daySelector) {
-                daySelector.addEventListener('change', () => {
-                    const day = daySelector.value || '';
-                    const params = new URLSearchParams(window.location.search);
-                    if (day) params.set('day', day);
-                    else params.delete('day');
-                    const { run_id } = currentDayAndRun();
-                    if (run_id) params.set('run_id', run_id);
-                    const newUrl = window.location.pathname + (params.toString() ? '?' + params.toString() : '');
-                    window.location.href = newUrl;
-                });
-            }
         });
     });
     

--- a/frontend/templates/partials/run_context.html
+++ b/frontend/templates/partials/run_context.html
@@ -57,11 +57,12 @@
     }
 
     function resolveDay() {
-        var params = new URLSearchParams(window.location.search);
-        var fromUrl = (params.get('day') || '').trim().toLowerCase();
-        if (fromUrl) return fromUrl;
+        // Issue #841: prefer run-derived day from chrome over possibly-stale ?day=
         if (window.runflowDay && window.runflowDay.selected) return String(window.runflowDay.selected).toLowerCase();
-        return (localStorage.getItem('selected_day') || '').trim().toLowerCase();
+        var stored = (localStorage.getItem('selected_day') || '').trim().toLowerCase();
+        if (stored) return stored;
+        var params = new URLSearchParams(window.location.search);
+        return (params.get('day') || '').trim().toLowerCase();
     }
 
     function isTablerUi() {
@@ -82,7 +83,7 @@
         var url = path;
         var qs = [];
         if (runId) qs.push('run_id=' + encodeURIComponent(runId));
-        if (day) qs.push('day=' + encodeURIComponent(day));
+        // Issue #841: subnav is run_id-primary; day stays in chrome/localStorage
         if (isTablerUi()) qs.push('ui=tabler');
         if (qs.length) url += '?' + qs.join('&');
         return url;
@@ -120,18 +121,15 @@
         if (ctx) ctx.style.display = 'none';
         if (!missing) return;
         var link = document.getElementById('run-context-choose-link');
-        var day = resolveDay();
         if (link) {
-            link.href = withTablerUi(day ? ('/dashboard?day=' + encodeURIComponent(day)) : '/dashboard');
+            link.href = withTablerUi('/dashboard');
         }
-        updateResultsSubnav(null, day);
+        updateResultsSubnav(null, resolveDay());
         missing.style.display = 'block';
     }
 
     function fillBanner(runId, run) {
         var day = resolveDay();
-        var multiDay = window.runflowDay && Array.isArray(window.runflowDay.available) &&
-            window.runflowDay.available.length > 1;
 
         document.getElementById('run-context-id').textContent = runId;
         document.getElementById('run-context-desc').textContent = (run && run.description) || '—';
@@ -141,7 +139,8 @@
         var dayWrap = document.getElementById('run-context-day-wrap');
         var dayEl = document.getElementById('run-context-day');
         if (dayWrap && dayEl) {
-            if (multiDay && day) {
+            // Issue #841: always show day as read-only when known
+            if (day) {
                 dayEl.textContent = day.toUpperCase();
                 dayWrap.style.display = '';
             } else {
@@ -153,9 +152,7 @@
         if (reports) reports.href = resultsHref('/reports', runId, day);
         var change = document.getElementById('run-context-change-run');
         if (change) {
-            change.href = withTablerUi(day
-                ? ('/dashboard?day=' + encodeURIComponent(day) + '&run_id=' + encodeURIComponent(runId))
-                : ('/dashboard?run_id=' + encodeURIComponent(runId)));
+            change.href = withTablerUi('/dashboard?run_id=' + encodeURIComponent(runId));
         }
 
         updateResultsSubnav(runId, day);

--- a/tests/unit/test_issue798_phase7_tabler_only.py
+++ b/tests/unit/test_issue798_phase7_tabler_only.py
@@ -59,7 +59,23 @@ def test_base_html_jinja_render_smoke():
     assert "@tabler/core@1.4.0/dist/js/tabler.min.js" in html
     assert "Classic UI" not in html
     assert "rf-tabler-exit" not in html
-    assert 'id="day-selector"' in html
+    assert 'id="day-selector"' not in html  # Issue #841: day from run, no dropdown
+    assert "initRunflowContext" in html
     assert 'id="rf-runs-dropdown"' in html
     assert 'id="rf-tabler-context-strip"' in html
+    assert 'id="rf-tabler-context-day"' in html
     assert 'id="rf-phase7-smoke"' in html
+
+
+def test_base_html_no_day_selector_markup(base_source: str):
+    """Issue #841: multi-day day dropdown removed from product chrome."""
+    assert 'id="day-selector"' not in base_source
+    assert 'id="day-selector-wrap"' not in base_source
+    assert "setDaySelectorVisible" not in base_source
+    assert "initDaySelector" not in base_source
+    assert "initRunflowContext" in base_source
+    assert 'id="rf-tabler-context-day"' in base_source
+    # Results nav is run_id-primary (day stripped from analysis links)
+    assert 'setQueryParam(newHref, "day", null)' in base_source
+    assert 'window.location.href = "/overview?run_id="' in base_source or \
+        'window.location.href = "/overview?run_id=" + encodeURIComponent(runId)' in base_source

--- a/tests/unit/test_issue841_one_day_chrome.py
+++ b/tests/unit/test_issue841_one_day_chrome.py
@@ -1,0 +1,76 @@
+"""Issue #841: one-day analysis product chrome — day from run, no day dropdown."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_HTML = REPO_ROOT / "frontend" / "templates" / "base.html"
+RUN_CONTEXT = REPO_ROOT / "frontend" / "templates" / "partials" / "run_context.html"
+TEMPLATES_DIR = REPO_ROOT / "frontend" / "templates"
+
+
+@pytest.fixture(scope="module")
+def base_source() -> str:
+    return BASE_HTML.read_text(encoding="utf-8")
+
+
+@pytest.fixture(scope="module")
+def run_context_source() -> str:
+    return RUN_CONTEXT.read_text(encoding="utf-8")
+
+
+def test_day_dropdown_removed(base_source: str):
+    assert 'id="day-selector"' not in base_source
+    assert "day-selector-wrap" not in base_source
+
+
+def test_runflow_context_strips_day_from_results_url(base_source: str):
+    assert "initRunflowContext" in base_source
+    assert "Do not pass URL day" in base_source or "stale ?day=" in base_source
+    assert 'p.delete("day")' in base_source
+    assert 'setQueryParam(newHref, "day", null)' in base_source
+
+
+def test_pick_run_navigates_without_day_query(base_source: str):
+    assert '"/overview?run_id=" + encodeURIComponent(runId)' in base_source
+
+
+def test_active_run_strip_always_shows_day_when_known(base_source: str):
+    assert "Issue #841: always show day as read-only run metadata when known" in base_source
+    assert 'dayEl.textContent = "· " + String(day).toUpperCase()' in base_source
+    # Old multi-day-only visibility gate removed
+    assert "window.runflowDay.available.length > 1" not in base_source
+
+def test_run_context_banner_shows_day_read_only(run_context_source: str):
+    assert "always show day as read-only when known" in run_context_source
+    assert "multiDay && day" not in run_context_source
+    # Subnav is run_id-primary
+    assert "day=' + encodeURIComponent(day)" not in run_context_source
+
+
+def test_base_html_renders_without_day_selector():
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+
+    class _Url:
+        path = "/overview"
+
+    class _Request:
+        url = _Url()
+        query_params = {}
+
+    template = env.from_string(
+        '{% extends "base.html" %}\n'
+        '{% block content %}<p id="rf-841-smoke">ok</p>{% endblock %}'
+    )
+    html = template.render(request=_Request(), cloud_mode=False)
+    assert 'id="day-selector"' not in html
+    assert 'id="rf-tabler-context-day"' in html
+    assert 'id="rf-841-smoke"' in html


### PR DESCRIPTION
## Summary
- Removes the top-nav day dropdown; day comes from the selected run (`available_days` / first day) and is shown read-only on the Active run strip and Results banner.
- Results nav and run picker use `?run_id=` only; stale `?day=` is stripped via `history.replaceState`.
- Density/Flow/Locations/Segments/Junctions load with run_id (day optional / chrome-derived); Junctions listens for the correct `runflow:context-ready` event.
- Inventory of remaining `?day=` / multi-day assumptions posted on #841 for #842.
- Unit tests for chrome; browser checklist from #841 executed locally against `localhost:8080`.

Closes #841

## Test plan
- [x] Unit: `tests/unit/test_issue841_one_day_chrome.py` + updated #798 chrome tests
- [x] Browser B1–B12 against FM2027 run `5sqk4pNRRJzLBphCnQbAwi` (single-day `sun`)
  - [x] No `#day-selector`; Active run shows `· SUN`
  - [x] Overview → Reports with `?run_id=` only (no `day` in nav hrefs)
  - [x] Stale `?day=sat` / `?day=mon` stripped; page still loads
  - [x] `/config` Build hub loads without day dropdown


Made with [Cursor](https://cursor.com)