### PR TITLE
Nav: Results/Build workspace selector (#842)

### DIFF
--- a/docs/dev-guides/frontend-ui.md
+++ b/docs/dev-guides/frontend-ui.md
@@ -75,7 +75,7 @@ Wired unconditionally from `frontend/templates/base.html` (`html.rf-tabler`).
 - Workspace control switches Results ↔ Build (mutually exclusive chrome; Issue #842)
 - **Runs ▾:** up to 10 recent runs (label primary, short id secondary) + **View all runs…** → `/dashboard` (Results only)
 - Picking a run opens **`/overview?run_id=`** (day is derived from the run — Issue #841; no day dropdown)
-- Context strip (Results only): Active run · label · short id · day (read-only) · **Open source package**
+- Context strip removed: run label/id/day live on the Results run dropdown; **Package** nav link (after Reports) opens the source config when known
 - Last Results route/run and last Build route are restored when switching workspaces
 - Runs catalog is history-only
 - Build hub page still has Legs / Courses / Packages panels; top nav mirrors hub views

--- a/docs/dev-guides/frontend-ui.md
+++ b/docs/dev-guides/frontend-ui.md
@@ -70,12 +70,15 @@ Wired unconditionally from `frontend/templates/base.html` (`html.rf-tabler`).
 
 ### UX model (horizontal light shell)
 
-- Top bar: **Runflow** | **Runs ▾** | Overview · Segments · Density · Flow · Junctions · Locations · Reports | **Build** | Logout
-- **Runs ▾:** up to 10 recent runs (label primary, short id secondary) + **View all runs…** → `/dashboard`
+- Top bar (Results): **Runflow** | **Results ▾** | **Runs ▾** | Overview · Segments · Density · Flow · Junctions · Locations · Reports | Logout
+- Top bar (Build): **Runflow** | **Build ▾** | Legs · Courses · Packages | Logout
+- Workspace control switches Results ↔ Build (mutually exclusive chrome; Issue #842)
+- **Runs ▾:** up to 10 recent runs (label primary, short id secondary) + **View all runs…** → `/dashboard` (Results only)
 - Picking a run opens **`/overview?run_id=`** (day is derived from the run — Issue #841; no day dropdown)
-- Context strip: Active run · label · short id · day (read-only) · **Open source package**
+- Context strip (Results only): Active run · label · short id · day (read-only) · **Open source package**
+- Last Results route/run and last Build route are restored when switching workspaces
 - Runs catalog is history-only
-- Build hub uses Tabler **card-header-tabs** for Legs / Courses / Packages
+- Build hub page still has Legs / Courses / Packages panels; top nav mirrors hub views
 - Historical multi-day analysis trees are not browsed in product chrome; archive offline if needed
 
 ### Attribution & license

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -33,20 +33,32 @@ html.rf-tabler .navbar .nav-link.active {
 /* Issue #842: workspace + run controls share one nav-row height */
 html.rf-tabler .navbar .navbar-nav {
     align-items: center;
+    gap: 0.15rem;
+}
+
+/* Tabler adds margin-bottom on .nav-item; with align-items:center that
+   offsets the workspace dropdown vs the run dropdown (Results only). */
+html.rf-tabler .navbar-expand-md .navbar-nav > .nav-item {
+    margin-bottom: 0 !important;
+    align-self: center;
 }
 
 html.rf-tabler .rf-workspace-toggle,
 html.rf-tabler .rf-runs-toggle {
     display: inline-flex;
     align-items: center;
+    box-sizing: border-box;
+    height: 2rem;
     min-height: 2rem;
+    max-height: 2rem;
     line-height: 1.25;
-    padding: 0.35rem 0.65rem;
+    padding: 0 0.65rem;
     margin: 0;
     border: 1px solid var(--tblr-border-color, #e6e7e9);
     border-radius: 0.35rem;
     background: #fff;
     font-weight: 600;
+    font-size: 0.875rem;
     color: #3b4a5a;
 }
 
@@ -72,9 +84,18 @@ html.rf-tabler .rf-workspace-toggle.active {
 html.rf-tabler .navbar-nav .nav-link {
     display: inline-flex;
     align-items: center;
+    height: 2rem;
     min-height: 2rem;
-    padding-top: 0.35rem;
-    padding-bottom: 0.35rem;
+    padding-top: 0;
+    padding-bottom: 0;
+    line-height: 1.25;
+}
+
+/* Bootstrap dropdown caret — keep both toggles optically centered */
+html.rf-tabler .rf-workspace-toggle.dropdown-toggle::after,
+html.rf-tabler .rf-runs-toggle.dropdown-toggle::after {
+    margin-left: 0.4em;
+    vertical-align: 0.15em;
 }
 
 html.rf-tabler .rf-build-chrome .nav-link.active,
@@ -109,56 +130,6 @@ html.rf-tabler .page-body {
 
 html.rf-tabler .rf-tabler-content {
     max-width: 1600px;
-}
-
-/* Context strip under top bar */
-html.rf-tabler .rf-tabler-context-strip {
-    background: #fff;
-    border-bottom: 1px solid var(--tblr-border-color, #e6e7e9);
-    padding: 0.55rem 0;
-}
-
-html.rf-tabler .rf-tabler-context-inner {
-    display: flex;
-    flex-wrap: wrap;
-    align-items: center;
-    gap: 0.5rem 0.75rem;
-    font-size: 0.875rem;
-}
-
-html.rf-tabler .rf-tabler-context-pill {
-    font-size: 0.65rem;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-    color: var(--tblr-primary, #206bc4);
-    background: rgba(32, 107, 196, 0.1);
-    padding: 0.2rem 0.45rem;
-    border-radius: 4px;
-}
-
-html.rf-tabler .rf-tabler-context-label {
-    font-weight: 650;
-    color: var(--tblr-body-color, #182433);
-}
-
-html.rf-tabler .rf-tabler-context-id,
-html.rf-tabler .rf-tabler-context-day {
-    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
-    font-size: 0.78rem;
-    color: var(--tblr-secondary, #667382);
-}
-
-html.rf-tabler .rf-tabler-context-pkg {
-    margin-left: auto;
-    font-weight: 600;
-    font-size: 0.8125rem;
-    color: var(--tblr-primary, #206bc4);
-    text-decoration: none;
-}
-
-html.rf-tabler .rf-tabler-context-pkg:hover {
-    text-decoration: underline;
 }
 
 /* Runs dropdown */

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -30,31 +30,51 @@ html.rf-tabler .navbar .nav-link.active {
     color: var(--tblr-primary, #206bc4);
 }
 
-/* Issue #842: workspace control vs run dropdown vs page links */
-html.rf-tabler .rf-workspace-toggle {
-    font-weight: 700;
-    letter-spacing: -0.01em;
-    color: #182433;
+/* Issue #842: workspace + run controls share one nav-row height */
+html.rf-tabler .navbar .navbar-nav {
+    align-items: center;
+}
+
+html.rf-tabler .rf-workspace-toggle,
+html.rf-tabler .rf-runs-toggle {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    line-height: 1.25;
+    padding: 0.35rem 0.65rem;
+    margin: 0;
     border: 1px solid var(--tblr-border-color, #e6e7e9);
     border-radius: 0.35rem;
-    padding: 0.25rem 0.55rem;
-    margin-right: 0.15rem;
-    background: #f8fafc;
-}
-
-html.rf-tabler .rf-workspace-toggle:hover,
-html.rf-tabler .rf-workspace-toggle.show {
-    background: #eef2f7;
-    color: #182433;
-}
-
-html.rf-tabler .rf-runs-toggle {
+    background: #fff;
     font-weight: 600;
     color: #3b4a5a;
 }
 
-html.rf-tabler .rf-runs-toggle.active {
+html.rf-tabler .rf-workspace-toggle {
+    font-weight: 700;
+    color: #182433;
+    background: #f8fafc;
+}
+
+html.rf-tabler .rf-workspace-toggle:hover,
+html.rf-tabler .rf-workspace-toggle.show,
+html.rf-tabler .rf-runs-toggle:hover,
+html.rf-tabler .rf-runs-toggle.show {
+    background: #eef2f7;
+    color: #182433;
+}
+
+html.rf-tabler .rf-runs-toggle.active,
+html.rf-tabler .rf-workspace-toggle.active {
     color: var(--tblr-primary, #206bc4);
+}
+
+html.rf-tabler .navbar-nav .nav-link {
+    display: inline-flex;
+    align-items: center;
+    min-height: 2rem;
+    padding-top: 0.35rem;
+    padding-bottom: 0.35rem;
 }
 
 html.rf-tabler .rf-build-chrome .nav-link.active,
@@ -64,6 +84,18 @@ html.rf-tabler .rf-results-chrome .nav-link.active {
 
 html.rf-tabler #rf-workspace-menu .dropdown-item.active {
     font-weight: 600;
+}
+
+html.rf-tabler .race-config-page .visually-hidden {
+    position: absolute !important;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 html.rf-tabler .page-wrapper {

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -30,6 +30,42 @@ html.rf-tabler .navbar .nav-link.active {
     color: var(--tblr-primary, #206bc4);
 }
 
+/* Issue #842: workspace control vs run dropdown vs page links */
+html.rf-tabler .rf-workspace-toggle {
+    font-weight: 700;
+    letter-spacing: -0.01em;
+    color: #182433;
+    border: 1px solid var(--tblr-border-color, #e6e7e9);
+    border-radius: 0.35rem;
+    padding: 0.25rem 0.55rem;
+    margin-right: 0.15rem;
+    background: #f8fafc;
+}
+
+html.rf-tabler .rf-workspace-toggle:hover,
+html.rf-tabler .rf-workspace-toggle.show {
+    background: #eef2f7;
+    color: #182433;
+}
+
+html.rf-tabler .rf-runs-toggle {
+    font-weight: 600;
+    color: #3b4a5a;
+}
+
+html.rf-tabler .rf-runs-toggle.active {
+    color: var(--tblr-primary, #206bc4);
+}
+
+html.rf-tabler .rf-build-chrome .nav-link.active,
+html.rf-tabler .rf-results-chrome .nav-link.active {
+    font-weight: 700;
+}
+
+html.rf-tabler #rf-workspace-menu .dropdown-item.active {
+    font-weight: 600;
+}
+
 html.rf-tabler .page-wrapper {
     background: #f1f5f9;
 }

--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -878,6 +878,9 @@
         function switchWorkspaceTab(tab, cid) {
             window.history.pushState({}, '', buildConfigUrl(cid, tab));
             setActiveTab(tab);
+            if (typeof window.rfRememberWorkspaceRoute === 'function') {
+                window.rfRememberWorkspaceRoute();
+            }
         }
 
         document.querySelectorAll('.race-config-hub-tab').forEach(function (btn) {
@@ -886,6 +889,9 @@
                 if (!view) return;
                 window.history.pushState({}, '', buildConfigUrl(null, null, view));
                 showHubView(view);
+                if (typeof window.rfRememberWorkspaceRoute === 'function') {
+                    window.rfRememberWorkspaceRoute();
+                }
             });
         });
 

--- a/frontend/static/js/race_configuration.js
+++ b/frontend/static/js/race_configuration.js
@@ -196,10 +196,35 @@
         });
     }
 
+    function syncHubPageHeader(view) {
+        const titleEl = document.getElementById('race-config-page-title');
+        const leadEl = document.getElementById('race-config-page-lead');
+        if (!titleEl || !leadEl) return;
+        const copy = {
+            legs: {
+                title: 'Legs',
+                lead: 'Shared routes and locations used by every package. Edit them here, then freeze distance recipes on Courses.',
+            },
+            courses: {
+                title: 'Courses',
+                lead: 'A course is a named frozen snapshot for one distance (e.g. 10K University). Assign courses to packages by distance.',
+            },
+            packages: {
+                title: 'Packages',
+                lead: 'Each package assigns one course per distance (Full / Half / 10K) and holds runner files for multi-distance analysis.',
+            },
+        };
+        const cfg = copy[view] || copy.legs;
+        titleEl.textContent = cfg.title;
+        leadEl.textContent = cfg.lead;
+        document.title = cfg.title + ' - Race Density & Flow Intelligence';
+    }
+
     function showHubView(view) {
         const packagesPanel = document.getElementById('race-config-hub-packages');
         const legsPanel = document.getElementById('race-config-hub-legs');
         const coursesPanel = document.getElementById('race-config-hub-courses');
+        // Legacy in-page hub tabs (removed from markup; keep for safety if restored)
         document.querySelectorAll('.race-config-hub-tab').forEach(function (btn) {
             const isActive = btn.getAttribute('data-hub-view') === view;
             btn.classList.toggle('active', isActive);
@@ -208,6 +233,7 @@
         if (packagesPanel) packagesPanel.style.display = view === 'packages' ? 'block' : 'none';
         if (legsPanel) legsPanel.style.display = view === 'legs' ? 'block' : 'none';
         if (coursesPanel) coursesPanel.style.display = view === 'courses' ? 'block' : 'none';
+        syncHubPageHeader(view);
 
         if (view === 'legs') {
             placeLegsPanelInHub();
@@ -284,7 +310,7 @@
 
     function setPageTitle(text) {
         const el = document.getElementById('race-config-page-title');
-        if (el) el.textContent = text || 'Build';
+        if (el) el.textContent = text || 'Packages';
     }
 
     function showEntryOnly() {
@@ -294,7 +320,6 @@
         if (entry) entry.style.display = 'block';
         if (workspace) workspace.style.display = 'none';
         if (pageHeader) pageHeader.style.display = '';
-        setPageTitle('Build');
         const lead = document.getElementById('race-config-page-lead');
         if (lead) lead.style.display = '';
         ensureHubModalsOnBody();

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -8,7 +8,7 @@
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css" />
     <link rel="stylesheet" href="/static/css/common.css?v=791p3">
-    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=796k">
+    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=842a">
     
     {% block extra_styles %}{% endblock %}
     
@@ -32,7 +32,7 @@
                     <a class="nav-link px-2 text-danger" href="/logout">Logout</a>
                 </div>
                 <div class="collapse navbar-collapse" id="rf-tabler-menu">
-                    <ul class="navbar-nav">
+                    <ul class="navbar-nav align-items-md-center">
                         {% if cloud_mode %}
                         <li class="nav-item">
                             <a class="nav-link{% if request.url and request.url.path == '/dashboard' %} active{% endif %}" href="/dashboard">Runs</a>
@@ -41,8 +41,18 @@
                             <a class="nav-link{% if request.url and request.url.path == '/locations' %} active{% endif %}" href="/locations">Locations</a>
                         </li>
                         {% else %}
-                        <li class="nav-item dropdown" id="rf-runs-dropdown">
-                            <a class="nav-link dropdown-toggle{% if request.url and request.url.path == '/dashboard' %} active{% endif %}" href="#" id="rf-runs-dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
+                        {# Issue #842: mutually exclusive Results | Build workspace control #}
+                        <li class="nav-item dropdown" id="rf-workspace-dropdown">
+                            <a class="nav-link dropdown-toggle rf-workspace-toggle" href="#" id="rf-workspace-toggle" data-bs-toggle="dropdown" aria-expanded="false" title="Switch workspace">
+                                <span id="rf-workspace-label">Results</span>
+                            </a>
+                            <div class="dropdown-menu" id="rf-workspace-menu" aria-labelledby="rf-workspace-toggle">
+                                <a class="dropdown-item rf-workspace-pick" href="#" data-workspace="results">Results</a>
+                                <a class="dropdown-item rf-workspace-pick" href="#" data-workspace="build">Build</a>
+                            </div>
+                        </li>
+                        <li class="nav-item dropdown rf-results-chrome" id="rf-runs-dropdown">
+                            <a class="nav-link dropdown-toggle rf-runs-toggle{% if request.url and request.url.path == '/dashboard' %} active{% endif %}" href="#" id="rf-runs-dropdown-toggle" data-bs-toggle="dropdown" data-bs-auto-close="outside" aria-expanded="false">
                                 <span id="rf-runs-trigger-label">Runs</span>
                             </a>
                             <div class="dropdown-menu" id="rf-runs-dropdown-menu">
@@ -54,29 +64,35 @@
                                 <a class="dropdown-item" id="rf-runs-view-all" href="/dashboard">View all runs…</a>
                             </div>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/overview' %} active{% endif %}" href="/overview" data-rf-run-view="1">Overview</a>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/segments' %} active{% endif %}" href="/segments" data-rf-run-view="1">Segments</a>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/density' %} active{% endif %}" href="/density" data-rf-run-view="1">Density</a>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/flow' %} active{% endif %}" href="/flow" data-rf-run-view="1">Flow</a>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/junctions' %} active{% endif %}" href="/junctions" data-rf-run-view="1">Junctions</a>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/locations' %} active{% endif %}" href="/locations" data-rf-run-view="1">Locations</a>
                         </li>
-                        <li class="nav-item rf-tabler-run-view-link" hidden>
+                        <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/reports' %} active{% endif %}" href="/reports" data-rf-run-view="1">Reports</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link{% if request.url and (request.url.path == '/config' or request.url.path.startswith('/race-configuration')) %} active{% endif %}" href="/config" title="Legs, Courses, and Packages">Build</a>
+                        <li class="nav-item rf-build-chrome" hidden>
+                            <a class="nav-link" href="/config?view=legs" data-rf-build-view="legs">Legs</a>
+                        </li>
+                        <li class="nav-item rf-build-chrome" hidden>
+                            <a class="nav-link" href="/config?view=courses" data-rf-build-view="courses">Courses</a>
+                        </li>
+                        <li class="nav-item rf-build-chrome" hidden>
+                            <a class="nav-link" href="/config?view=packages" data-rf-build-view="packages">Packages</a>
                         </li>
                         {% endif %}
                     </ul>
@@ -203,6 +219,142 @@
             return isResultsRoutePath(pathname);
         }
 
+        const WS_KEY = "rf_workspace";
+        const WS_LAST_RESULTS = "rf_last_results_path";
+        const WS_LAST_BUILD = "rf_last_build_path";
+        const DEFAULT_RESULTS_PATH = "/overview";
+        const DEFAULT_BUILD_PATH = "/config?view=legs";
+
+        function currentPathWithQuery() {
+            return window.location.pathname + (window.location.search || "");
+        }
+
+        function workspaceFromPath(pathname) {
+            if (isConfigRoutePath(pathname)) return "build";
+            if (isResultsRoutePath(pathname)) return "results";
+            return null;
+        }
+
+        function getStoredWorkspace() {
+            const raw = (localStorage.getItem(WS_KEY) || "").trim().toLowerCase();
+            return raw === "build" ? "build" : "results";
+        }
+
+        function setStoredWorkspace(ws) {
+            localStorage.setItem(WS_KEY, ws === "build" ? "build" : "results");
+        }
+
+        function rememberWorkspaceRoute(ws, pathOverride) {
+            const path = pathOverride || currentPathWithQuery();
+            if (!path || path === "/" || path === "/login" || path === "/logout") return;
+            if (ws === "build") {
+                localStorage.setItem(WS_LAST_BUILD, path);
+            } else if (ws === "results") {
+                // Prefer analysis pages over bare dashboard for restore
+                localStorage.setItem(WS_LAST_RESULTS, path);
+            }
+        }
+
+        function lastResultsPath() {
+            const stored = (localStorage.getItem(WS_LAST_RESULTS) || "").trim();
+            if (stored) return stored;
+            const runId = (localStorage.getItem("selected_run_id") || "").trim();
+            return runId ? ("/overview?run_id=" + encodeURIComponent(runId)) : DEFAULT_RESULTS_PATH;
+        }
+
+        function lastBuildPath() {
+            return (localStorage.getItem(WS_LAST_BUILD) || "").trim() || DEFAULT_BUILD_PATH;
+        }
+
+        function applyWorkspaceChrome(ws) {
+            const isBuild = ws === "build";
+            document.querySelectorAll(".rf-results-chrome").forEach(function (el) {
+                // Run-view links still gate on hasRun via syncTablerRunNav; hide whole Results chrome in Build
+                if (isBuild) {
+                    el.hidden = true;
+                } else if (el.classList.contains("rf-tabler-run-view-link")) {
+                    // leave for syncTablerRunNav
+                } else {
+                    el.hidden = false;
+                }
+            });
+            document.querySelectorAll(".rf-build-chrome").forEach(function (el) {
+                el.hidden = !isBuild;
+            });
+            const label = document.getElementById("rf-workspace-label");
+            if (label) label.textContent = isBuild ? "Build" : "Results";
+            document.querySelectorAll(".rf-workspace-pick").forEach(function (a) {
+                a.classList.toggle("active", a.getAttribute("data-workspace") === ws);
+            });
+            const toggle = document.getElementById("rf-workspace-toggle");
+            if (toggle) {
+                toggle.classList.toggle("active", true);
+                toggle.setAttribute("aria-label", isBuild ? "Workspace: Build" : "Workspace: Results");
+            }
+            // Mark active Build hub link from URL
+            if (isBuild) {
+                const view = (new URLSearchParams(window.location.search).get("view") || "").toLowerCase();
+                const configId = (new URLSearchParams(window.location.search).get("config_id") || "").trim();
+                document.querySelectorAll("[data-rf-build-view]").forEach(function (a) {
+                    const v = a.getAttribute("data-rf-build-view");
+                    let active = false;
+                    if (configId) {
+                        // Nested package: highlight Packages
+                        active = v === "packages";
+                    } else {
+                        active = (view || "legs") === v;
+                    }
+                    a.classList.toggle("active", active);
+                });
+            }
+        }
+
+        function switchWorkspace(ws) {
+            const target = ws === "build" ? "build" : "results";
+            setStoredWorkspace(target);
+            const dest = target === "build" ? lastBuildPath() : lastResultsPath();
+            if (dest === currentPathWithQuery()) {
+                applyWorkspaceChrome(target);
+                return;
+            }
+            window.location.href = dest;
+        }
+
+        function initWorkspaceControl() {
+            if (CLOUD_MODE) return;
+            const fromPath = workspaceFromPath(window.location.pathname);
+            const ws = fromPath || getStoredWorkspace();
+            setStoredWorkspace(ws);
+            rememberWorkspaceRoute(ws);
+            applyWorkspaceChrome(ws);
+
+            document.querySelectorAll(".rf-workspace-pick").forEach(function (a) {
+                a.addEventListener("click", function (ev) {
+                    ev.preventDefault();
+                    switchWorkspace(a.getAttribute("data-workspace"));
+                });
+            });
+
+            // Brand returns to Results workspace (last Results route)
+            const brand = document.querySelector(".navbar-brand a");
+            if (brand) {
+                brand.addEventListener("click", function (ev) {
+                    if (getStoredWorkspace() === "build" || isConfigRoutePath(window.location.pathname)) {
+                        ev.preventDefault();
+                        switchWorkspace("results");
+                    }
+                });
+            }
+        }
+
+        window.rfRememberWorkspaceRoute = function () {
+            const fromPath = workspaceFromPath(window.location.pathname);
+            if (!fromPath) return;
+            setStoredWorkspace(fromPath);
+            rememberWorkspaceRoute(fromPath);
+            applyWorkspaceChrome(fromPath);
+        };
+
         function announceRunflowContextReady(runId, day) {
             // Issue #791 / #841: Results pages wait for run (and derived day) before empty CTA
             window.dispatchEvent(new CustomEvent("runflow:context-ready", {
@@ -218,8 +370,19 @@
         function syncTablerRunNav(runId, day) {
             if (!document.documentElement.classList.contains("rf-tabler")) return;
             const hasRun = !!(runId && String(runId).trim());
+            const onBuild = isConfigRoutePath(window.location.pathname)
+                || (!CLOUD_MODE && getStoredWorkspace() === "build");
+
+            // Issue #842: Results page links only in Results workspace
             document.querySelectorAll(".rf-tabler-run-view-link").forEach(function (li) {
-                li.hidden = !hasRun;
+                li.hidden = onBuild || !hasRun;
+            });
+            document.querySelectorAll(".rf-results-chrome").forEach(function (el) {
+                if (el.classList.contains("rf-tabler-run-view-link")) return;
+                el.hidden = onBuild;
+            });
+            document.querySelectorAll(".rf-build-chrome").forEach(function (el) {
+                el.hidden = !onBuild;
             });
 
             const strip = document.getElementById("rf-tabler-context-strip");
@@ -228,14 +391,12 @@
             const dayEl = document.getElementById("rf-tabler-context-day");
             const trigger = document.getElementById("rf-runs-trigger-label");
 
-            // Issue #815: Build mode does not need Active run chrome (avoids Package vs Packages clash)
-            const onBuild = isConfigRoutePath(window.location.pathname);
-
             if (!hasRun) {
                 if (strip) strip.hidden = true;
                 if (trigger) trigger.textContent = "Runs";
                 syncTablerPackageLink(null);
-                refreshRunsDropdown(null);
+                if (!onBuild) refreshRunsDropdown(null);
+                applyWorkspaceChrome(onBuild ? "build" : "results");
                 return;
             }
 
@@ -246,6 +407,7 @@
                 if (cached) label = cached;
             } catch (e) { /* ignore */ }
 
+            // Issue #815 / #842: Build never shows Active-run strip
             if (strip) strip.hidden = onBuild;
             if (labelEl) labelEl.textContent = label;
             if (idEl) {
@@ -265,9 +427,10 @@
                 const trunc = label.length > 28 ? label.slice(0, 26) + "…" : label;
                 trigger.textContent = trunc + " · " + shortRunId(id);
             }
-            // Package deep-link is analysis chrome only
+            // Package deep-link is Results chrome only
             syncTablerPackageLink(onBuild ? null : id);
-            refreshRunsDropdown(id);
+            if (!onBuild) refreshRunsDropdown(id);
+            applyWorkspaceChrome(onBuild ? "build" : "results");
         }
 
         function configIdFromDataDir(dataDir) {
@@ -296,10 +459,16 @@
                         return;
                     }
                     localStorage.setItem("selected_config_id", configId);
-                    link.href = "/config?config_id=" + encodeURIComponent(configId);
+                    // Do not flip workspace here — only navigating to Build should (Issue #842)
+                    const pkgPath = "/config?config_id=" + encodeURIComponent(configId);
+                    link.href = pkgPath;
                     link.textContent = "Open source package";
                     link.title = "Open source package " + configId;
                     link.hidden = false;
+                    link.onclick = function () {
+                        setStoredWorkspace("build");
+                        rememberWorkspaceRoute("build", pkgPath);
+                    };
                 })
                 .catch(function () {
                     link.hidden = true;
@@ -372,6 +541,7 @@
                 try { sessionStorage.setItem("rf_run_label_" + runId, label); } catch (e) { /* ignore */ }
             }
             localStorage.setItem("selected_run_id", runId);
+            setStoredWorkspace("results");
             fetch("/api/runs/" + encodeURIComponent(runId) + "/summary", { credentials: "same-origin" })
                 .then(function (r) { return r.ok ? r.json() : null; })
                 .then(function (data) {
@@ -379,10 +549,14 @@
                     // Issue #841: day from run only — do not carry ?day= in Results nav
                     const day = days.length ? String(days[0]).toLowerCase() : null;
                     if (day) localStorage.setItem("selected_day", day);
-                    window.location.href = "/overview?run_id=" + encodeURIComponent(runId);
+                    const dest = "/overview?run_id=" + encodeURIComponent(runId);
+                    rememberWorkspaceRoute("results", dest);
+                    window.location.href = dest;
                 })
                 .catch(function () {
-                    window.location.href = "/overview?run_id=" + encodeURIComponent(runId);
+                    const dest = "/overview?run_id=" + encodeURIComponent(runId);
+                    rememberWorkspaceRoute("results", dest);
+                    window.location.href = dest;
                 });
         }
 
@@ -392,6 +566,13 @@
                 if (!href || href === "/logout" || href === "/health-check" || href === "#") return;
                 if (a.id === "rf-tabler-open-package" || a.getAttribute("data-rf-package-link") === "1") return;
                 if (a.classList.contains("dropdown-toggle") || a.classList.contains("dropdown-item")) return;
+                if (a.classList.contains("rf-workspace-pick")) return;
+                const buildView = a.getAttribute("data-rf-build-view");
+                if (buildView) {
+                    // Issue #842: Build hub links stay view=legs|courses|packages (no run scoping)
+                    a.setAttribute("href", "/config?view=" + encodeURIComponent(buildView));
+                    return;
+                }
                 const linkPath = href.split("?")[0];
                 if (!linkPath) return;
                 let newHref = href.split("?")[0];
@@ -431,7 +612,6 @@
             if (configId) {
                 localStorage.setItem("selected_config_id", configId);
             }
-            // Keep Results nest visible while on Build (Issue #796); Active run strip hidden on Build (#815)
             const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
             const storedDay = (localStorage.getItem("selected_day") || "").trim() || null;
             updateNavLinks(storedDay, storedRun);
@@ -446,6 +626,9 @@
         }
 
         function initConfigPageNav() {
+            setStoredWorkspace("build");
+            rememberWorkspaceRoute("build");
+
             const params = new URLSearchParams(window.location.search);
             let changed = false;
             if (params.has("day")) {
@@ -471,10 +654,11 @@
                 const qs = p2.toString();
                 window.history.replaceState({}, "", window.location.pathname + (qs ? "?" + qs : ""));
             }
-            // Keep last Results run in top-bar views while authoring
+            // Keep last Results run for restore when switching back (Issue #842)
             const storedRun = (localStorage.getItem("selected_run_id") || "").trim() || null;
             const storedDay = (localStorage.getItem("selected_day") || "").trim() || null;
             updateNavLinks(storedDay, storedRun);
+            applyWorkspaceChrome("build");
         }
 
         /**
@@ -482,6 +666,8 @@
          * Derive day from the run; never show a day dropdown; strip ?day= from Results URLs.
          */
         async function initRunflowContext() {
+            initWorkspaceControl();
+
             if (isConfigRoutePath(window.location.pathname)) {
                 initConfigPageNav();
                 announceRunflowContextReady(
@@ -498,6 +684,9 @@
                 announceRunflowContextReady(storedRun, day);
                 return;
             }
+
+            setStoredWorkspace("results");
+            rememberWorkspaceRoute("results");
 
             const params = new URLSearchParams(window.location.search);
             const urlDayRaw = params.get("day");

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -8,7 +8,7 @@
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css" />
     <link rel="stylesheet" href="/static/css/common.css?v=791p3">
-    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=842c">
+    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=842e">
     
     {% block extra_styles %}{% endblock %}
     
@@ -85,6 +85,10 @@
                         <li class="nav-item rf-results-chrome rf-tabler-run-view-link" hidden>
                             <a class="nav-link{% if request.url and request.url.path == '/reports' %} active{% endif %}" href="/reports" data-rf-run-view="1">Reports</a>
                         </li>
+                        {# Issue #842: Package jumps to source config; replaces Active-run strip link #}
+                        <li class="nav-item rf-results-chrome rf-tabler-package-nav" id="rf-tabler-package-nav" hidden>
+                            <a class="nav-link" id="rf-tabler-open-package" href="/config" data-rf-package-link="1">Package</a>
+                        </li>
                         <li class="nav-item rf-build-chrome" hidden>
                             <a class="nav-link" href="/config?view=legs" data-rf-build-view="legs">Legs</a>
                         </li>
@@ -99,15 +103,6 @@
                 </div>
             </div>
         </header>
-        <div id="rf-tabler-context-strip" class="rf-tabler-context-strip" hidden>
-            <div class="container-xl rf-tabler-context-inner">
-                <span class="rf-tabler-context-pill">Active run</span>
-                <span id="rf-tabler-context-label" class="rf-tabler-context-label">—</span>
-                <span id="rf-tabler-context-id" class="rf-tabler-context-id"></span>
-                <span id="rf-tabler-context-day" class="rf-tabler-context-day" hidden></span>
-                <a id="rf-tabler-open-package" class="rf-tabler-context-pkg" href="/config" hidden>Open source package</a>
-            </div>
-        </div>
         <div class="page-wrapper">
             <div class="page-body">
                 <div class="container-xl rf-tabler-content">
@@ -274,6 +269,8 @@
                     el.hidden = true;
                 } else if (el.classList.contains("rf-tabler-run-view-link")) {
                     // leave for syncTablerRunNav
+                } else if (el.classList.contains("rf-tabler-package-nav")) {
+                    // leave for syncTablerPackageLink
                 } else {
                     el.hidden = false;
                 }
@@ -367,6 +364,15 @@
             return id.length > 10 ? id.slice(0, 8) + "…" : id;
         }
 
+        function formatRunsTriggerLabel(label, runId, day) {
+            const trunc = String(label || runId || "Runs");
+            const short = trunc.length > 28 ? trunc.slice(0, 26) + "…" : trunc;
+            let text = short + " · " + shortRunId(runId);
+            // Issue #841: day stays on the run control (Active-run strip removed)
+            if (day) text += " · " + String(day).toUpperCase();
+            return text;
+        }
+
         function syncTablerRunNav(runId, day) {
             if (!document.documentElement.classList.contains("rf-tabler")) return;
             const hasRun = !!(runId && String(runId).trim());
@@ -379,20 +385,16 @@
             });
             document.querySelectorAll(".rf-results-chrome").forEach(function (el) {
                 if (el.classList.contains("rf-tabler-run-view-link")) return;
+                if (el.classList.contains("rf-tabler-package-nav")) return;
                 el.hidden = onBuild;
             });
             document.querySelectorAll(".rf-build-chrome").forEach(function (el) {
                 el.hidden = !onBuild;
             });
 
-            const strip = document.getElementById("rf-tabler-context-strip");
-            const labelEl = document.getElementById("rf-tabler-context-label");
-            const idEl = document.getElementById("rf-tabler-context-id");
-            const dayEl = document.getElementById("rf-tabler-context-day");
             const trigger = document.getElementById("rf-runs-trigger-label");
 
             if (!hasRun) {
-                if (strip) strip.hidden = true;
                 if (trigger) trigger.textContent = "Runs";
                 syncTablerPackageLink(null);
                 if (!onBuild) refreshRunsDropdown(null);
@@ -407,27 +409,8 @@
                 if (cached) label = cached;
             } catch (e) { /* ignore */ }
 
-            // Issue #815 / #842: Build never shows Active-run strip
-            if (strip) strip.hidden = onBuild;
-            if (labelEl) labelEl.textContent = label;
-            if (idEl) {
-                idEl.textContent = shortRunId(id);
-                idEl.title = id;
-            }
-            if (dayEl) {
-                // Issue #841: always show day as read-only run metadata when known
-                if (day) {
-                    dayEl.textContent = "· " + String(day).toUpperCase();
-                    dayEl.hidden = false;
-                } else {
-                    dayEl.hidden = true;
-                }
-            }
-            if (trigger) {
-                const trunc = label.length > 28 ? label.slice(0, 26) + "…" : label;
-                trigger.textContent = trunc + " · " + shortRunId(id);
-            }
-            // Package deep-link is Results chrome only
+            if (trigger) trigger.textContent = formatRunsTriggerLabel(label, id, day);
+            // Package nav item is Results chrome only (after Reports)
             syncTablerPackageLink(onBuild ? null : id);
             if (!onBuild) refreshRunsDropdown(id);
             applyWorkspaceChrome(onBuild ? "build" : "results");
@@ -444,10 +427,11 @@
         }
 
         function syncTablerPackageLink(runId) {
+            const nav = document.getElementById("rf-tabler-package-nav");
             const link = document.getElementById("rf-tabler-open-package");
-            if (!link) return;
+            if (!nav || !link) return;
             if (!runId) {
-                link.hidden = true;
+                nav.hidden = true;
                 return;
             }
             fetch("/api/analysis/" + encodeURIComponent(runId) + "/config", { credentials: "same-origin" })
@@ -455,23 +439,23 @@
                 .then(function (cfg) {
                     const configId = configIdFromDataDir(cfg && cfg.data_dir);
                     if (!configId) {
-                        link.hidden = true;
+                        nav.hidden = true;
                         return;
                     }
                     localStorage.setItem("selected_config_id", configId);
                     // Do not flip workspace here — only navigating to Build should (Issue #842)
                     const pkgPath = "/config?config_id=" + encodeURIComponent(configId);
                     link.href = pkgPath;
-                    link.textContent = "Open source package";
+                    link.textContent = "Package";
                     link.title = "Open source package " + configId;
-                    link.hidden = false;
                     link.onclick = function () {
                         setStoredWorkspace("build");
                         rememberWorkspaceRoute("build", pkgPath);
                     };
+                    nav.hidden = false;
                 })
                 .catch(function () {
-                    link.hidden = true;
+                    nav.hidden = true;
                 });
         }
 
@@ -518,14 +502,12 @@
                         list.appendChild(a);
                     });
                     if (activeRunId) {
-                        const labelEl = document.getElementById("rf-tabler-context-label");
                         const trigger = document.getElementById("rf-runs-trigger-label");
                         try {
                             const cached = sessionStorage.getItem("rf_run_label_" + activeRunId);
-                            if (cached && labelEl) labelEl.textContent = cached;
                             if (cached && trigger) {
-                                const trunc = cached.length > 28 ? cached.slice(0, 26) + "…" : cached;
-                                trigger.textContent = trunc + " · " + shortRunId(activeRunId);
+                                const day = (localStorage.getItem("selected_day") || "").trim() || null;
+                                trigger.textContent = formatRunsTriggerLabel(cached, activeRunId, day);
                             }
                         } catch (e) { /* ignore */ }
                     }

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -8,7 +8,7 @@
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css" />
     <link rel="stylesheet" href="/static/css/common.css?v=791p3">
-    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=842a">
+    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=842c">
     
     {% block extra_styles %}{% endblock %}
     

--- a/frontend/templates/pages/locations.html
+++ b/frontend/templates/pages/locations.html
@@ -252,7 +252,7 @@
 <!-- External JavaScript modules -->
 <script src="/static/js/map/base_map.js"></script>
 <script src="/static/js/map/location_pairing.js?v=2026-07-28-810"></script>
-<script src="/static/js/map/locations.js?v=2026-07-29-pass-line"></script>
+<script src="/static/js/map/locations.js?v=842b"></script>
 
 <!-- Table interaction script -->
 <script>

--- a/frontend/templates/pages/race_configuration.html
+++ b/frontend/templates/pages/race_configuration.html
@@ -1,6 +1,6 @@
 {% extends "base.html" %}
 
-{% block title %}Build{% endblock %}
+{% block title %}Legs{% endblock %}
 
 {% block extra_head %}
 {% include 'partials/course_mapping_styles.html' %}
@@ -10,48 +10,27 @@
 {% block content %}
 <div class="race-config-page">
     <div class="page-header">
-        <h2 id="race-config-page-title">Build</h2>
+        <h2 id="race-config-page-title">Legs</h2>
         <p id="race-config-page-lead" class="race-config-page-lead">
-            Build global <strong>Legs</strong> and named <strong>Courses</strong>, then assemble them into race <strong>Packages</strong>.
+            Shared routes and locations used by every package. Edit them here, then freeze distance recipes on Courses.
         </p>
     </div>
 
     <div id="race-config-entry" class="page-shell page-shell--entry">
         <div class="content-card race-config-hub-shell">
-            <div class="race-config-hub-header">
-                <ul class="race-config-hub-tabs nav nav-tabs card-header-tabs" role="tablist" aria-label="Build library">
-                    <li class="nav-item" role="presentation">
-                        <button type="button" class="nav-link race-config-hub-tab active" data-hub-view="legs" role="tab" aria-selected="true">Legs</button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button type="button" class="nav-link race-config-hub-tab" data-hub-view="courses" role="tab" aria-selected="false">Courses</button>
-                    </li>
-                    <li class="nav-item" role="presentation">
-                        <button type="button" class="nav-link race-config-hub-tab" data-hub-view="packages" role="tab" aria-selected="false">Packages</button>
-                    </li>
-                </ul>
-            </div>
-
+            {# Issue #842 follow-up: hub tabs removed — top nav is Legs | Courses | Packages #}
             <div class="race-config-hub-body">
                 <div id="race-config-hub-legs" class="race-config-hub-panel">
-                    <p class="card-help race-config-hub-lead" title="Stored in the organization leg library">
-                        Legs are shared routes and locations used by every package.
-                        Edit them here, then freeze distance recipes on the <strong>Courses</strong> tab.
-                    </p>
                     <div id="race-config-hub-legs-slot" class="race-config-hub-legs-slot"></div>
                 </div>
 
                 <div id="race-config-hub-courses" class="race-config-hub-panel" style="display: none;">
                     <div class="card-header">
-                        <h3 class="card-title">Courses</h3>
+                        <h3 class="card-title visually-hidden">Courses</h3>
                         <div class="card-actions">
                             <button type="button" id="btn-save-named-course" class="course-btn primary" title="Compose a course from org legs and freeze exports">New course</button>
                         </div>
                     </div>
-                    <p class="card-help" title="Frozen snapshots live in the organization course library">
-                        A course is a named frozen snapshot for one distance (e.g. 10K University).
-                        Assign courses to packages by distance.
-                    </p>
                     <p id="saved-courses-status" class="course-derived-empty" style="display: none;"></p>
                     <div id="saved-courses-table-wrap" style="display: none;">
                         <div class="scrollable-table-container">
@@ -104,12 +83,11 @@
 
                 <div id="race-config-hub-packages" class="race-config-hub-panel" style="display: none;">
                     <div class="card-header">
-                        <h3 class="card-title">Packages</h3>
+                        <h3 class="card-title visually-hidden">Packages</h3>
                         <div class="card-actions">
                             <button type="button" id="race-config-new-btn" class="course-btn primary">New package</button>
                         </div>
                     </div>
-                    <p class="card-help">Each package assigns one course per distance (Full / Half / 10K) and holds runner files for multi-distance analysis.</p>
                     <div class="scrollable-table-container">
                         <table id="race-config-list-table" class="table-sticky-header">
                             <thead>
@@ -322,5 +300,5 @@
 <script src="/static/js/map/saved_courses.js?v=791p2"></script>
 <script src="/static/js/runners_baseline.js?v=756k"></script>
 <script src="/static/js/map/junctions_authoring.js?v=819x"></script>
-<script src="/static/js/race_configuration.js?v=817f"></script>
+<script src="/static/js/race_configuration.js?v=842c"></script>
 {% endblock %}

--- a/frontend/templates/pages/segments.html
+++ b/frontend/templates/pages/segments.html
@@ -149,7 +149,7 @@
 
 <!-- External JavaScript modules (cache-busted for latest fixes) -->
 <script src="/static/js/map/base_map.js"></script>
-<script src="/static/js/map/segments.js?v=2026-01-24T1145Z"></script>
+<script src="/static/js/map/segments.js?v=842b"></script>
 
 <!-- Table interaction script -->
 <script>

--- a/tests/unit/test_issue798_phase7_tabler_only.py
+++ b/tests/unit/test_issue798_phase7_tabler_only.py
@@ -77,5 +77,5 @@ def test_base_html_no_day_selector_markup(base_source: str):
     assert 'id="rf-tabler-context-day"' in base_source
     # Results nav is run_id-primary (day stripped from analysis links)
     assert 'setQueryParam(newHref, "day", null)' in base_source
-    assert 'window.location.href = "/overview?run_id="' in base_source or \
-        'window.location.href = "/overview?run_id=" + encodeURIComponent(runId)' in base_source
+    assert '"/overview?run_id=" + encodeURIComponent(runId)' in base_source
+    assert "initWorkspaceControl" in base_source

--- a/tests/unit/test_issue798_phase7_tabler_only.py
+++ b/tests/unit/test_issue798_phase7_tabler_only.py
@@ -62,8 +62,8 @@ def test_base_html_jinja_render_smoke():
     assert 'id="day-selector"' not in html  # Issue #841: day from run, no dropdown
     assert "initRunflowContext" in html
     assert 'id="rf-runs-dropdown"' in html
-    assert 'id="rf-tabler-context-strip"' in html
-    assert 'id="rf-tabler-context-day"' in html
+    assert 'id="rf-tabler-package-nav"' in html
+    assert 'id="rf-tabler-context-strip"' not in html
     assert 'id="rf-phase7-smoke"' in html
 
 
@@ -74,7 +74,8 @@ def test_base_html_no_day_selector_markup(base_source: str):
     assert "setDaySelectorVisible" not in base_source
     assert "initDaySelector" not in base_source
     assert "initRunflowContext" in base_source
-    assert 'id="rf-tabler-context-day"' in base_source
+    assert 'id="rf-tabler-context-day"' not in base_source
+    assert "formatRunsTriggerLabel" in base_source
     # Results nav is run_id-primary (day stripped from analysis links)
     assert 'setQueryParam(newHref, "day", null)' in base_source
     assert '"/overview?run_id=" + encodeURIComponent(runId)' in base_source

--- a/tests/unit/test_issue841_one_day_chrome.py
+++ b/tests/unit/test_issue841_one_day_chrome.py
@@ -42,9 +42,12 @@ def test_pick_run_navigates_without_day_query(base_source: str):
         'rememberWorkspaceRoute("results", dest)' in base_source
 
 
-def test_active_run_strip_always_shows_day_when_known(base_source: str):
-    assert "Issue #841: always show day as read-only run metadata when known" in base_source
-    assert 'dayEl.textContent = "· " + String(day).toUpperCase()' in base_source
+def test_run_dropdown_shows_day_when_known(base_source: str):
+    assert "Issue #841: day stays on the run control" in base_source
+    assert "formatRunsTriggerLabel" in base_source
+    assert 'text += " · " + String(day).toUpperCase()' in base_source
+    # Old Active-run strip day node removed
+    assert 'id="rf-tabler-context-day"' not in base_source
     # Old multi-day-only visibility gate removed
     assert "window.runflowDay.available.length > 1" not in base_source
 
@@ -74,5 +77,6 @@ def test_base_html_renders_without_day_selector():
     )
     html = template.render(request=_Request(), cloud_mode=False)
     assert 'id="day-selector"' not in html
-    assert 'id="rf-tabler-context-day"' in html
+    assert 'id="rf-tabler-context-day"' not in html
+    assert 'id="rf-runs-dropdown"' in html
     assert 'id="rf-841-smoke"' in html

--- a/tests/unit/test_issue841_one_day_chrome.py
+++ b/tests/unit/test_issue841_one_day_chrome.py
@@ -38,6 +38,8 @@ def test_runflow_context_strips_day_from_results_url(base_source: str):
 
 def test_pick_run_navigates_without_day_query(base_source: str):
     assert '"/overview?run_id=" + encodeURIComponent(runId)' in base_source
+    assert "rememberWorkspaceRoute(\"results\", dest)" in base_source or \
+        'rememberWorkspaceRoute("results", dest)' in base_source
 
 
 def test_active_run_strip_always_shows_day_when_known(base_source: str):

--- a/tests/unit/test_issue842_workspace_nav.py
+++ b/tests/unit/test_issue842_workspace_nav.py
@@ -54,9 +54,18 @@ def test_results_chrome_class_on_run_controls(base_source: str):
     assert "rf_last_build_path" in base_source
 
 
-def test_build_does_not_show_active_run_strip(base_source: str):
-    assert "Build never shows Active-run strip" in base_source
-    assert 'strip.hidden = onBuild' in base_source
+def test_no_active_run_strip_in_results_chrome(base_source: str):
+    assert 'id="rf-tabler-context-strip"' not in base_source
+    assert "Active run" not in base_source
+    assert 'id="rf-tabler-package-nav"' in base_source
+    assert 'link.textContent = "Package"' in base_source
+    assert "Open source package</a>" not in base_source
+
+
+def test_package_nav_gated_separately_from_run_views(base_source: str):
+    assert "rf-tabler-package-nav" in base_source
+    assert "leave for syncTablerPackageLink" in base_source
+    assert "formatRunsTriggerLabel" in base_source
 
 
 def test_base_html_renders_workspace_control():

--- a/tests/unit/test_issue842_workspace_nav.py
+++ b/tests/unit/test_issue842_workspace_nav.py
@@ -1,0 +1,74 @@
+"""Issue #842: Results/Build workspace selector chrome."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from jinja2 import Environment, FileSystemLoader, select_autoescape
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+BASE_HTML = REPO_ROOT / "frontend" / "templates" / "base.html"
+TEMPLATES_DIR = REPO_ROOT / "frontend" / "templates"
+
+
+@pytest.fixture(scope="module")
+def base_source() -> str:
+    return BASE_HTML.read_text(encoding="utf-8")
+
+
+def test_workspace_dropdown_markup(base_source: str):
+    assert 'id="rf-workspace-dropdown"' in base_source
+    assert 'id="rf-workspace-label"' in base_source
+    assert 'data-workspace="results"' in base_source
+    assert 'data-workspace="build"' in base_source
+    assert "initWorkspaceControl" in base_source
+    assert "switchWorkspace" in base_source
+
+
+def test_build_hub_links_in_top_nav(base_source: str):
+    assert 'data-rf-build-view="legs"' in base_source
+    assert 'data-rf-build-view="courses"' in base_source
+    assert 'data-rf-build-view="packages"' in base_source
+    assert 'class="nav-item rf-build-chrome"' in base_source
+    # Old single Build link removed from local chrome
+    assert 'title="Legs, Courses, and Packages"' not in base_source
+
+
+def test_results_chrome_class_on_run_controls(base_source: str):
+    assert "rf-results-chrome" in base_source
+    assert 'id="rf-runs-dropdown"' in base_source
+    assert "WS_LAST_RESULTS" in base_source
+    assert "WS_LAST_BUILD" in base_source
+    assert "rf_last_results_path" in base_source
+    assert "rf_last_build_path" in base_source
+
+
+def test_build_does_not_show_active_run_strip(base_source: str):
+    assert "Build never shows Active-run strip" in base_source
+    assert 'strip.hidden = onBuild' in base_source
+
+
+def test_base_html_renders_workspace_control():
+    env = Environment(
+        loader=FileSystemLoader(str(TEMPLATES_DIR)),
+        autoescape=select_autoescape(["html", "xml"]),
+    )
+
+    class _Url:
+        path = "/overview"
+
+    class _Request:
+        url = _Url()
+        query_params = {}
+
+    template = env.from_string(
+        '{% extends "base.html" %}\n'
+        '{% block content %}<p id="rf-842-smoke">ok</p>{% endblock %}'
+    )
+    html = template.render(request=_Request(), cloud_mode=False)
+    assert 'id="rf-workspace-dropdown"' in html
+    assert 'data-rf-build-view="courses"' in html
+    assert 'id="rf-842-smoke"' in html
+    assert 'id="day-selector"' not in html

--- a/tests/unit/test_issue842_workspace_nav.py
+++ b/tests/unit/test_issue842_workspace_nav.py
@@ -36,6 +36,15 @@ def test_build_hub_links_in_top_nav(base_source: str):
     assert 'title="Legs, Courses, and Packages"' not in base_source
 
 
+def test_build_page_has_no_in_page_hub_tabs():
+    src = (REPO_ROOT / "frontend" / "templates" / "pages" / "race_configuration.html").read_text(
+        encoding="utf-8"
+    )
+    assert "race-config-hub-tab" not in src
+    assert 'id="race-config-page-title"' in src
+    assert "Shared routes and locations" in src
+
+
 def test_results_chrome_class_on_run_controls(base_source: str):
     assert "rf-results-chrome" in base_source
     assert 'id="rf-runs-dropdown"' in base_source


### PR DESCRIPTION
## Summary
- Adds a **Results | Build** workspace control; each workspace shows only its own top-nav controls.
- **Results:** Run dropdown + Overview / Segments / Density / Flow / Junctions / Locations / Reports / Package; no Active-run strip (label/id/day live on the run control).
- **Build:** Legs / Courses / Packages; no run dropdown or Results links.
- Remembers last Results route (`run_id`) and last Build route; switching restores them. Deep-links set workspace from the path.
- Fixes Results/Runs dropdown vertical alignment when both controls are present.
- Nested package subnav (Courses / Junctions / Runners) stays inside the package page.

Closes #842

## Test plan
- [x] Unit: `tests/unit/test_issue842_workspace_nav.py` (+ #841/#798 chrome tests)
- [x] Browser smoke against local `localhost:8080`
  - [x] Results chrome: workspace + run + Results links + Package; Active-run strip gone
  - [x] Build chrome: Legs/Courses/Packages; run/Results hidden
  - [x] Results/Runs dropdowns vertically aligned
  - [x] Package deep-link opens source config and switches to Build
  - [x] Last Results route restored after Build