### PR TITLE
Flow segment-first parent preview (#845–#848)

### DIFF
--- a/app/api/flow.py
+++ b/app/api/flow.py
@@ -152,33 +152,18 @@ async def get_flow_segment_parents(
     """
     try:
         from app.utils.run_id import get_latest_run_id, get_run_directory, resolve_selected_day
-        from app.storage import create_runflow_storage
-        from app.utils.constants import FLOW_SEGMENT_SUMMARY_FILENAME
         from app.core.flow.segment_summary import build_segment_flow_summary_from_day_dir
 
         if not run_id:
             run_id = get_latest_run_id()
         selected_day, available_days = resolve_selected_day(run_id, day)
-        storage = create_runflow_storage(run_id)
-        artifact_path = f"{selected_day}/ui/metrics/{FLOW_SEGMENT_SUMMARY_FILENAME}"
-
-        summary = None
-        try:
-            content = storage.read_text(artifact_path)
-            if content:
-                summary = json.loads(content)
-        except FileNotFoundError:
-            summary = None
-        except Exception as e:
-            logger.warning("Failed to read %s: %s", artifact_path, e)
-            summary = None
-
-        if not summary:
-            day_dir = get_run_directory(run_id) / selected_day
-            if day_dir.is_dir():
-                summary = build_segment_flow_summary_from_day_dir(day_dir, selected_day)
-            else:
-                summary = {"schema_version": None, "segments": []}
+        day_dir = get_run_directory(run_id) / selected_day
+        # Always rebuild from pair artifacts. The durable JSON may be written in
+        # Phase 7 before overlaps exist, so serving it stale drops t0/t1/occupancy.
+        if day_dir.is_dir():
+            summary = build_segment_flow_summary_from_day_dir(day_dir, selected_day)
+        else:
+            summary = {"schema_version": None, "segments": []}
 
         response = JSONResponse(content={
             "selected_day": selected_day,

--- a/app/api/flow.py
+++ b/app/api/flow.py
@@ -138,3 +138,58 @@ async def get_flow_segments(
         logger.error(f"Error generating flow segments: {e}")
         raise HTTPException(status_code=500, detail=f"Failed to load flow data: {str(e)}")
 
+
+@router.get("/api/flow/segment-parents")
+async def get_flow_segment_parents(
+    run_id: Optional[str] = Query(None, description="Run ID (defaults to latest)"),
+    day: Optional[str] = Query(None, description="Day code (fri|sat|sun|mon)"),
+):
+    """
+    Additive segment-parent Flow summary (#845/#847).
+
+    Does not change `/api/flow/segments`. Missing artifact falls back to an
+    on-the-fly O(pairs) build from existing pair files.
+    """
+    try:
+        from app.utils.run_id import get_latest_run_id, get_run_directory, resolve_selected_day
+        from app.storage import create_runflow_storage
+        from app.utils.constants import FLOW_SEGMENT_SUMMARY_FILENAME
+        from app.core.flow.segment_summary import build_segment_flow_summary_from_day_dir
+
+        if not run_id:
+            run_id = get_latest_run_id()
+        selected_day, available_days = resolve_selected_day(run_id, day)
+        storage = create_runflow_storage(run_id)
+        artifact_path = f"{selected_day}/ui/metrics/{FLOW_SEGMENT_SUMMARY_FILENAME}"
+
+        summary = None
+        try:
+            content = storage.read_text(artifact_path)
+            if content:
+                summary = json.loads(content)
+        except FileNotFoundError:
+            summary = None
+        except Exception as e:
+            logger.warning("Failed to read %s: %s", artifact_path, e)
+            summary = None
+
+        if not summary:
+            day_dir = get_run_directory(run_id) / selected_day
+            if day_dir.is_dir():
+                summary = build_segment_flow_summary_from_day_dir(day_dir, selected_day)
+            else:
+                summary = {"schema_version": None, "segments": []}
+
+        response = JSONResponse(content={
+            "selected_day": selected_day,
+            "available_days": available_days,
+            "summary": summary,
+        })
+        response.headers["Cache-Control"] = "public, max-age=60"
+        return response
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Error loading flow segment parents: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to load flow segment parents: {str(e)}")
+

--- a/app/core/flow/flow.py
+++ b/app/core/flow/flow.py
@@ -189,6 +189,7 @@ def _compute_flow_segment_task(
         "zones": zones,
         "worst_zone_index": worst_zone.zone_index if worst_zone else None,
         "worst_zone": worst_zone,
+        "flow_id": segment_data.get("flow_id") or "",
     }
     
     has_convergence = cp_km is not None and worst_zone is not None

--- a/app/core/flow/segment_summary.py
+++ b/app/core/flow/segment_summary.py
@@ -380,6 +380,22 @@ def build_segment_flow_summary(
                     tables.append((events_in_table, rows))
             occupancy = merge_occupancy_series(tables)
 
+        state_cursor = cursor_hhmm
+        if not state_cursor and t0 and t1:
+            start_m = hhmm_to_minutes(t0)
+            end_m = hhmm_to_minutes(t1)
+            if start_m is not None and end_m is not None:
+                mid = (start_m + end_m) // 2
+                state_cursor = f"{mid // 60:02d}:{mid % 60:02d}"
+        if state_cursor:
+            for group in (same_pass, corridor, same_event):
+                for pair in group:
+                    pair["state"] = pair_temporal_state(
+                        state_cursor,
+                        pair.get("overlap_start") or "",
+                        pair.get("overlap_end") or "",
+                    )
+
         parents.append(
             {
                 "seg_id": seg_id,

--- a/app/core/flow/segment_summary.py
+++ b/app/core/flow/segment_summary.py
@@ -1,0 +1,505 @@
+"""
+Segment-first Flow summary (#845–#848).
+
+Groups existing pair artifacts by seg_id. No subset-proportional compute.
+Parent KPIs (unique overtakers) ship only when fz_runners rows carry pair keys
+and the same-pass × cross-event filter is applied.
+"""
+
+from __future__ import annotations
+
+import csv
+import json
+import logging
+import re
+from collections import defaultdict
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping, Optional, Sequence, Tuple
+
+from app.core.course.flow_csv import default_flow_id
+from app.utils.constants import (
+    FLOW_SEGMENT_SUMMARY_FILENAME,
+    FLOW_SEGMENT_SUMMARY_SCHEMA,
+    REPORTS_OVERLAPS_DIRNAME,
+    REPORTS_OVERLAPS_SUMMARY_FILENAME,
+)
+
+logger = logging.getLogger(__name__)
+
+PAIR_KIND_SAME_PASS = "same_pass"
+PAIR_KIND_CORRIDOR = "corridor"
+PAIR_KIND_SAME_EVENT = "same_event"
+
+PACE_MIXING_READY = "ready"
+PACE_MIXING_UNAVAILABLE = "unavailable_needs_pair_keyed_fz_runners"
+
+_SEG_TOKEN_RE = re.compile(r"^[A-Za-z]+\d+[A-Za-z0-9]*$")
+_HHMM_RE = re.compile(r"^(\d{1,2}):(\d{2})$")
+
+
+def _norm_event(value: Any) -> str:
+    return str(value or "").strip().lower()
+
+
+def _looks_like_seg_id(token: str) -> bool:
+    return bool(_SEG_TOKEN_RE.match(str(token or "").strip()))
+
+
+def classify_pair_kind(
+    flow_id: str,
+    event_a: str,
+    event_b: str,
+    seg_id: str = "",
+) -> str:
+    """Classify a pair atom for parent vs typed-child treatment."""
+    ea = _norm_event(event_a)
+    eb = _norm_event(event_b)
+    if ea and eb and ea == eb:
+        return PAIR_KIND_SAME_EVENT
+
+    fid = str(flow_id or "").strip()
+    sid = str(seg_id or "").strip()
+    if fid and sid and fid == default_flow_id(sid, ea, eb):
+        return PAIR_KIND_SAME_PASS
+
+    if fid and sid and fid.startswith(f"{sid}_"):
+        remainder = fid[len(sid) + 1 :]
+        first = remainder.split("_", 1)[0]
+        if first not in {ea, eb} and _looks_like_seg_id(first):
+            return PAIR_KIND_CORRIDOR
+
+    if ea and eb:
+        return PAIR_KIND_SAME_PASS if ea != eb else PAIR_KIND_SAME_EVENT
+    if fid and sid and fid.startswith(f"{sid}_"):
+        remainder = fid[len(sid) + 1 :]
+        first = remainder.split("_", 1)[0]
+        if _looks_like_seg_id(first):
+            return PAIR_KIND_CORRIDOR
+        return PAIR_KIND_SAME_PASS
+    return PAIR_KIND_SAME_PASS
+
+
+def hhmm_to_minutes(value: Any) -> Optional[int]:
+    text = str(value or "").strip()
+    match = _HHMM_RE.match(text)
+    if not match:
+        return None
+    hours = int(match.group(1))
+    mins = int(match.group(2))
+    if mins > 59:
+        return None
+    return hours * 60 + mins
+
+
+def pair_temporal_state(
+    cursor_hhmm: str,
+    pair_start_hhmm: str,
+    pair_end_hhmm: str,
+) -> str:
+    cursor = hhmm_to_minutes(cursor_hhmm)
+    start = hhmm_to_minutes(pair_start_hhmm)
+    end = hhmm_to_minutes(pair_end_hhmm)
+    if cursor is None or start is None or end is None:
+        return "unknown"
+    if cursor < start:
+        return "not_yet_active"
+    if cursor > end:
+        return "inactive"
+    return "active"
+
+
+def unique_role_unions(
+    runner_rows: Sequence[Mapping[str, Any]],
+    *,
+    role: str,
+    allowed_flow_ids: Iterable[str],
+) -> Dict[str, int]:
+    allowed = {str(fid) for fid in allowed_flow_ids}
+    by_event: Dict[str, set] = defaultdict(set)
+    for row in runner_rows:
+        if str(row.get("role") or "") != role:
+            continue
+        flow_id = str(row.get("flow_id") or "").strip()
+        if flow_id not in allowed:
+            continue
+        event = _norm_event(row.get("event"))
+        runner_id = row.get("runner_id")
+        if not event or runner_id is None or runner_id == "":
+            continue
+        by_event[event].add(str(runner_id))
+    return {event: len(ids) for event, ids in sorted(by_event.items())}
+
+
+def _pct(count: int, field_size: int) -> Optional[float]:
+    if field_size <= 0:
+        return None
+    return round(100.0 * count / field_size, 1)
+
+
+def _field_sizes_from_pairs(pair_entries: Sequence[Mapping[str, Any]]) -> Dict[str, int]:
+    sizes: Dict[str, int] = {}
+    for pair in pair_entries:
+        ea = _norm_event(pair.get("event_a"))
+        eb = _norm_event(pair.get("event_b"))
+        total_a = pair.get("total_a")
+        total_b = pair.get("total_b")
+        if ea and isinstance(total_a, (int, float)) and total_a:
+            sizes[ea] = max(sizes.get(ea, 0), int(total_a))
+        if eb and isinstance(total_b, (int, float)) and total_b:
+            sizes[eb] = max(sizes.get(eb, 0), int(total_b))
+    return sizes
+
+
+def _worst_pair_attribution(same_pass_pairs: Sequence[Mapping[str, Any]]) -> Optional[Dict[str, Any]]:
+    best = None
+    best_score = -1
+    for pair in same_pass_pairs:
+        worst = pair.get("worst_zone") or {}
+        score = int(worst.get("overtaking_a") or 0) + int(worst.get("overtaking_b") or 0)
+        score = max(score, int(worst.get("unique_encounters") or 0))
+        if score > best_score:
+            best_score = score
+            best = {
+                "flow_id": pair.get("flow_id"),
+                "event_a": pair.get("event_a"),
+                "event_b": pair.get("event_b"),
+                "zone_index": worst.get("zone_index"),
+                "severity_metric": "overtaking_a_plus_b_or_unique_encounters",
+                "severity_value": score,
+                "overlap_start": pair.get("overlap_start"),
+                "overlap_end": pair.get("overlap_end"),
+            }
+    return best
+
+
+def merge_occupancy_series(
+    per_minute_tables: Sequence[Tuple[Sequence[str], Sequence[Mapping[str, Any]]]],
+) -> List[Dict[str, Any]]:
+    """Merge same-pass per-minute CSVs into event occupancy context.
+
+    For each minute × event, take the max count across pair tables. Same-segment
+    concurrent headcount should agree; max is conservative if one series is sparse.
+    """
+    by_minute: Dict[str, Dict[str, int]] = defaultdict(dict)
+    for events, rows in per_minute_tables:
+        for row in rows:
+            minute = str(row.get("minute_start") or "").strip()
+            if not minute:
+                continue
+            for event in events:
+                col = f"{event}_count"
+                if col not in row:
+                    continue
+                try:
+                    count = int(row.get(col) or 0)
+                except (TypeError, ValueError):
+                    continue
+                prev = by_minute[minute].get(event)
+                by_minute[minute][event] = count if prev is None else max(prev, count)
+
+    series = []
+    for minute in sorted(by_minute, key=lambda m: hhmm_to_minutes(m) or 0):
+        point = {"minute": minute}
+        point.update(by_minute[minute])
+        series.append(point)
+    return series
+
+
+def build_segment_flow_summary(
+    *,
+    flow_segments: Mapping[str, Any],
+    overlaps_summary: Mapping[str, Any],
+    runner_rows: Optional[Sequence[Mapping[str, Any]]] = None,
+    occupancy_tables: Optional[Sequence[Tuple[str, Sequence[str], Sequence[Mapping[str, Any]]]]] = None,
+    cursor_hhmm: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Build the durable per-seg_id Flow summary from existing pair artifacts."""
+    overlap_by_flow_id = {}
+    for item in overlaps_summary.get("segments") or []:
+        if isinstance(item, dict) and item.get("flow_id"):
+            overlap_by_flow_id[str(item["flow_id"])] = item
+
+    fs_by_key: Dict[str, Tuple[str, Dict[str, Any]]] = {}
+    fs_by_pair: Dict[Tuple[str, str, str], List[Tuple[str, Dict[str, Any]]]] = defaultdict(list)
+    for composite_key, raw in (flow_segments or {}).items():
+        if not isinstance(raw, dict):
+            continue
+        seg_id = str(raw.get("seg_id") or "").strip()
+        if not seg_id:
+            continue
+        event_a = _norm_event(raw.get("event_a"))
+        event_b = _norm_event(raw.get("event_b"))
+        explicit_id = str(raw.get("flow_id") or "").strip()
+        fs_by_key[composite_key] = (composite_key, raw)
+        if explicit_id:
+            fs_by_key[explicit_id] = (composite_key, raw)
+        fs_by_pair[(seg_id, event_a, event_b)].append((composite_key, raw))
+
+    def _lookup_flow_segment(flow_id: str, seg_id: str, event_a: str, event_b: str):
+        if flow_id in fs_by_key:
+            return fs_by_key[flow_id]
+        matches = fs_by_pair.get((seg_id, event_a, event_b)) or []
+        return matches[0] if matches else (None, {})
+
+    grouped: Dict[str, Dict[str, Any]] = {}
+    consumed_composites = set()
+    consumed_pair_keys = set()
+
+    def _append_pair(seg_id: str, pair: Dict[str, Any]) -> None:
+        bucket = grouped.setdefault(
+            seg_id,
+            {"seg_id": seg_id, "segment_label": pair.get("segment_label") or "", "pairs": []},
+        )
+        label = pair.get("segment_label") or ""
+        if label and " / " not in label:
+            bucket["segment_label"] = label
+        elif not bucket["segment_label"]:
+            bucket["segment_label"] = label
+        bucket["pairs"].append(pair)
+
+    for overlap in overlaps_summary.get("segments") or []:
+        if not isinstance(overlap, dict):
+            continue
+        flow_id = str(overlap.get("flow_id") or "").strip()
+        seg_id = str(overlap.get("seg_id") or "").strip()
+        event_a = _norm_event(overlap.get("event_a"))
+        event_b = _norm_event(overlap.get("event_b"))
+        if not flow_id or not seg_id:
+            continue
+        composite_key, raw = _lookup_flow_segment(flow_id, seg_id, event_a, event_b)
+        kind = classify_pair_kind(flow_id, event_a, event_b, seg_id)
+        pair = {
+            "flow_id": flow_id,
+            "composite_key": composite_key,
+            "kind": kind,
+            "event_a": event_a,
+            "event_b": event_b,
+            "segment_label": (raw or {}).get("segment_label") or overlap.get("seg_label") or "",
+            "flow_type": (raw or {}).get("flow_type"),
+            "total_a": int((raw or {}).get("total_a") or 0),
+            "total_b": int((raw or {}).get("total_b") or 0),
+            "overlap_start": overlap.get("overlap_start"),
+            "overlap_end": overlap.get("overlap_end"),
+            "peak_concurrent_a": overlap.get("peak_concurrent_a"),
+            "peak_concurrent_b": overlap.get("peak_concurrent_b"),
+            "csv_filename": overlap.get("csv_filename"),
+            "worst_zone": (raw or {}).get("worst_zone"),
+            "zone_count": len((raw or {}).get("zones") or []),
+        }
+        if cursor_hhmm:
+            pair["state"] = pair_temporal_state(
+                cursor_hhmm,
+                pair.get("overlap_start") or "",
+                pair.get("overlap_end") or "",
+            )
+        _append_pair(seg_id, pair)
+        if composite_key:
+            consumed_composites.add(composite_key)
+        consumed_pair_keys.add((seg_id, event_a, event_b))
+
+    for composite_key, raw in (flow_segments or {}).items():
+        if not isinstance(raw, dict) or composite_key in consumed_composites:
+            continue
+        seg_id = str(raw.get("seg_id") or "").strip()
+        event_a = _norm_event(raw.get("event_a"))
+        event_b = _norm_event(raw.get("event_b"))
+        if not seg_id or (seg_id, event_a, event_b) in consumed_pair_keys:
+            continue
+        flow_id = str(raw.get("flow_id") or composite_key or default_flow_id(seg_id, event_a, event_b)).strip()
+        kind = classify_pair_kind(flow_id, event_a, event_b, seg_id)
+        pair = {
+            "flow_id": flow_id,
+            "composite_key": composite_key,
+            "kind": kind,
+            "event_a": event_a,
+            "event_b": event_b,
+            "segment_label": raw.get("segment_label") or "",
+            "flow_type": raw.get("flow_type"),
+            "total_a": int(raw.get("total_a") or 0),
+            "total_b": int(raw.get("total_b") or 0),
+            "overlap_start": None,
+            "overlap_end": None,
+            "peak_concurrent_a": None,
+            "peak_concurrent_b": None,
+            "csv_filename": None,
+            "worst_zone": raw.get("worst_zone"),
+            "zone_count": len(raw.get("zones") or []),
+        }
+        _append_pair(seg_id, pair)
+
+    parents = []
+    for seg_id, bucket in sorted(grouped.items(), key=lambda item: item[0]):
+        pairs = bucket["pairs"]
+        same_pass = [p for p in pairs if p["kind"] == PAIR_KIND_SAME_PASS]
+        corridor = [p for p in pairs if p["kind"] == PAIR_KIND_CORRIDOR]
+        same_event = [p for p in pairs if p["kind"] == PAIR_KIND_SAME_EVENT]
+
+        events = []
+        for pair in same_pass:
+            for event in (pair["event_a"], pair["event_b"]):
+                if event and event not in events:
+                    events.append(event)
+
+        starts = [hhmm_to_minutes(p.get("overlap_start")) for p in same_pass]
+        ends = [hhmm_to_minutes(p.get("overlap_end")) for p in same_pass]
+        valid_starts = [m for m in starts if m is not None]
+        valid_ends = [m for m in ends if m is not None]
+        t0 = (
+            f"{min(valid_starts) // 60:02d}:{min(valid_starts) % 60:02d}"
+            if valid_starts
+            else None
+        )
+        t1 = (
+            f"{max(valid_ends) // 60:02d}:{max(valid_ends) % 60:02d}"
+            if valid_ends
+            else None
+        )
+
+        field_sizes = _field_sizes_from_pairs(same_pass)
+        allowed_ids = [p["flow_id"] for p in same_pass]
+        runner_keyed = bool(runner_rows) and any(str(r.get("flow_id") or "") for r in runner_rows or [])
+        if runner_keyed and same_pass:
+            overtakers = unique_role_unions(
+                runner_rows or [], role="overtaking", allowed_flow_ids=allowed_ids
+            )
+            overtaken = unique_role_unions(
+                runner_rows or [], role="overtaken", allowed_flow_ids=allowed_ids
+            )
+            status = PACE_MIXING_READY
+        else:
+            overtakers = {}
+            overtaken = {}
+            status = PACE_MIXING_UNAVAILABLE
+
+        occupancy = []
+        if occupancy_tables:
+            tables = []
+            allowed = set(allowed_ids)
+            for flow_id, events_in_table, rows in occupancy_tables:
+                if flow_id in allowed:
+                    tables.append((events_in_table, rows))
+            occupancy = merge_occupancy_series(tables)
+
+        parents.append(
+            {
+                "seg_id": seg_id,
+                "segment_label": bucket["segment_label"],
+                "events": events,
+                "t0": t0,
+                "t1": t1,
+                "field_denominator": "starters_in_analysis_run",
+                "field_sizes": field_sizes,
+                "pace_mixing_status": status,
+                "unique_overtakers": {
+                    event: overtakers.get(event, 0) for event in events
+                },
+                "unique_overtaken": {
+                    event: overtaken.get(event, 0) for event in events
+                },
+                "share_of_starters_overtaking": {
+                    event: _pct(overtakers.get(event, 0), field_sizes.get(event, 0))
+                    for event in events
+                },
+                "highest_severity_pair": _worst_pair_attribution(same_pass),
+                "occupancy_source": "same_pass_overlap_per_minute_max",
+                "occupancy": occupancy,
+                "pairs": {
+                    "same_pass": same_pass,
+                    "corridor": corridor,
+                    "same_event": same_event,
+                },
+            }
+        )
+
+    return {
+        "schema_version": FLOW_SEGMENT_SUMMARY_SCHEMA,
+        "epic": "#845",
+        "kpis_ship_gate": "same_pass_cross_event_filter",
+        "narrative": None,
+        "segments": parents,
+    }
+
+
+def _load_json(path: Path) -> Any:
+    return json.loads(path.read_text(encoding="utf-8"))
+
+
+def _load_runner_rows(reports_dir: Path, day: str) -> List[Dict[str, Any]]:
+    candidates = [
+        reports_dir / f"{day}_fz_runners.parquet",
+        reports_dir / "fz_runners.parquet",
+    ]
+    for path in candidates:
+        if not path.is_file():
+            continue
+        try:
+            import pandas as pd
+
+            frame = pd.read_parquet(path)
+        except Exception as exc:
+            logger.warning("Could not read %s: %s", path, exc)
+            return []
+        if "flow_id" not in frame.columns:
+            return []
+        return frame.to_dict(orient="records")
+    return []
+
+
+def _load_occupancy_tables(
+    overlaps_dir: Path,
+    overlaps_summary: Mapping[str, Any],
+) -> List[Tuple[str, Sequence[str], Sequence[Mapping[str, Any]]]]:
+    tables: List[Tuple[str, Sequence[str], Sequence[Mapping[str, Any]]]] = []
+    for item in overlaps_summary.get("segments") or []:
+        if not isinstance(item, dict):
+            continue
+        flow_id = str(item.get("flow_id") or "").strip()
+        filename = str(item.get("csv_filename") or "").strip()
+        if not flow_id or not filename:
+            continue
+        path = overlaps_dir / filename
+        if not path.is_file():
+            continue
+        kind = classify_pair_kind(
+            flow_id,
+            item.get("event_a"),
+            item.get("event_b"),
+            str(item.get("seg_id") or ""),
+        )
+        if kind != PAIR_KIND_SAME_PASS:
+            continue
+        with path.open(newline="", encoding="utf-8") as handle:
+            rows = list(csv.DictReader(handle))
+        events = [
+            event
+            for event in (_norm_event(item.get("event_a")), _norm_event(item.get("event_b")))
+            if event
+        ]
+        tables.append((flow_id, events, rows))
+    return tables
+
+
+def build_segment_flow_summary_from_day_dir(day_dir: Path, day: str) -> Dict[str, Any]:
+    """Read existing day artifacts and build the segment summary (O(pairs))."""
+    metrics_path = day_dir / "ui" / "metrics" / "flow_segments.json"
+    overlaps_dir = day_dir / "reports" / REPORTS_OVERLAPS_DIRNAME
+    overlaps_path = overlaps_dir / REPORTS_OVERLAPS_SUMMARY_FILENAME
+    flow_segments = _load_json(metrics_path) if metrics_path.is_file() else {}
+    overlaps_summary = _load_json(overlaps_path) if overlaps_path.is_file() else {}
+    runner_rows = _load_runner_rows(day_dir / "reports", day)
+    occupancy_tables = _load_occupancy_tables(overlaps_dir, overlaps_summary)
+    return build_segment_flow_summary(
+        flow_segments=flow_segments,
+        overlaps_summary=overlaps_summary,
+        runner_rows=runner_rows,
+        occupancy_tables=occupancy_tables,
+    )
+
+
+def write_segment_flow_summary(day_dir: Path, day: str) -> Optional[Path]:
+    summary = build_segment_flow_summary_from_day_dir(day_dir, day)
+    out_dir = day_dir / "ui" / "metrics"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    out_path = out_dir / FLOW_SEGMENT_SUMMARY_FILENAME
+    out_path.write_text(json.dumps(summary, indent=2), encoding="utf-8")
+    return out_path

--- a/app/core/flow/segment_summary.py
+++ b/app/core/flow/segment_summary.py
@@ -130,6 +130,83 @@ def unique_role_unions(
     return {event: len(ids) for event, ids in sorted(by_event.items())}
 
 
+def empty_mix_breakdown(events: Sequence[str]) -> Dict[str, Dict[str, Any]]:
+    return {
+        event: {
+            "vs": {other: 0 for other in events if other != event},
+            "in_two_or_more": 0,
+            "unique": 0,
+        }
+        for event in events
+    }
+
+
+def event_mix_breakdown(
+    runner_rows: Sequence[Mapping[str, Any]],
+    *,
+    role: str,
+    events: Sequence[str],
+    same_pass_pairs: Sequence[Mapping[str, Any]],
+) -> Dict[str, Dict[str, Any]]:
+    """Per-event counterpart unions for overtaking (→) or overtaken (←).
+
+    ``in_two_or_more`` is runners present in 2+ counterpart pairs — not a 2^n
+    subset enumeration. ``unique`` is the runner-ID union across counterparts.
+    """
+    result = empty_mix_breakdown(events)
+    if not events or not same_pass_pairs:
+        return result
+
+    allowed = {str(pair.get("flow_id") or "").strip() for pair in same_pass_pairs}
+    allowed.discard("")
+    pair_events = {
+        str(pair.get("flow_id") or "").strip(): (
+            _norm_event(pair.get("event_a")),
+            _norm_event(pair.get("event_b")),
+        )
+        for pair in same_pass_pairs
+        if str(pair.get("flow_id") or "").strip()
+    }
+    event_set = set(events)
+    by_event_vs: Dict[str, Dict[str, set]] = {
+        event: {other: set() for other in events if other != event}
+        for event in events
+    }
+
+    for row in runner_rows:
+        if str(row.get("role") or "") != role:
+            continue
+        flow_id = str(row.get("flow_id") or "").strip()
+        if flow_id not in allowed:
+            continue
+        event = _norm_event(row.get("event"))
+        runner_id = row.get("runner_id")
+        if event not in event_set or runner_id is None or runner_id == "":
+            continue
+        event_a, event_b = pair_events.get(flow_id, ("", ""))
+        if event == event_a:
+            counterpart = event_b
+        elif event == event_b:
+            counterpart = event_a
+        else:
+            continue
+        if counterpart in by_event_vs[event]:
+            by_event_vs[event][counterpart].add(str(runner_id))
+
+    for event in events:
+        vs_sets = by_event_vs[event]
+        membership: Dict[str, int] = defaultdict(int)
+        for ids in vs_sets.values():
+            for runner_id in ids:
+                membership[runner_id] += 1
+        result[event] = {
+            "vs": {other: len(vs_sets[other]) for other in events if other != event},
+            "in_two_or_more": sum(1 for count in membership.values() if count >= 2),
+            "unique": len(membership),
+        }
+    return result
+
+
 def _pct(count: int, field_size: int) -> Optional[float]:
     if field_size <= 0:
         return None
@@ -358,12 +435,26 @@ def build_segment_flow_summary(
         field_sizes = _field_sizes_from_pairs(same_pass)
         allowed_ids = [p["flow_id"] for p in same_pass]
         runner_keyed = bool(runner_rows) and any(str(r.get("flow_id") or "") for r in runner_rows or [])
+        mix_overtaking = empty_mix_breakdown(events)
+        mix_overtaken = empty_mix_breakdown(events)
         if runner_keyed and same_pass:
             overtakers = unique_role_unions(
                 runner_rows or [], role="overtaking", allowed_flow_ids=allowed_ids
             )
             overtaken = unique_role_unions(
                 runner_rows or [], role="overtaken", allowed_flow_ids=allowed_ids
+            )
+            mix_overtaking = event_mix_breakdown(
+                runner_rows or [],
+                role="overtaking",
+                events=events,
+                same_pass_pairs=same_pass,
+            )
+            mix_overtaken = event_mix_breakdown(
+                runner_rows or [],
+                role="overtaken",
+                events=events,
+                same_pass_pairs=same_pass,
             )
             status = PACE_MIXING_READY
         else:
@@ -415,6 +506,10 @@ def build_segment_flow_summary(
                 "share_of_starters_overtaking": {
                     event: _pct(overtakers.get(event, 0), field_sizes.get(event, 0))
                     for event in events
+                },
+                "mix_breakdown": {
+                    "overtaking": mix_overtaking,
+                    "overtaken": mix_overtaken,
                 },
                 "highest_severity_pair": _worst_pair_attribution(same_pass),
                 "occupancy_source": "same_pass_overlap_per_minute_max",

--- a/app/core/v2/flow.py
+++ b/app/core/v2/flow.py
@@ -344,7 +344,8 @@ def create_flow_segments_from_flow_csv(
             "width_m": width_m,  # Issue #549: Always from segments.csv (physical property)
             "flow_type": _get_required_flow_type(flow_row, seg_id, event_a, event_b),
             "notes": flow_row.get("notes", ""),
-            "length_km": to_km_a - from_km_a if to_km_a > from_km_a else 0
+            "length_km": to_km_a - from_km_a if to_km_a > from_km_a else 0,
+            "flow_id": str(flow_row.get("flow_id") or "").strip(),
         }
         flow_format_segments.append(flow_segment)
     

--- a/app/core/v2/pipeline.py
+++ b/app/core/v2/pipeline.py
@@ -1814,6 +1814,16 @@ def create_full_analysis_pipeline(
                                 exc_info=True,
                             )
             
+            # Issue #845: rewrite segment-parent summary after overlaps exist.
+            try:
+                from app.core.flow.segment_summary import write_segment_flow_summary
+
+                for day_code in events_by_day:
+                    code = day_code.value if hasattr(day_code, "value") else str(day_code)
+                    write_segment_flow_summary(run_path / code, code)
+            except Exception as exc:
+                logger.warning("Could not refresh flow_segments_by_seg.json after overlaps: %s", exc)
+
             # Update metadata verification after reports are generated
             # Bug fix: Metadata was created before reports, causing false FAIL status
             logger.info("[Phase 10] Updating metadata verification after report generation")

--- a/app/core/v2/ui_artifacts.py
+++ b/app/core/v2/ui_artifacts.py
@@ -645,6 +645,17 @@ def _export_ui_artifacts_v2(
         # Issue #628: Write to metrics/ subdirectory
         (metrics_dir / "flow_segments.json").write_text(json.dumps(flow_segments, indent=2))
         logger.info(f"   ✅ flow_segments.json: {len(flow_segments)} segment+event-pair entries (in metrics/)")
+
+        # Issue #845/#847: additive segment-parent summary. Never fail the pipeline.
+        try:
+            from app.core.flow.segment_summary import write_segment_flow_summary
+            from app.utils.run_id import get_run_directory
+
+            day_dir = get_run_directory(run_id) / day.value
+            summary_path = write_segment_flow_summary(day_dir, day.value)
+            logger.info("   ✅ %s written", summary_path.name if summary_path else "flow_segments_by_seg.json")
+        except Exception as e:
+            logger.warning("   ⚠️  Could not generate flow_segments_by_seg.json: %s", e)
         
         # 5.6. Generate zone_captions.json (Issue #628)
         logger.info("5️⃣.6️⃣  Generating zone_captions.json...")
@@ -990,7 +1001,8 @@ def _generate_flow_segments_json(
             "width_m": float(width_m) if width_m else 0.0,
             "has_convergence": bool(has_convergence),
             "worst_zone": worst_zone_data,
-            "zones": zone_dicts
+            "zones": zone_dicts,
+            "flow_id": segment.get("flow_id") or composite_key,
         }
     
     logger.info(f"Generated flow_segments.json: {len(flow_segments)} segment+event-pair entries")

--- a/app/flow_report.py
+++ b/app/flow_report.py
@@ -1083,6 +1083,7 @@ def export_fz_runners_parquet(segments: List[Dict[str, Any]], output_dir: str, r
     - event: Event name (e.g., "10k", "half")
     - role: One of "overtaking", "overtaken", "copresent"
     - side: "a" or "b" (event A or event B)
+    - event_a / event_b / flow_id: pair identity (#845; additive, optional for older files)
     
     Args:
         segments: List of segment result dictionaries with zone data
@@ -1196,6 +1197,29 @@ def export_fz_runners_parquet(segments: List[Dict[str, Any]], output_dir: str, r
                             f"Metrics keys: {list(metrics.keys())[:10]}..."
                         )
             
+            flow_id = (
+                segment.get("flow_id")
+                or f"{seg_id}_{event_a}_{event_b}"
+            )
+
+            def _runner_row(runner_id, event, role, side):
+                rid = (
+                    int(runner_id)
+                    if isinstance(runner_id, (int, str)) and str(runner_id).isdigit()
+                    else runner_id
+                )
+                return {
+                    "seg_id": seg_id,
+                    "zone_index": zone_index,
+                    "runner_id": rid,
+                    "event": event,
+                    "role": role,
+                    "side": side,
+                    "event_a": event_a,
+                    "event_b": event_b,
+                    "flow_id": flow_id,
+                }
+
             # Convert sets to lists if needed (handle JSON deserialization)
             def normalize_set(s):
                 if isinstance(s, list):
@@ -1212,73 +1236,18 @@ def export_fz_runners_parquet(segments: List[Dict[str, Any]], output_dir: str, r
             b_bibs_overtaken = normalize_set(b_bibs_overtaken)
             b_bibs_copresence = normalize_set(b_bibs_copresence)
             
-            # Emit rows for event A runners
-            # Role: overtaking (A runners who overtook B runners)
             for runner_id in a_bibs_overtakes:
-                runners_rows.append({
-                    "seg_id": seg_id,
-                    "zone_index": zone_index,
-                    "runner_id": int(runner_id) if isinstance(runner_id, (int, str)) and str(runner_id).isdigit() else runner_id,
-                    "event": event_a,
-                    "role": "overtaking",
-                    "side": "a",
-                })
-            
-            # Role: overtaken (A runners who were overtaken by B runners)
+                runners_rows.append(_runner_row(runner_id, event_a, "overtaking", "a"))
             for runner_id in a_bibs_overtaken:
-                runners_rows.append({
-                    "seg_id": seg_id,
-                    "zone_index": zone_index,
-                    "runner_id": int(runner_id) if isinstance(runner_id, (int, str)) and str(runner_id).isdigit() else runner_id,
-                    "event": event_a,
-                    "role": "overtaken",
-                    "side": "a",
-                })
-            
-            # Role: copresent (A runners who were copresent with B runners)
+                runners_rows.append(_runner_row(runner_id, event_a, "overtaken", "a"))
             for runner_id in a_bibs_copresence:
-                runners_rows.append({
-                    "seg_id": seg_id,
-                    "zone_index": zone_index,
-                    "runner_id": int(runner_id) if isinstance(runner_id, (int, str)) and str(runner_id).isdigit() else runner_id,
-                    "event": event_a,
-                    "role": "copresent",
-                    "side": "a",
-                })
-            
-            # Emit rows for event B runners
-            # Role: overtaking (B runners who overtook A runners)
+                runners_rows.append(_runner_row(runner_id, event_a, "copresent", "a"))
             for runner_id in b_bibs_overtakes:
-                runners_rows.append({
-                    "seg_id": seg_id,
-                    "zone_index": zone_index,
-                    "runner_id": int(runner_id) if isinstance(runner_id, (int, str)) and str(runner_id).isdigit() else runner_id,
-                    "event": event_b,
-                    "role": "overtaking",
-                    "side": "b",
-                })
-            
-            # Role: overtaken (B runners who were overtaken by A runners)
+                runners_rows.append(_runner_row(runner_id, event_b, "overtaking", "b"))
             for runner_id in b_bibs_overtaken:
-                runners_rows.append({
-                    "seg_id": seg_id,
-                    "zone_index": zone_index,
-                    "runner_id": int(runner_id) if isinstance(runner_id, (int, str)) and str(runner_id).isdigit() else runner_id,
-                    "event": event_b,
-                    "role": "overtaken",
-                    "side": "b",
-                })
-            
-            # Role: copresent (B runners who were copresent with A runners)
+                runners_rows.append(_runner_row(runner_id, event_b, "overtaken", "b"))
             for runner_id in b_bibs_copresence:
-                runners_rows.append({
-                    "seg_id": seg_id,
-                    "zone_index": zone_index,
-                    "runner_id": int(runner_id) if isinstance(runner_id, (int, str)) and str(runner_id).isdigit() else runner_id,
-                    "event": event_b,
-                    "role": "copresent",
-                    "side": "b",
-                })
+                runners_rows.append(_runner_row(runner_id, event_b, "copresent", "b"))
         
         # Track segments that contributed runner data
         rows_after_segment = len(runners_rows)

--- a/app/utils/constants.py
+++ b/app/utils/constants.py
@@ -186,6 +186,10 @@ _RUNFLOW_ROOT_CONTAINER_DEFAULT = DEFAULT_RUNFLOW_ROOT_CONTAINER
 REPORTS_OVERLAPS_DIRNAME = "overlaps"
 REPORTS_OVERLAPS_SUMMARY_FILENAME = "overlaps_summary.json"
 
+# Flow consolidation (#845): additive segment-parent summary; does not replace flow_segments.json
+FLOW_SEGMENT_SUMMARY_FILENAME = "flow_segments_by_seg.json"
+FLOW_SEGMENT_SUMMARY_SCHEMA = "0.1.0-draft"
+
 # Data directory path (Issue #596)
 DATA_DIR = "data"
 

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -239,6 +239,36 @@ html.rf-tabler .card h3 {
     font-weight: 650;
 }
 
+html.rf-tabler .flow-parent-row.is-open {
+    background: #e8f1fb;
+}
+
+html.rf-tabler .flow-parent-kpis {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    gap: 0.75rem;
+}
+
+html.rf-tabler .flow-parent-kpi {
+    border: 1px solid var(--tblr-border-color, #e6e7e9);
+    border-radius: 0.4rem;
+    background: #fff;
+    padding: 0.75rem 0.9rem;
+}
+
+html.rf-tabler .flow-parent-kpi-value {
+    font-size: 1.6rem;
+    font-weight: 700;
+    line-height: 1.1;
+    color: #206bc4;
+}
+
+html.rf-tabler .flow-parent-kpi-label {
+    margin-top: 0.35rem;
+    font-size: 0.8rem;
+    color: #526277;
+}
+
 /* Buttons */
 html.rf-tabler .course-btn,
 html.rf-tabler .race-config-page .card-actions button {

--- a/frontend/static/css/tabler_spike.css
+++ b/frontend/static/css/tabler_spike.css
@@ -243,30 +243,108 @@ html.rf-tabler .flow-parent-row.is-open {
     background: #e8f1fb;
 }
 
-html.rf-tabler .flow-parent-kpis {
+html.rf-tabler .flow-parent-tile-grid {
     display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
     gap: 0.75rem;
+    margin-top: 0.75rem;
 }
 
-html.rf-tabler .flow-parent-kpi {
+html.rf-tabler .flow-parent-tile-grid-secondary {
+    margin-top: 0.65rem;
+}
+
+html.rf-tabler .flow-parent-tile {
     border: 1px solid var(--tblr-border-color, #e6e7e9);
-    border-radius: 0.4rem;
+    border-radius: 0.5rem;
     background: #fff;
-    padding: 0.75rem 0.9rem;
+    padding: 0.9rem 1rem;
+    box-shadow: 0 1px 2px rgba(24, 36, 51, 0.04);
 }
 
-html.rf-tabler .flow-parent-kpi-value {
-    font-size: 1.6rem;
+html.rf-tabler .flow-parent-tile-header {
+    background: #f8fafc;
+}
+
+html.rf-tabler .flow-parent-tile-title {
+    font-size: 1.05rem;
     font-weight: 700;
-    line-height: 1.1;
+    color: #182433;
+}
+
+html.rf-tabler .flow-parent-tile-kicker {
+    font-size: 0.75rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #64748b;
+}
+
+html.rf-tabler .flow-parent-tile-value {
+    margin-top: 0.2rem;
+    font-size: 2rem;
+    font-weight: 750;
+    line-height: 1.05;
     color: #206bc4;
 }
 
-html.rf-tabler .flow-parent-kpi-label {
-    margin-top: 0.35rem;
+html.rf-tabler .flow-parent-tile-secondary .flow-parent-tile-value {
+    font-size: 1.45rem;
+    color: #475569;
+}
+
+html.rf-tabler .flow-parent-tile-label {
+    margin-top: 0.25rem;
+    font-size: 0.85rem;
+    font-weight: 600;
+    color: #334155;
+}
+
+html.rf-tabler .flow-parent-tile-meta {
+    margin-top: 0.3rem;
     font-size: 0.8rem;
-    color: #526277;
+    color: #64748b;
+}
+
+html.rf-tabler .flow-parent-chart {
+    position: relative;
+    width: 100%;
+}
+
+html.rf-tabler .flow-parent-chart canvas {
+    width: 100% !important;
+    height: 100% !important;
+}
+
+html.rf-tabler .flow-parent-chart-occ {
+    height: 260px;
+}
+
+html.rf-tabler .flow-parent-mix-heading {
+    margin: 1.15rem 0 0.35rem;
+    font-size: 1rem;
+}
+
+html.rf-tabler .flow-parent-mix-read {
+    font-size: 0.8rem;
+    margin: 0 0 0.55rem;
+    max-width: 58rem;
+}
+
+html.rf-tabler .flow-parent-mix-table th,
+html.rf-tabler .flow-parent-mix-table td {
+    text-align: right;
+    white-space: nowrap;
+}
+
+html.rf-tabler .flow-parent-mix-table th:first-child,
+html.rf-tabler .flow-parent-mix-table td:first-child,
+html.rf-tabler .flow-parent-mix-table th[scope="row"] {
+    text-align: left;
+}
+
+html.rf-tabler .flow-parent-mix-unique {
+    font-weight: 700;
 }
 
 /* Buttons */

--- a/frontend/templates/base.html
+++ b/frontend/templates/base.html
@@ -8,7 +8,7 @@
     
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@tabler/core@1.4.0/dist/css/tabler.min.css" />
     <link rel="stylesheet" href="/static/css/common.css?v=791p3">
-    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=842e">
+    <link rel="stylesheet" href="/static/css/tabler_spike.css?v=845b">
     
     {% block extra_styles %}{% endblock %}
     

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -10,6 +10,34 @@
 </div>
 {% include "partials/run_context.html" %}
 
+<div id="flow-parent-preview" class="card" style="display:none;">
+    <h3 style="margin-bottom: 0.5rem;">Segment Flow (preview)</h3>
+    <p id="flow-parent-note" style="margin-bottom: 1rem; color: #7f8c8d; font-size: 0.875rem;">
+        Opt-in preview (<code>?flow_parent=1</code>). Unique overtakers lead; occupancy is context.
+        Existing Flow tables below are unchanged. Rollback: omit the query param or return to <code>main</code>.
+    </p>
+    <div class="scrollable-table-container">
+        <table id="flow-parent-table" class="table-sticky-header">
+            <thead>
+                <tr>
+                    <th>SEGMENT</th>
+                    <th>EVENTS</th>
+                    <th>UNION WINDOW</th>
+                    <th>UNIQUE OVERTAKERS</th>
+                    <th>SHARE OF STARTERS</th>
+                    <th>HIGHEST-SEVERITY PAIR</th>
+                </tr>
+            </thead>
+            <tbody id="flow-parent-tbody">
+                <tr>
+                    <td colspan="6" class="placeholder">Loading segment parents...</td>
+                </tr>
+            </tbody>
+        </table>
+    </div>
+    <p id="flow-parent-secondary" class="text-secondary" style="font-size:0.8rem; margin:0.75rem 0 0;"></p>
+</div>
+
 <!-- Flow Overlaps -->
 <div class="card">
     <h3 style="margin-bottom: 0.5rem;">Flow Overlaps</h3>
@@ -137,11 +165,91 @@
         initializeSorting();
         loadFlowData();
         loadOverlapData();
+        loadFlowParentPreview();
         window.addEventListener('runflow:context-ready', function () {
             loadFlowData();
             loadOverlapData();
+            loadFlowParentPreview();
         });
     });
+
+    function flowParentPreviewEnabled() {
+        return new URLSearchParams(window.location.search).get('flow_parent') === '1';
+    }
+
+    function loadFlowParentPreview() {
+        const wrap = document.getElementById('flow-parent-preview');
+        if (!wrap || !flowParentPreviewEnabled()) {
+            if (wrap) wrap.style.display = 'none';
+            return;
+        }
+        wrap.style.display = '';
+        const { day, run_id } = resolveRunAndDay();
+        if (!run_id) {
+            return;
+        }
+        const qp = new URLSearchParams({ run_id });
+        if (day) qp.set('day', day);
+        fetch(`/api/flow/segment-parents?${qp.toString()}`, { cache: 'no-store' })
+            .then(function (response) {
+                if (!response.ok) throw new Error(response.statusText);
+                return response.json();
+            })
+            .then(function (data) {
+                renderFlowParentPreview((data.summary && data.summary.segments) || []);
+            })
+            .catch(function (error) {
+                console.error('Error loading flow segment parents:', error);
+                const tbody = document.getElementById('flow-parent-tbody');
+                if (tbody) {
+                    tbody.innerHTML = '<tr><td colspan="6" class="placeholder">Segment parent preview unavailable.</td></tr>';
+                }
+            });
+    }
+
+    function renderFlowParentPreview(segments) {
+        const tbody = document.getElementById('flow-parent-tbody');
+        const secondary = document.getElementById('flow-parent-secondary');
+        if (!tbody) return;
+        tbody.innerHTML = '';
+        if (!segments.length) {
+            tbody.innerHTML = '<tr><td colspan="6" class="placeholder">No multi-event segment parents.</td></tr>';
+            return;
+        }
+        segments.forEach(function (seg) {
+            const events = (seg.events || []).join(' · ') || '—';
+            const windowLabel = (seg.t0 && seg.t1) ? (seg.t0 + '–' + seg.t1) : '—';
+            const status = seg.pace_mixing_status || '';
+            const overtakers = (seg.events || []).map(function (event) {
+                return status === 'ready' ? ((seg.unique_overtakers || {})[event] || 0) : '—';
+            }).join(' / ') || '—';
+            const shares = (seg.events || []).map(function (event) {
+                const value = (seg.share_of_starters_overtaking || {})[event];
+                return (status === 'ready' && value != null) ? (value + '%') : '—';
+            }).join(' · ') || '—';
+            const worst = seg.highest_severity_pair || {};
+            const worstLabel = worst.flow_id
+                ? (worst.flow_id + (worst.zone_index != null ? (' · zone ' + worst.zone_index) : ''))
+                : '—';
+            const tr = document.createElement('tr');
+            tr.innerHTML =
+                '<td>' + (seg.seg_id || '') + (seg.segment_label ? (' · ' + seg.segment_label) : '') + '</td>' +
+                '<td>' + events + '</td>' +
+                '<td>' + windowLabel + '</td>' +
+                '<td>' + overtakers + '</td>' +
+                '<td>' + shares + '</td>' +
+                '<td>' + worstLabel + '</td>';
+            tbody.appendChild(tr);
+        });
+        if (secondary) {
+            const gated = segments.some(function (seg) {
+                return seg.pace_mixing_status !== 'ready';
+            });
+            secondary.textContent = gated
+                ? 'Unique overtaker KPIs gated until pair-keyed fz_runners + same-pass filter. Denominator = starters in this analysis run. Occupancy source = same-pass overlap per-minute max.'
+                : 'Unique overtaken is secondary (expand later). Denominator = starters in this analysis run.';
+        }
+    }
 
     function resolveRunAndDay() {
         const params = new URLSearchParams(window.location.search);

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -15,7 +15,7 @@
         <h3 style="margin-bottom: 0.5rem;">Flow Overlaps</h3>
         <p id="flow-parent-note" style="margin-bottom: 1rem; color: #7f8c8d; font-size: 0.875rem;">
             Segment-first preview. <strong>Unique overtakers</strong> are the Flow insight (who had to work through another field).
-            Occupancy is crowding context. Pair rows are evidence — unions, not sums.
+            Occupancy is crowding context. Mix tables break uniques down by counterpart — unions, not sums.
             Denominator = starters in this analysis run.
         </p>
         <div class="scrollable-table-container">
@@ -167,7 +167,6 @@
     let overlapChart = null;
     let parentSegments = [];
     let selectedParentSegId = null;
-    let parentMixChart = null;
     let parentOccChart = null;
     
     // Load flow data on page load (and after chrome derives day — Issue #841)
@@ -302,50 +301,93 @@
         const status = seg.pace_mixing_status || '';
         const ready = status === 'ready';
         const windowLabel = (seg.t0 && seg.t1) ? (seg.t0 + '–' + seg.t1) : '—';
-        const kpis = events.map(function (event) {
+        const overtakerTiles = events.map(function (event) {
             const count = ready ? ((seg.unique_overtakers || {})[event] || 0) : '—';
             const share = ready ? (seg.share_of_starters_overtaking || {})[event] : null;
             const field = (seg.field_sizes || {})[event];
-            return '<div class="flow-parent-kpi">' +
-                '<div class="flow-parent-kpi-value">' + escapeHtml(String(count)) + '</div>' +
-                '<div class="flow-parent-kpi-label">' + escapeHtml(eventLabel(event)) + ' unique overtakers' +
-                (share != null ? (' · ' + share + '% of starters') : '') +
-                (field ? (' <span class="text-secondary">(' + field + ')</span>') : '') +
+            return '<div class="flow-parent-tile flow-parent-tile-primary">' +
+                '<div class="flow-parent-tile-kicker">' + escapeHtml(eventLabel(event)) + '</div>' +
+                '<div class="flow-parent-tile-value">' + escapeHtml(String(count)) + '</div>' +
+                '<div class="flow-parent-tile-label">Unique overtakers</div>' +
+                '<div class="flow-parent-tile-meta">' +
+                (share != null ? (share + '% of starters') : 'Share unavailable') +
+                (field ? (' · ' + field + ' starters') : '') +
                 '</div></div>';
         }).join('');
-        const overtaken = events.map(function (event) {
-            return eventLabel(event) + ' ' + (ready ? ((seg.unique_overtaken || {})[event] || 0) : '—');
-        }).join(' · ');
-        const samePass = ((seg.pairs || {}).same_pass || []);
-        const corridor = ((seg.pairs || {}).corridor || []);
-        const sameEvent = ((seg.pairs || {}).same_event || []);
-        const pairRows = samePass.map(function (pair) {
-            const wz = pair.worst_zone || {};
-            return '<tr>' +
-                '<td>' + escapeHtml(eventLabel(pair.event_a) + ' ↔ ' + eventLabel(pair.event_b)) + '</td>' +
-                '<td>' + escapeHtml((pair.overlap_start && pair.overlap_end) ? (pair.overlap_start + '–' + pair.overlap_end) : '—') + '</td>' +
-                '<td>' + escapeHtml(pair.state || '—') + '</td>' +
-                '<td>' + escapeHtml((pair.peak_concurrent_a != null ? pair.peak_concurrent_a : '—') + ' / ' + (pair.peak_concurrent_b != null ? pair.peak_concurrent_b : '—')) + '</td>' +
-                '<td>' + escapeHtml((wz.overtaking_a != null ? wz.overtaking_a : '—') + ' / ' + (wz.overtaking_b != null ? wz.overtaking_b : '—')) + '</td>' +
-                '</tr>';
-        }).join('') || '<tr><td colspan="5" class="placeholder">No same-pass pairs.</td></tr>';
+        const overtakenTiles = events.map(function (event) {
+            const count = ready ? ((seg.unique_overtaken || {})[event] || 0) : '—';
+            return '<div class="flow-parent-tile flow-parent-tile-secondary">' +
+                '<div class="flow-parent-tile-kicker">' + escapeHtml(eventLabel(event)) + '</div>' +
+                '<div class="flow-parent-tile-value">' + escapeHtml(String(count)) + '</div>' +
+                '<div class="flow-parent-tile-label">Unique overtaken</div>' +
+                '</div>';
+        }).join('');
+        const showMulti = events.length > 2;
+        const mix = seg.mix_breakdown || {};
         detail.innerHTML =
             '<div class="card">' +
-            '<h3 style="margin-bottom:0.35rem;">' + escapeHtml(seg.seg_id) + ' — ' + escapeHtml(seg.segment_label || '') + '</h3>' +
-            '<p class="text-secondary" style="margin-bottom:1rem;">' + escapeHtml(events.map(eventLabel).join(' · ')) +
-            ' · union window ' + escapeHtml(windowLabel) + '</p>' +
-            '<div class="flow-parent-kpis">' + kpis + '</div>' +
-            '<p class="text-secondary" style="margin:0.75rem 0 0.25rem;">Unique overtaken (secondary): ' + escapeHtml(overtaken) + '</p>' +
-            '<p class="text-secondary" style="margin:0 0 1rem; font-size:0.8rem;">% of starters uses the analysis-run field size, not DNS and not “entered this segment only.” Parent totals are runner-ID unions across same-pass cross-event pairs.</p>' +
-            '<canvas id="flow-parent-mix-chart" height="90"></canvas>' +
-            '<h4 style="margin:1.25rem 0 0.5rem;">Pair evidence</h4>' +
-            '<p class="text-secondary" style="font-size:0.8rem; margin-bottom:0.5rem;">Do not sum these overtaking columns into the parent KPIs. Corridor ' + corridor.length + ' · same-event ' + sameEvent.length + ' typed children stay out of the union.</p>' +
-            '<div class="scrollable-table-container"><table class="table-sticky-header"><thead><tr><th>PAIR</th><th>WINDOW</th><th>STATE</th><th>PEAK CONCURRENT</th><th>OVERTAKING A / B</th></tr></thead><tbody>' + pairRows + '</tbody></table></div>' +
-            '<h4 style="margin:1.25rem 0 0.35rem;">Crowding context</h4>' +
+            '<div class="flow-parent-tile flow-parent-tile-header">' +
+            '<div class="flow-parent-tile-title">' + escapeHtml(seg.seg_id) + ' — ' + escapeHtml(seg.segment_label || '') + '</div>' +
+            '<div class="flow-parent-tile-meta">' + escapeHtml(events.map(eventLabel).join(' · ')) +
+            ' · union window ' + escapeHtml(windowLabel) + '</div>' +
+            '</div>' +
+            '<div class="flow-parent-tile-grid">' + overtakerTiles + '</div>' +
+            '<div class="flow-parent-tile-grid flow-parent-tile-grid-secondary">' + overtakenTiles + '</div>' +
+            '<p class="text-secondary" style="margin:0.85rem 0 0.25rem; font-size:0.8rem;">% of starters uses the analysis-run field size, not DNS and not “entered this segment only.” Parent totals are runner-ID unions across same-pass cross-event pairs.</p>' +
+            renderMixMatrix(
+                'Overtaking →',
+                'Each cell is unique runners from the row event who overtook at least one runner from the column event. Unique matches the tile above — a union, so do not sum the → columns. In 2+ pairs counts runners who overtook more than one other field. Corridor and same-event pairs are excluded.',
+                '→',
+                mix.overtaking || {},
+                events,
+                ready,
+                showMulti
+            ) +
+            renderMixMatrix(
+                'Overtaken ←',
+                'Each cell is unique runners from the row event who were overtaken by at least one runner from the column event. Unique is a union across those counterparts, not a sum. In 2+ pairs counts runners overtaken by more than one other field.',
+                '←',
+                mix.overtaken || {},
+                events,
+                ready,
+                showMulti
+            ) +
+            '<h4 class="flow-parent-mix-heading">Crowding context</h4>' +
             '<p class="text-secondary" style="font-size:0.8rem; margin-bottom:0.5rem;">Concurrent occupancy from same-pass overlap minutes — secondary to pace mixing.</p>' +
-            '<canvas id="flow-parent-occ-chart" height="70"></canvas>' +
+            '<div class="flow-parent-chart flow-parent-chart-occ"><canvas id="flow-parent-occ-chart"></canvas></div>' +
             '</div>';
         renderParentCharts(seg);
+    }
+
+    function mixCell(value, ready) {
+        if (!ready || value == null) return '—';
+        return String(value);
+    }
+
+    function renderMixMatrix(title, readCopy, arrow, breakdown, events, ready, showMulti) {
+        const headCells = events.map(function (event) {
+            return '<th>' + escapeHtml(arrow + ' ' + eventLabel(event)) + '</th>';
+        }).join('');
+        const rows = events.map(function (event) {
+            const row = breakdown[event] || {};
+            const vs = row.vs || {};
+            const counterpartCells = events.map(function (other) {
+                if (other === event) return '<td>—</td>';
+                return '<td>' + escapeHtml(mixCell(vs[other], ready)) + '</td>';
+            }).join('');
+            return '<tr>' +
+                '<th scope="row">' + escapeHtml(eventLabel(event)) + '</th>' +
+                counterpartCells +
+                (showMulti ? ('<td>' + escapeHtml(mixCell(row.in_two_or_more, ready)) + '</td>') : '') +
+                '<td class="flow-parent-mix-unique">' + escapeHtml(mixCell(row.unique, ready)) + '</td>' +
+                '</tr>';
+        }).join('');
+        return '<h4 class="flow-parent-mix-heading">' + escapeHtml(title) + '</h4>' +
+            '<p class="text-secondary flow-parent-mix-read">' + escapeHtml(readCopy) + '</p>' +
+            '<div class="scrollable-table-container"><table class="table-sticky-header flow-parent-mix-table"><thead><tr>' +
+            '<th>Event</th>' + headCells +
+            (showMulti ? '<th>In 2+ pairs</th>' : '') +
+            '<th>Unique</th></tr></thead><tbody>' + rows + '</tbody></table></div>';
     }
 
     function downsampleOccupancy(points) {
@@ -356,37 +398,9 @@
 
     function renderParentCharts(seg) {
         const events = seg.events || [];
-        const ready = seg.pace_mixing_status === 'ready';
-        const mixEl = document.getElementById('flow-parent-mix-chart');
         const occEl = document.getElementById('flow-parent-occ-chart');
         const tones = ['#206bc4', '#d97706', '#2fb344', '#ae3ec9'];
-        if (parentMixChart) parentMixChart.destroy();
         if (parentOccChart) parentOccChart.destroy();
-        if (mixEl && window.Chart) {
-            parentMixChart = new Chart(mixEl, {
-                type: 'bar',
-                data: {
-                    labels: events.map(eventLabel),
-                    datasets: [
-                        {
-                            label: 'Unique overtakers',
-                            data: events.map(function (event) { return ready ? ((seg.unique_overtakers || {})[event] || 0) : 0; }),
-                            backgroundColor: '#206bc4'
-                        },
-                        {
-                            label: 'Unique overtaken',
-                            data: events.map(function (event) { return ready ? ((seg.unique_overtaken || {})[event] || 0) : 0; }),
-                            backgroundColor: '#94a3b8'
-                        }
-                    ]
-                },
-                options: {
-                    responsive: true,
-                    plugins: { legend: { position: 'bottom' } },
-                    scales: { y: { beginAtZero: true, title: { display: true, text: 'Unique runners' } } }
-                }
-            });
-        }
         const occ = downsampleOccupancy(seg.occupancy || []);
         if (occEl && window.Chart && occ.length) {
             parentOccChart = new Chart(occEl, {
@@ -401,14 +415,43 @@
                             backgroundColor: tones[idx % tones.length] + '22',
                             fill: true,
                             tension: 0.25,
-                            pointRadius: 0
+                            pointRadius: 0,
+                            pointHoverRadius: 4,
+                            pointStyle: 'circle',
                         };
                     })
                 },
                 options: {
                     responsive: true,
-                    plugins: { legend: { position: 'bottom' } },
-                    scales: { y: { beginAtZero: true, title: { display: true, text: 'Concurrent runners' } } }
+                    maintainAspectRatio: false,
+                    interaction: { mode: 'index', intersect: false },
+                    plugins: {
+                        legend: {
+                            position: 'bottom',
+                            labels: {
+                                usePointStyle: true,
+                                pointStyle: 'circle',
+                                boxWidth: 8,
+                                boxHeight: 8,
+                                padding: 16,
+                            },
+                        },
+                        tooltip: {
+                            enabled: true,
+                            callbacks: {
+                                title: function (items) {
+                                    return items[0] ? ('Minute ' + items[0].label) : '';
+                                },
+                            },
+                        },
+                    },
+                    scales: {
+                        x: {
+                            title: { display: true, text: 'Time' },
+                            ticks: { maxTicksLimit: 10 },
+                        },
+                        y: { beginAtZero: true, title: { display: true, text: 'Concurrent runners' } },
+                    },
                 }
             });
         }

--- a/frontend/templates/pages/flow.html
+++ b/frontend/templates/pages/flow.html
@@ -10,34 +10,39 @@
 </div>
 {% include "partials/run_context.html" %}
 
-<div id="flow-parent-preview" class="card" style="display:none;">
-    <h3 style="margin-bottom: 0.5rem;">Segment Flow (preview)</h3>
-    <p id="flow-parent-note" style="margin-bottom: 1rem; color: #7f8c8d; font-size: 0.875rem;">
-        Opt-in preview (<code>?flow_parent=1</code>). Unique overtakers lead; occupancy is context.
-        Existing Flow tables below are unchanged. Rollback: omit the query param or return to <code>main</code>.
-    </p>
-    <div class="scrollable-table-container">
-        <table id="flow-parent-table" class="table-sticky-header">
-            <thead>
-                <tr>
-                    <th>SEGMENT</th>
-                    <th>EVENTS</th>
-                    <th>UNION WINDOW</th>
-                    <th>UNIQUE OVERTAKERS</th>
-                    <th>SHARE OF STARTERS</th>
-                    <th>HIGHEST-SEVERITY PAIR</th>
-                </tr>
-            </thead>
-            <tbody id="flow-parent-tbody">
-                <tr>
-                    <td colspan="6" class="placeholder">Loading segment parents...</td>
-                </tr>
-            </tbody>
-        </table>
+<div id="flow-parent-preview" style="display:none;">
+    <div class="card">
+        <h3 style="margin-bottom: 0.5rem;">Flow Overlaps</h3>
+        <p id="flow-parent-note" style="margin-bottom: 1rem; color: #7f8c8d; font-size: 0.875rem;">
+            Segment-first preview. <strong>Unique overtakers</strong> are the Flow insight (who had to work through another field).
+            Occupancy is crowding context. Pair rows are evidence — unions, not sums.
+            Denominator = starters in this analysis run.
+        </p>
+        <div class="scrollable-table-container">
+            <table id="flow-parent-table" class="table-sticky-header">
+                <thead>
+                    <tr>
+                        <th></th>
+                        <th>SEGMENT</th>
+                        <th>EVENTS</th>
+                        <th>UNION WINDOW</th>
+                        <th>UNIQUE OVERTAKERS</th>
+                        <th>SHARE OF STARTERS</th>
+                        <th>HIGHEST-SEVERITY PAIR</th>
+                    </tr>
+                </thead>
+                <tbody id="flow-parent-tbody">
+                    <tr>
+                        <td colspan="7" class="placeholder">Loading segment parents...</td>
+                    </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
-    <p id="flow-parent-secondary" class="text-secondary" style="font-size:0.8rem; margin:0.75rem 0 0;"></p>
+    <div id="flow-parent-detail"></div>
 </div>
 
+<div id="flow-legacy-wrap">
 <!-- Flow Overlaps -->
 <div class="card">
     <h3 style="margin-bottom: 0.5rem;">Flow Overlaps</h3>
@@ -149,6 +154,7 @@
         </tbody>
     </table>
 </div>
+</div>
 
 {% endblock %}
 
@@ -159,6 +165,10 @@
     let currentSort = { column: null, direction: 'asc' }; // 'asc' or 'desc' (Issue #596: Fix - moved outside DOMContentLoaded)
     let overlapSummary = null;
     let overlapChart = null;
+    let parentSegments = [];
+    let selectedParentSegId = null;
+    let parentMixChart = null;
+    let parentOccChart = null;
     
     // Load flow data on page load (and after chrome derives day — Issue #841)
     document.addEventListener('DOMContentLoaded', function() {
@@ -177,13 +187,28 @@
         return new URLSearchParams(window.location.search).get('flow_parent') === '1';
     }
 
+    function eventLabel(event) {
+        if (event === '10k') return '10K';
+        if (!event) return '—';
+        return String(event).charAt(0).toUpperCase() + String(event).slice(1);
+    }
+
+    function escapeHtml(value) {
+        return String(value == null ? '' : value).replace(/[&<>"']/g, function (ch) {
+            return ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' })[ch];
+        });
+    }
+
     function loadFlowParentPreview() {
         const wrap = document.getElementById('flow-parent-preview');
+        const legacy = document.getElementById('flow-legacy-wrap');
         if (!wrap || !flowParentPreviewEnabled()) {
             if (wrap) wrap.style.display = 'none';
+            if (legacy) legacy.style.display = '';
             return;
         }
         wrap.style.display = '';
+        if (legacy) legacy.style.display = 'none';
         const { day, run_id } = resolveRunAndDay();
         if (!run_id) {
             return;
@@ -196,28 +221,36 @@
                 return response.json();
             })
             .then(function (data) {
-                renderFlowParentPreview((data.summary && data.summary.segments) || []);
+                parentSegments = ((data.summary && data.summary.segments) || []).filter(function (seg) {
+                    return (seg.events || []).length > 1 || ((seg.pairs || {}).same_pass || []).length;
+                });
+                renderFlowParentPreview(parentSegments);
+                const preferred = parentSegments.find(function (seg) { return seg.seg_id === 'S8'; })
+                    || parentSegments.find(function (seg) { return (seg.events || []).length > 1; })
+                    || parentSegments[0];
+                if (preferred) {
+                    selectParentSegment(preferred.seg_id);
+                }
             })
             .catch(function (error) {
                 console.error('Error loading flow segment parents:', error);
                 const tbody = document.getElementById('flow-parent-tbody');
                 if (tbody) {
-                    tbody.innerHTML = '<tr><td colspan="6" class="placeholder">Segment parent preview unavailable.</td></tr>';
+                    tbody.innerHTML = '<tr><td colspan="7" class="placeholder">Segment parent preview unavailable.</td></tr>';
                 }
             });
     }
 
     function renderFlowParentPreview(segments) {
         const tbody = document.getElementById('flow-parent-tbody');
-        const secondary = document.getElementById('flow-parent-secondary');
         if (!tbody) return;
         tbody.innerHTML = '';
         if (!segments.length) {
-            tbody.innerHTML = '<tr><td colspan="6" class="placeholder">No multi-event segment parents.</td></tr>';
+            tbody.innerHTML = '<tr><td colspan="7" class="placeholder">No multi-event segment parents.</td></tr>';
             return;
         }
         segments.forEach(function (seg) {
-            const events = (seg.events || []).join(' · ') || '—';
+            const events = (seg.events || []).map(eventLabel).join(' · ') || '—';
             const windowLabel = (seg.t0 && seg.t1) ? (seg.t0 + '–' + seg.t1) : '—';
             const status = seg.pace_mixing_status || '';
             const overtakers = (seg.events || []).map(function (event) {
@@ -228,26 +261,156 @@
                 return (status === 'ready' && value != null) ? (value + '%') : '—';
             }).join(' · ') || '—';
             const worst = seg.highest_severity_pair || {};
-            const worstLabel = worst.flow_id
-                ? (worst.flow_id + (worst.zone_index != null ? (' · zone ' + worst.zone_index) : ''))
-                : '—';
+            const worstLabel = worst.event_a
+                ? (eventLabel(worst.event_a) + ' ↔ ' + eventLabel(worst.event_b) + (worst.zone_index != null ? (' · zone ' + worst.zone_index) : ''))
+                : (worst.flow_id || '—');
+            const open = seg.seg_id === selectedParentSegId;
             const tr = document.createElement('tr');
+            tr.className = 'flow-parent-row' + (open ? ' is-open' : '');
+            tr.dataset.segId = seg.seg_id;
+            tr.style.cursor = 'pointer';
             tr.innerHTML =
-                '<td>' + (seg.seg_id || '') + (seg.segment_label ? (' · ' + seg.segment_label) : '') + '</td>' +
-                '<td>' + events + '</td>' +
-                '<td>' + windowLabel + '</td>' +
-                '<td>' + overtakers + '</td>' +
-                '<td>' + shares + '</td>' +
-                '<td>' + worstLabel + '</td>';
+                '<td>' + (open ? '▾' : '▸') + '</td>' +
+                '<td>' + escapeHtml(seg.seg_id || '') + (seg.segment_label ? (' · ' + escapeHtml(seg.segment_label)) : '') + '</td>' +
+                '<td>' + escapeHtml(events) + '</td>' +
+                '<td>' + escapeHtml(windowLabel) + '</td>' +
+                '<td>' + escapeHtml(String(overtakers)) + '</td>' +
+                '<td>' + escapeHtml(String(shares)) + '</td>' +
+                '<td>' + escapeHtml(worstLabel) + '</td>';
+            tr.addEventListener('click', function () {
+                selectParentSegment(seg.seg_id);
+            });
             tbody.appendChild(tr);
         });
-        if (secondary) {
-            const gated = segments.some(function (seg) {
-                return seg.pace_mixing_status !== 'ready';
+    }
+
+    function selectParentSegment(segId) {
+        selectedParentSegId = segId;
+        renderFlowParentPreview(parentSegments);
+        const seg = parentSegments.find(function (item) { return item.seg_id === segId; });
+        renderFlowParentDetail(seg);
+    }
+
+    function renderFlowParentDetail(seg) {
+        const detail = document.getElementById('flow-parent-detail');
+        if (!detail) return;
+        if (!seg) {
+            detail.innerHTML = '';
+            return;
+        }
+        const events = seg.events || [];
+        const status = seg.pace_mixing_status || '';
+        const ready = status === 'ready';
+        const windowLabel = (seg.t0 && seg.t1) ? (seg.t0 + '–' + seg.t1) : '—';
+        const kpis = events.map(function (event) {
+            const count = ready ? ((seg.unique_overtakers || {})[event] || 0) : '—';
+            const share = ready ? (seg.share_of_starters_overtaking || {})[event] : null;
+            const field = (seg.field_sizes || {})[event];
+            return '<div class="flow-parent-kpi">' +
+                '<div class="flow-parent-kpi-value">' + escapeHtml(String(count)) + '</div>' +
+                '<div class="flow-parent-kpi-label">' + escapeHtml(eventLabel(event)) + ' unique overtakers' +
+                (share != null ? (' · ' + share + '% of starters') : '') +
+                (field ? (' <span class="text-secondary">(' + field + ')</span>') : '') +
+                '</div></div>';
+        }).join('');
+        const overtaken = events.map(function (event) {
+            return eventLabel(event) + ' ' + (ready ? ((seg.unique_overtaken || {})[event] || 0) : '—');
+        }).join(' · ');
+        const samePass = ((seg.pairs || {}).same_pass || []);
+        const corridor = ((seg.pairs || {}).corridor || []);
+        const sameEvent = ((seg.pairs || {}).same_event || []);
+        const pairRows = samePass.map(function (pair) {
+            const wz = pair.worst_zone || {};
+            return '<tr>' +
+                '<td>' + escapeHtml(eventLabel(pair.event_a) + ' ↔ ' + eventLabel(pair.event_b)) + '</td>' +
+                '<td>' + escapeHtml((pair.overlap_start && pair.overlap_end) ? (pair.overlap_start + '–' + pair.overlap_end) : '—') + '</td>' +
+                '<td>' + escapeHtml(pair.state || '—') + '</td>' +
+                '<td>' + escapeHtml((pair.peak_concurrent_a != null ? pair.peak_concurrent_a : '—') + ' / ' + (pair.peak_concurrent_b != null ? pair.peak_concurrent_b : '—')) + '</td>' +
+                '<td>' + escapeHtml((wz.overtaking_a != null ? wz.overtaking_a : '—') + ' / ' + (wz.overtaking_b != null ? wz.overtaking_b : '—')) + '</td>' +
+                '</tr>';
+        }).join('') || '<tr><td colspan="5" class="placeholder">No same-pass pairs.</td></tr>';
+        detail.innerHTML =
+            '<div class="card">' +
+            '<h3 style="margin-bottom:0.35rem;">' + escapeHtml(seg.seg_id) + ' — ' + escapeHtml(seg.segment_label || '') + '</h3>' +
+            '<p class="text-secondary" style="margin-bottom:1rem;">' + escapeHtml(events.map(eventLabel).join(' · ')) +
+            ' · union window ' + escapeHtml(windowLabel) + '</p>' +
+            '<div class="flow-parent-kpis">' + kpis + '</div>' +
+            '<p class="text-secondary" style="margin:0.75rem 0 0.25rem;">Unique overtaken (secondary): ' + escapeHtml(overtaken) + '</p>' +
+            '<p class="text-secondary" style="margin:0 0 1rem; font-size:0.8rem;">% of starters uses the analysis-run field size, not DNS and not “entered this segment only.” Parent totals are runner-ID unions across same-pass cross-event pairs.</p>' +
+            '<canvas id="flow-parent-mix-chart" height="90"></canvas>' +
+            '<h4 style="margin:1.25rem 0 0.5rem;">Pair evidence</h4>' +
+            '<p class="text-secondary" style="font-size:0.8rem; margin-bottom:0.5rem;">Do not sum these overtaking columns into the parent KPIs. Corridor ' + corridor.length + ' · same-event ' + sameEvent.length + ' typed children stay out of the union.</p>' +
+            '<div class="scrollable-table-container"><table class="table-sticky-header"><thead><tr><th>PAIR</th><th>WINDOW</th><th>STATE</th><th>PEAK CONCURRENT</th><th>OVERTAKING A / B</th></tr></thead><tbody>' + pairRows + '</tbody></table></div>' +
+            '<h4 style="margin:1.25rem 0 0.35rem;">Crowding context</h4>' +
+            '<p class="text-secondary" style="font-size:0.8rem; margin-bottom:0.5rem;">Concurrent occupancy from same-pass overlap minutes — secondary to pace mixing.</p>' +
+            '<canvas id="flow-parent-occ-chart" height="70"></canvas>' +
+            '</div>';
+        renderParentCharts(seg);
+    }
+
+    function downsampleOccupancy(points) {
+        if (!points || points.length <= 48) return points || [];
+        const step = Math.ceil(points.length / 48);
+        return points.filter(function (_, idx) { return idx % step === 0; });
+    }
+
+    function renderParentCharts(seg) {
+        const events = seg.events || [];
+        const ready = seg.pace_mixing_status === 'ready';
+        const mixEl = document.getElementById('flow-parent-mix-chart');
+        const occEl = document.getElementById('flow-parent-occ-chart');
+        const tones = ['#206bc4', '#d97706', '#2fb344', '#ae3ec9'];
+        if (parentMixChart) parentMixChart.destroy();
+        if (parentOccChart) parentOccChart.destroy();
+        if (mixEl && window.Chart) {
+            parentMixChart = new Chart(mixEl, {
+                type: 'bar',
+                data: {
+                    labels: events.map(eventLabel),
+                    datasets: [
+                        {
+                            label: 'Unique overtakers',
+                            data: events.map(function (event) { return ready ? ((seg.unique_overtakers || {})[event] || 0) : 0; }),
+                            backgroundColor: '#206bc4'
+                        },
+                        {
+                            label: 'Unique overtaken',
+                            data: events.map(function (event) { return ready ? ((seg.unique_overtaken || {})[event] || 0) : 0; }),
+                            backgroundColor: '#94a3b8'
+                        }
+                    ]
+                },
+                options: {
+                    responsive: true,
+                    plugins: { legend: { position: 'bottom' } },
+                    scales: { y: { beginAtZero: true, title: { display: true, text: 'Unique runners' } } }
+                }
             });
-            secondary.textContent = gated
-                ? 'Unique overtaker KPIs gated until pair-keyed fz_runners + same-pass filter. Denominator = starters in this analysis run. Occupancy source = same-pass overlap per-minute max.'
-                : 'Unique overtaken is secondary (expand later). Denominator = starters in this analysis run.';
+        }
+        const occ = downsampleOccupancy(seg.occupancy || []);
+        if (occEl && window.Chart && occ.length) {
+            parentOccChart = new Chart(occEl, {
+                type: 'line',
+                data: {
+                    labels: occ.map(function (point) { return point.minute; }),
+                    datasets: events.map(function (event, idx) {
+                        return {
+                            label: eventLabel(event),
+                            data: occ.map(function (point) { return point[event] || 0; }),
+                            borderColor: tones[idx % tones.length],
+                            backgroundColor: tones[idx % tones.length] + '22',
+                            fill: true,
+                            tension: 0.25,
+                            pointRadius: 0
+                        };
+                    })
+                },
+                options: {
+                    responsive: true,
+                    plugins: { legend: { position: 'bottom' } },
+                    scales: { y: { beginAtZero: true, title: { display: true, text: 'Concurrent runners' } } }
+                }
+            });
         }
     }
 

--- a/tests/unit/test_issue845_segment_summary.py
+++ b/tests/unit/test_issue845_segment_summary.py
@@ -200,8 +200,11 @@ def test_existing_flow_segments_api_shape_unchanged():
 def test_flow_html_default_hides_parent_preview():
     source = Path("frontend/templates/pages/flow.html").read_text(encoding="utf-8")
     assert 'id="flow-parent-preview"' in source
-    assert "flow_parent=1" in source
+    assert 'id="flow-parent-detail"' in source
+    assert 'id="flow-legacy-wrap"' in source
+    assert "get('flow_parent')" in source
     assert "flowParentPreviewEnabled" in source
+    assert "selectParentSegment" in source
     assert "loadFlowData();" in source
     assert "loadOverlapData();" in source
 
@@ -229,3 +232,24 @@ def test_s8_reference_run_builds_parent_without_shipping_naive_unions():
     assert s8["occupancy"][0]["minute"] <= "08:13"
     dumped = json.dumps(summary)
     assert "313" not in dumped
+
+
+NEW_RUN = Path("/Users/jthompson/Documents/runflow/analysis/4WPc8TogaBYqRNVK7gswd7/sun")
+
+
+@pytest.mark.skipif(not NEW_RUN.is_dir(), reason="new analysis run not on this machine")
+def test_new_run_live_summary_has_windows_and_filtered_uniques():
+    summary = build_segment_flow_summary_from_day_dir(NEW_RUN, "sun")
+    s8 = next(seg for seg in summary["segments"] if seg["seg_id"] == "S8")
+    assert s8["t0"] == "08:13"
+    assert s8["t1"] == "09:56"
+    assert s8["pace_mixing_status"] == PACE_MIXING_READY
+    assert s8["unique_overtakers"]["full"] == 196
+    assert s8["unique_overtakers"]["half"] == 520
+    assert s8["unique_overtakers"]["10k"] == 0
+    assert s8["occupancy"]
+    assert {p["flow_id"] for p in s8["pairs"]["same_pass"]} == {
+        "S8_full_half",
+        "S8_full_10k",
+        "S8_half_10k",
+    }

--- a/tests/unit/test_issue845_segment_summary.py
+++ b/tests/unit/test_issue845_segment_summary.py
@@ -1,0 +1,231 @@
+"""Issue #845–#848: segment-first Flow summary without breaking pair atoms."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from app.core.flow.segment_summary import (
+    PACE_MIXING_READY,
+    PACE_MIXING_UNAVAILABLE,
+    build_segment_flow_summary,
+    build_segment_flow_summary_from_day_dir,
+    classify_pair_kind,
+    pair_temporal_state,
+    unique_role_unions,
+)
+from app.flow_report import export_fz_runners_parquet
+from app.main import app
+
+REFERENCE_RUN = Path(
+    "/Users/jthompson/Documents/runflow/analysis/5sqk4pNRRJzLBphCnQbAwi/sun"
+)
+
+
+def test_classify_pair_kind_same_pass_corridor_same_event():
+    assert classify_pair_kind("S8_full_half", "full", "half", "S8") == "same_pass"
+    assert classify_pair_kind("S8_S12_half_full", "half", "full", "S8") == "corridor"
+    assert classify_pair_kind("S8_S21_10k_full", "10k", "full", "S8") == "corridor"
+    assert classify_pair_kind("S8_full_full", "full", "full", "S8") == "same_event"
+
+
+def test_pair_temporal_states_pre_active_inactive():
+    assert pair_temporal_state("08:10", "08:13", "09:56") == "not_yet_active"
+    assert pair_temporal_state("08:42", "08:13", "09:56") == "active"
+    assert pair_temporal_state("10:01", "08:13", "09:56") == "inactive"
+
+
+def test_unique_unions_do_not_sum_or_include_corridor():
+    rows = [
+        {"flow_id": "S8_full_half", "event": "full", "runner_id": "1", "role": "overtaking"},
+        {"flow_id": "S8_full_10k", "event": "full", "runner_id": "1", "role": "overtaking"},
+        {"flow_id": "S8_full_10k", "event": "full", "runner_id": "2", "role": "overtaking"},
+        {"flow_id": "S8_S12_half_full", "event": "full", "runner_id": "9", "role": "overtaking"},
+        {"flow_id": "S8_full_full", "event": "full", "runner_id": "8", "role": "overtaking"},
+        {"flow_id": "S8_full_half", "event": "half", "runner_id": "3", "role": "overtaking"},
+    ]
+    counts = unique_role_unions(
+        rows,
+        role="overtaking",
+        allowed_flow_ids=["S8_full_half", "S8_full_10k", "S8_half_10k"],
+    )
+    assert counts == {"full": 2, "half": 1}
+
+
+def test_parent_summary_gates_kpis_without_pair_keys_and_excludes_corridor_events():
+    flow_segments = {
+        "S8_full_half": {
+            "seg_id": "S8",
+            "segment_label": "Walking Bridge South to George",
+            "event_a": "full",
+            "event_b": "half",
+            "total_a": 467,
+            "total_b": 999,
+            "worst_zone": {"zone_index": 1, "overtaking_a": 0, "overtaking_b": 423},
+            "zones": [{}, {}],
+        },
+        "S8_full_10k": {
+            "seg_id": "S8",
+            "segment_label": "Walking Bridge South to George",
+            "event_a": "full",
+            "event_b": "10k",
+            "total_a": 467,
+            "total_b": 700,
+            "worst_zone": {"zone_index": 2, "overtaking_a": 196, "overtaking_b": 0},
+            "zones": [{}, {}, {}],
+        },
+        "S8_half_10k": {
+            "seg_id": "S8",
+            "segment_label": "Walking Bridge South to George",
+            "event_a": "half",
+            "event_b": "10k",
+            "total_a": 999,
+            "total_b": 700,
+            "worst_zone": {"zone_index": 1, "overtaking_a": 230, "overtaking_b": 0},
+            "zones": [{}, {}],
+        },
+        "S8_10k_full": {
+            "seg_id": "S8",
+            "flow_id": "S8_S12_10k_full",
+            "segment_label": "Walking Bridge South to George / reverse",
+            "event_a": "10k",
+            "event_b": "full",
+            "total_a": 700,
+            "total_b": 467,
+            "worst_zone": {"zone_index": 0, "overtaking_a": 0, "overtaking_b": 177},
+            "zones": [{}],
+        },
+        "S8_full_full": {
+            "seg_id": "S8",
+            "event_a": "full",
+            "event_b": "full",
+            "total_a": 467,
+            "total_b": 467,
+            "worst_zone": {"zone_index": 0, "overtaking_a": 1, "overtaking_b": 1},
+            "zones": [{}],
+        },
+    }
+    overlaps = {
+        "segments": [
+            {"flow_id": "S8_full_half", "seg_id": "S8", "event_a": "full", "event_b": "half", "overlap_start": "08:29", "overlap_end": "09:56"},
+            {"flow_id": "S8_full_10k", "seg_id": "S8", "event_a": "full", "event_b": "10k", "overlap_start": "08:13", "overlap_end": "09:52"},
+            {"flow_id": "S8_half_10k", "seg_id": "S8", "event_a": "half", "event_b": "10k", "overlap_start": "08:29", "overlap_end": "09:52"},
+            {"flow_id": "S8_S12_10k_full", "seg_id": "S8", "event_a": "10k", "event_b": "full", "overlap_start": "08:21", "overlap_end": "09:52"},
+        ]
+    }
+
+    ungated = build_segment_flow_summary(
+        flow_segments=flow_segments,
+        overlaps_summary=overlaps,
+        runner_rows=None,
+    )
+    parent = ungated["segments"][0]
+    assert parent["events"] == ["full", "half", "10k"]
+    assert parent["t0"] == "08:13"
+    assert parent["t1"] == "09:56"
+    assert parent["pace_mixing_status"] == PACE_MIXING_UNAVAILABLE
+    assert parent["field_denominator"] == "starters_in_analysis_run"
+    assert parent["field_sizes"] == {"full": 467, "half": 999, "10k": 700}
+    assert len(parent["pairs"]["same_pass"]) == 3
+    assert len(parent["pairs"]["corridor"]) == 1
+    assert len(parent["pairs"]["same_event"]) == 1
+    assert parent["highest_severity_pair"]["flow_id"] == "S8_full_half"
+    assert ungated["narrative"] is None
+
+    runner_rows = [
+        {"flow_id": "S8_full_10k", "event": "full", "runner_id": "a", "role": "overtaking"},
+        {"flow_id": "S8_full_half", "event": "half", "runner_id": "b", "role": "overtaking"},
+        {"flow_id": "S8_S12_10k_full", "event": "full", "runner_id": "corridor", "role": "overtaking"},
+        {"flow_id": "S8_full_full", "event": "full", "runner_id": "same", "role": "overtaking"},
+        {"flow_id": "S8_full_10k", "event": "10k", "runner_id": "c", "role": "overtaken"},
+    ]
+    ready = build_segment_flow_summary(
+        flow_segments=flow_segments,
+        overlaps_summary=overlaps,
+        runner_rows=runner_rows,
+    )["segments"][0]
+    assert ready["pace_mixing_status"] == PACE_MIXING_READY
+    assert ready["unique_overtakers"] == {"full": 1, "half": 1, "10k": 0}
+    assert ready["unique_overtaken"] == {"full": 0, "half": 0, "10k": 1}
+    assert ready["share_of_starters_overtaking"]["full"] == 0.2
+
+
+def test_fz_runners_export_adds_pair_keys_without_dropping_legacy_columns(tmp_path):
+    segments = [
+        {
+            "seg_id": "S8",
+            "event_a": "full",
+            "event_b": "half",
+            "flow_id": "S8_full_half",
+            "zones": [
+                {
+                    "zone_index": 0,
+                    "metrics": {
+                        "_a_bibs_overtakes": {"r1"},
+                        "_a_bibs_overtaken": set(),
+                        "_a_bibs_copresence": set(),
+                        "_b_bibs_overtakes": set(),
+                        "_b_bibs_overtaken": {"r2"},
+                        "_b_bibs_copresence": set(),
+                    },
+                }
+            ],
+        }
+    ]
+    path = export_fz_runners_parquet(segments, str(tmp_path), run_id="test", day="sun")
+    frame = pd.read_parquet(path)
+    for col in ("seg_id", "zone_index", "runner_id", "event", "role", "side"):
+        assert col in frame.columns
+    assert {"flow_id", "event_a", "event_b"}.issubset(frame.columns)
+    assert set(frame["flow_id"]) == {"S8_full_half"}
+
+
+def test_existing_flow_segments_api_shape_unchanged():
+    client = TestClient(app)
+    routes = {route.path for route in app.routes}
+    assert "/api/flow/segments" in routes
+    assert "/api/flow/segment-parents" in routes
+    response = client.get("/api/flow/segments")
+    assert response.status_code in {200, 400, 404, 500}
+    if response.status_code == 200:
+        payload = response.json()
+        assert "flow" in payload
+        assert "summary" not in payload
+
+
+def test_flow_html_default_hides_parent_preview():
+    source = Path("frontend/templates/pages/flow.html").read_text(encoding="utf-8")
+    assert 'id="flow-parent-preview"' in source
+    assert "flow_parent=1" in source
+    assert "flowParentPreviewEnabled" in source
+    assert "loadFlowData();" in source
+    assert "loadOverlapData();" in source
+
+
+@pytest.mark.skipif(not REFERENCE_RUN.is_dir(), reason="reference run artifacts not on this machine")
+def test_s8_reference_run_builds_parent_without_shipping_naive_unions():
+    summary = build_segment_flow_summary_from_day_dir(REFERENCE_RUN, "sun")
+    s8 = next(seg for seg in summary["segments"] if seg["seg_id"] == "S8")
+    assert s8["events"] == ["full", "half", "10k"]
+    assert s8["t0"] == "08:13"
+    assert s8["t1"] == "09:56"
+    assert s8["pace_mixing_status"] == PACE_MIXING_UNAVAILABLE
+    assert {p["flow_id"] for p in s8["pairs"]["same_pass"]} == {
+        "S8_full_half",
+        "S8_full_10k",
+        "S8_half_10k",
+    }
+    assert {p["flow_id"] for p in s8["pairs"]["corridor"]} >= {
+        "S8_S12_half_full",
+        "S8_S12_10k_full",
+        "S8_S21_half_full",
+        "S8_S21_10k_full",
+    }
+    assert s8["occupancy"]
+    assert s8["occupancy"][0]["minute"] <= "08:13"
+    dumped = json.dumps(summary)
+    assert "313" not in dumped

--- a/tests/unit/test_issue845_segment_summary.py
+++ b/tests/unit/test_issue845_segment_summary.py
@@ -15,6 +15,7 @@ from app.core.flow.segment_summary import (
     build_segment_flow_summary,
     build_segment_flow_summary_from_day_dir,
     classify_pair_kind,
+    event_mix_breakdown,
     pair_temporal_state,
     unique_role_unions,
 )
@@ -54,6 +55,48 @@ def test_unique_unions_do_not_sum_or_include_corridor():
         allowed_flow_ids=["S8_full_half", "S8_full_10k", "S8_half_10k"],
     )
     assert counts == {"full": 2, "half": 1}
+
+
+def test_mix_breakdown_is_union_not_sum():
+    pairs = [
+        {"flow_id": "S8_full_half", "event_a": "full", "event_b": "half"},
+        {"flow_id": "S8_full_10k", "event_a": "full", "event_b": "10k"},
+        {"flow_id": "S8_half_10k", "event_a": "half", "event_b": "10k"},
+    ]
+    rows = [
+        {"flow_id": "S8_full_half", "event": "half", "runner_id": "h1", "role": "overtaking"},
+        {"flow_id": "S8_half_10k", "event": "half", "runner_id": "h1", "role": "overtaking"},
+        {"flow_id": "S8_full_half", "event": "half", "runner_id": "h2", "role": "overtaking"},
+        {"flow_id": "S8_half_10k", "event": "half", "runner_id": "h3", "role": "overtaking"},
+        {"flow_id": "S8_full_10k", "event": "full", "runner_id": "f1", "role": "overtaking"},
+        {"flow_id": "S8_S12_half_full", "event": "half", "runner_id": "corridor", "role": "overtaking"},
+        {"flow_id": "S8_full_half", "event": "full", "runner_id": "f9", "role": "overtaken"},
+        {"flow_id": "S8_half_10k", "event": "10k", "runner_id": "k1", "role": "overtaken"},
+        {"flow_id": "S8_full_10k", "event": "10k", "runner_id": "k1", "role": "overtaken"},
+        {"flow_id": "S8_full_10k", "event": "10k", "runner_id": "k2", "role": "overtaken"},
+    ]
+    overtaking = event_mix_breakdown(
+        rows,
+        role="overtaking",
+        events=["full", "half", "10k"],
+        same_pass_pairs=pairs,
+    )
+    assert overtaking["half"]["vs"] == {"full": 2, "10k": 2}
+    assert overtaking["half"]["in_two_or_more"] == 1
+    assert overtaking["half"]["unique"] == 3
+    assert overtaking["full"]["vs"] == {"half": 0, "10k": 1}
+    assert overtaking["full"]["unique"] == 1
+    assert overtaking["10k"]["unique"] == 0
+    overtaken = event_mix_breakdown(
+        rows,
+        role="overtaken",
+        events=["full", "half", "10k"],
+        same_pass_pairs=pairs,
+    )
+    assert overtaken["full"]["vs"] == {"half": 1, "10k": 0}
+    assert overtaken["10k"]["vs"] == {"full": 2, "half": 1}
+    assert overtaken["10k"]["in_two_or_more"] == 1
+    assert overtaken["10k"]["unique"] == 2
 
 
 def test_parent_summary_gates_kpis_without_pair_keys_and_excludes_corridor_events():
@@ -152,6 +195,11 @@ def test_parent_summary_gates_kpis_without_pair_keys_and_excludes_corridor_event
     assert ready["unique_overtakers"] == {"full": 1, "half": 1, "10k": 0}
     assert ready["unique_overtaken"] == {"full": 0, "half": 0, "10k": 1}
     assert ready["share_of_starters_overtaking"]["full"] == 0.2
+    assert ready["mix_breakdown"]["overtaking"]["full"]["vs"]["10k"] == 1
+    assert ready["mix_breakdown"]["overtaking"]["half"]["vs"]["full"] == 1
+    assert ready["mix_breakdown"]["overtaking"]["half"]["unique"] == 1
+    assert ready["mix_breakdown"]["overtaken"]["10k"]["vs"]["full"] == 1
+    assert "corridor" not in json.dumps(ready["mix_breakdown"])
 
 
 def test_fz_runners_export_adds_pair_keys_without_dropping_legacy_columns(tmp_path):
@@ -202,6 +250,14 @@ def test_flow_html_default_hides_parent_preview():
     assert 'id="flow-parent-preview"' in source
     assert 'id="flow-parent-detail"' in source
     assert 'id="flow-legacy-wrap"' in source
+    assert "flow-parent-tile" in source
+    assert "flow-parent-mix-table" in source
+    assert "renderMixMatrix" in source
+    assert "flow-parent-chart-mix" not in source
+    assert "Pair evidence" not in source
+    assert source.count("usePointStyle: true") >= 2
+    assert source.count("pointStyle: 'circle'") >= 2
+    assert source.count("mode: 'index', intersect: false") >= 2
     assert "get('flow_parent')" in source
     assert "flowParentPreviewEnabled" in source
     assert "selectParentSegment" in source
@@ -247,6 +303,18 @@ def test_new_run_live_summary_has_windows_and_filtered_uniques():
     assert s8["unique_overtakers"]["full"] == 196
     assert s8["unique_overtakers"]["half"] == 520
     assert s8["unique_overtakers"]["10k"] == 0
+    assert s8["mix_breakdown"]["overtaking"]["half"] == {
+        "vs": {"full": 426, "10k": 230},
+        "in_two_or_more": 136,
+        "unique": 520,
+    }
+    assert s8["mix_breakdown"]["overtaking"]["full"]["vs"] == {"half": 0, "10k": 196}
+    assert s8["mix_breakdown"]["overtaken"]["full"]["unique"] == 267
+    assert s8["mix_breakdown"]["overtaken"]["10k"] == {
+        "vs": {"full": 247, "half": 213},
+        "in_two_or_more": 99,
+        "unique": 361,
+    }
     assert s8["occupancy"]
     assert {p["flow_id"] for p in s8["pairs"]["same_pass"]} == {
         "S8_full_half",


### PR DESCRIPTION
## Summary
- Adds an opt-in segment-first Flow parent (`?flow_parent=1`) on top of existing pair atoms: same-pass unique overtakers / overtaken, starter-share denominator, and live rebuild so Phase-7 artifacts are not trusted stale.
- Replaces the parent mix chart and pair-evidence table with two counterpart matrices (overtaking → and overtaken ←), including the 2+ pair overlap that explains why unions are not sums.
- Leaves default `/flow`, Density, Junctions, and Locations unchanged. Rollback is omit the query param or revert this branch.

## Test plan
- [ ] Open `/flow?run_id=<multi-event-run>&flow_parent=1` and confirm S8 (or another 3-event seg) shows tiles + mix matrices + crowding chart
- [ ] Confirm Half unique overtakers equals the Unique column, not the sum of → counterparts (S8 reference: 426 + 230 ≠ 520; In 2+ = 136)
- [ ] Confirm default `/flow` (no `flow_parent`) is unchanged
- [ ] `PYTHONPATH=. .venv/bin/pytest tests/unit/test_issue845_segment_summary.py tests/unit/test_issue798_phase7_tabler_only.py`


Made with [Cursor](https://cursor.com)